### PR TITLE
Vendor pr-review skill into project (stacked on PR #3)

### DIFF
--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: pr-review
+description: >
+  Handle PR review comments: fetch, reply, and resolve threads.
+  Use when: working with PR reviews, responding to review comments,
+  resolving review threads, or the user says "review comments",
+  "PR comments", "resolve threads", or "reply to reviews".
+---
+
+# PR Review
+
+Fetch, reply to, and resolve PR review comments via `gh` CLI.
+
+## When to Use
+
+- Before fixing PR review comments (fetch first to understand them)
+- After fixing issues flagged in a PR review (reply and resolve)
+- When the user asks to handle, respond to, or resolve PR comments
+
+## Workflow
+
+### 1. Fetch comments
+
+Read all PR feedback before acting. One call returns inline review comments,
+issue comments (qodo code reviews, sonarcloud quality gate, etc.), and
+top-level review bodies (copilot overviews):
+
+```bash
+bash .claude/skills/pr-review/scripts/pr-comments.sh PR_NUMBER
+```
+
+### 2. Triage
+
+For each comment, decide:
+
+- **FIX** — valid concern, make the code change
+- **PUSHBACK** — disagree, explain why in the reply
+
+### 3. Fix code
+
+Make changes, commit, and push.
+
+### 4. Respond
+
+Reply to each comment. Use batch mode for multiple comments:
+
+```bash
+bash .claude/skills/pr-review/scripts/pr-batch.sh --resolve PR_NUMBER <<'EOF'
+{"comment_id": 123, "body": "Fixed -- removed from repo"}
+{"comment_id": 456, "body": "Intentional -- this is a dev tool"}
+EOF
+```
+
+Or reply to a single comment:
+
+```bash
+bash .claude/skills/pr-review/scripts/pr-reply.sh --resolve PR_NUMBER COMMENT_ID "Fixed -- updated the code"
+```
+
+## Scripts
+
+### pr-comments.sh
+
+Fetch and display all PR feedback in one pass, grouped into three sections:
+
+1. **Inline review comments** — file/line comments on the diff, with thread
+   resolve status and thread ID (these are what `pr-reply.sh` acts on).
+2. **Issue comments** — general PR comments (qodo summary + code review,
+   sonarcloud quality gate, cloudflare pages deploy preview, etc.).
+3. **Top-level reviews** — PR-level review bodies with content (e.g. copilot
+   PR overviews). Reviews whose only content is inline comments are skipped
+   to avoid duplicating section 1.
+
+```bash
+bash .claude/skills/pr-review/scripts/pr-comments.sh [--repo OWNER/REPO] PR_NUMBER
+```
+
+Bodies are truncated at 10 lines. Only inline review comments have thread IDs
+and can be resolved via `pr-reply.sh`/`pr-batch.sh`; the other sections are
+listed for visibility only.
+
+### pr-reply.sh
+
+Reply to a single review comment, optionally resolve its thread.
+
+```bash
+bash .claude/skills/pr-review/scripts/pr-reply.sh [--repo OWNER/REPO] [--resolve] PR_NUMBER COMMENT_ID "body"
+```
+
+### pr-batch.sh
+
+Batch reply (and optionally resolve) from JSONL on stdin.
+
+```bash
+bash .claude/skills/pr-review/scripts/pr-batch.sh [--repo OWNER/REPO] [--resolve] PR_NUMBER <<'EOF'
+{"comment_id": 123, "body": "Fixed"}
+{"comment_id": 456, "body": "Intentional"}
+EOF
+```
+
+## Options
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--repo OWNER/REPO` | auto-detect | Override repository (default: from `gh repo view`) |
+| `--resolve` | off | Also resolve the thread after replying |
+
+## Branch Hygiene
+
+If the current branch already has an open PR, **do not** add unrelated commits to it. Instead:
+
+1. Branch off `main` with a descriptive name (e.g., `docs/irc-rationale`)
+2. Commit and push there
+3. Open a separate PR
+
+Only add commits to an existing PR's branch if they are directly related to that PR's scope.
+
+## Notes
+
+- All scripts auto-detect `owner/repo` from the current git repo
+- Replies are auto-signed with `\n\n- Claude` per global CLAUDE.md
+- Thread resolution uses GitHub GraphQL API (REST doesn't support it)
+- Requires `gh` CLI authenticated and `jq` installed

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -118,6 +118,11 @@ Only add commits to an existing PR's branch if they are directly related to that
 ## Notes
 
 - All scripts auto-detect `owner/repo` from the current git repo
-- Replies are auto-signed with `\n\n- Claude` per global CLAUDE.md
+- Replies are auto-signed with `\n\n- Claude` so recipients know the reply was written by an AI assistant
 - Thread resolution uses GitHub GraphQL API (REST doesn't support it)
 - Requires `gh` CLI authenticated and `jq` installed
+- `reviewThreads(first: 100)` is not paginated; the scripts warn to stderr on PRs with more than 100 review threads. If you hit that, either narrow the PR scope or extend the scripts with full GraphQL pagination
+
+## Argument validation
+
+`PR_NUMBER` and `COMMENT_ID` must be positive integers — the scripts interpolate them into GraphQL query strings and jq filters, and reject non-numeric input with exit status 2.

--- a/.claude/skills/pr-review/scripts/pr-batch.sh
+++ b/.claude/skills/pr-review/scripts/pr-batch.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Batch reply to PR review comments from JSONL on stdin.
+# Each line: {"comment_id": 123, "body": "reply text"}
+# Usage: pr-batch.sh [--repo OWNER/REPO] [--resolve] PR_NUMBER < input.jsonl
+
+REPO=""
+RESOLVE=false
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --repo) REPO="$2"; shift 2 ;;
+        --resolve) RESOLVE=true; shift ;;
+        *) break ;;
+    esac
+done
+
+PR_NUMBER="${1:?Usage: pr-batch.sh [--repo OWNER/REPO] [--resolve] PR_NUMBER < input.jsonl}"
+
+if [[ -z "$REPO" ]]; then
+    REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RESOLVE_FLAG=""
+if [[ "$RESOLVE" == true ]]; then
+    RESOLVE_FLAG="--resolve"
+fi
+
+SUCCESS=0
+FAIL=0
+
+while IFS= read -r line; do
+    # Skip empty lines
+    [[ -z "$line" ]] && continue
+
+    COMMENT_ID=$(echo "$line" | jq -r '.comment_id')
+    BODY=$(echo "$line" | jq -r '.body')
+
+    if [[ "$COMMENT_ID" == "null" || "$BODY" == "null" ]]; then
+        echo "SKIP: invalid line: $line"
+        ((FAIL++)) || true
+        continue
+    fi
+
+    echo "--- Comment $COMMENT_ID ---"
+    if bash "$SCRIPT_DIR/pr-reply.sh" --repo "$REPO" $RESOLVE_FLAG "$PR_NUMBER" "$COMMENT_ID" "$BODY"; then
+        ((SUCCESS++)) || true
+    else
+        echo "FAILED: comment $COMMENT_ID"
+        ((FAIL++)) || true
+    fi
+done
+
+echo ""
+echo "Done: $SUCCESS succeeded, $FAIL failed"

--- a/.claude/skills/pr-review/scripts/pr-batch.sh
+++ b/.claude/skills/pr-review/scripts/pr-batch.sh
@@ -17,15 +17,20 @@ while [[ $# -gt 0 ]]; do
 done
 
 PR_NUMBER="${1:?Usage: pr-batch.sh [--repo OWNER/REPO] [--resolve] PR_NUMBER < input.jsonl}"
+[[ "$PR_NUMBER" =~ ^[0-9]+$ ]] || { echo "ERROR: PR_NUMBER must be a positive integer, got: $PR_NUMBER" >&2; exit 2; }
 
 if [[ -z "$REPO" ]]; then
     REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
 fi
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-RESOLVE_FLAG=""
+
+# Build optional flags as an array so pr-reply.sh receives exactly the
+# intended arguments — an unquoted empty var would add a stray "" arg
+# which shellcheck SC2086 flags and which can behave unpredictably.
+EXTRA_ARGS=()
 if [[ "$RESOLVE" == true ]]; then
-    RESOLVE_FLAG="--resolve"
+    EXTRA_ARGS+=(--resolve)
 fi
 
 SUCCESS=0
@@ -45,7 +50,7 @@ while IFS= read -r line; do
     fi
 
     echo "--- Comment $COMMENT_ID ---"
-    if bash "$SCRIPT_DIR/pr-reply.sh" --repo "$REPO" $RESOLVE_FLAG "$PR_NUMBER" "$COMMENT_ID" "$BODY"; then
+    if bash "$SCRIPT_DIR/pr-reply.sh" --repo "$REPO" "${EXTRA_ARGS[@]}" "$PR_NUMBER" "$COMMENT_ID" "$BODY"; then
         ((SUCCESS++)) || true
     else
         echo "FAILED: comment $COMMENT_ID"

--- a/.claude/skills/pr-review/scripts/pr-comments.sh
+++ b/.claude/skills/pr-review/scripts/pr-comments.sh
@@ -18,38 +18,59 @@ while [[ $# -gt 0 ]]; do
 done
 
 PR_NUMBER="${1:?Usage: pr-comments.sh [--repo OWNER/REPO] PR_NUMBER}"
+[[ "$PR_NUMBER" =~ ^[0-9]+$ ]] || { echo "ERROR: PR_NUMBER must be a positive integer, got: $PR_NUMBER" >&2; exit 2; }
 
 if [[ -z "$REPO" ]]; then
     REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
 fi
 
 # ── Section 1: inline review comments ─────────────────────────────────────
-THREADS_JSON=$(gh api graphql -f query="
+# Fetch ALL comments per thread (not just the root) so reply comments can
+# still be mapped back to their thread and resolved. For realistic PRs,
+# `comments(first: 100)` is enough; a warning is emitted below if the
+# reviewThreads page is also capped.
+THREADS_RAW=$(gh api graphql -f query="
 {
   repository(owner: \"${REPO%%/*}\", name: \"${REPO##*/}\") {
     pullRequest(number: $PR_NUMBER) {
       reviewThreads(first: 100) {
+        pageInfo { hasNextPage }
         nodes {
           id
           isResolved
-          comments(first: 1) {
+          comments(first: 100) {
+            pageInfo { hasNextPage }
             nodes { databaseId }
           }
         }
       }
     }
   }
-}" --jq '.data.repository.pullRequest.reviewThreads.nodes')
+}")
 
+THREADS_HAS_MORE=$(echo "$THREADS_RAW" | jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage')
+if [[ "$THREADS_HAS_MORE" == "true" ]]; then
+    echo "Warning: PR has >100 review threads; some threads may not appear below." >&2
+fi
+
+THREADS_JSON=$(echo "$THREADS_RAW" | jq '.data.repository.pullRequest.reviewThreads.nodes')
+
+# Flatten: one entry per (comment_id, thread_id, resolved) so EVERY comment
+# in the thread maps to its thread — not just the root. This is what
+# lets callers look up the thread for a reply comment.
 THREAD_MAP=$(echo "$THREADS_JSON" | jq -r '
-  [.[] | {
-    comment_id: .comments.nodes[0].databaseId,
-    thread_id: .id,
-    resolved: .isResolved
+  [.[] | . as $t | .comments.nodes[] | {
+    comment_id: .databaseId,
+    thread_id: $t.id,
+    resolved: $t.isResolved
   }]
 ')
 
-INLINE=$(gh api "repos/$REPO/pulls/$PR_NUMBER/comments" --paginate)
+# gh api --paginate concatenates multiple JSON arrays (one per page) into
+# its output. jq -s slurps them into an array-of-arrays; `add` flattens
+# to a single array so length / iteration are correct regardless of page
+# count.
+INLINE=$(gh api "repos/$REPO/pulls/$PR_NUMBER/comments" --paginate | jq -s 'add // []')
 INLINE_COUNT=$(echo "$INLINE" | jq 'length')
 
 echo "════════════════ INLINE REVIEW COMMENTS ($INLINE_COUNT) ════════════════"
@@ -67,7 +88,7 @@ echo "$INLINE" | jq -r --argjson threads "$THREAD_MAP" '
 '
 
 # ── Section 2: issue comments (general PR comments) ───────────────────────
-ISSUE=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" --paginate)
+ISSUE=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" --paginate | jq -s 'add // []')
 ISSUE_COUNT=$(echo "$ISSUE" | jq 'length')
 
 echo ""
@@ -82,7 +103,7 @@ echo "$ISSUE" | jq -r '
 '
 
 # ── Section 3: top-level reviews with a body ──────────────────────────────
-REVIEWS=$(gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" --paginate)
+REVIEWS=$(gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" --paginate | jq -s 'add // []')
 REVIEWS_WITH_BODY=$(echo "$REVIEWS" | jq '[.[] | select((.body // "") != "")]')
 REVIEW_COUNT=$(echo "$REVIEWS_WITH_BODY" | jq 'length')
 

--- a/.claude/skills/pr-review/scripts/pr-comments.sh
+++ b/.claude/skills/pr-review/scripts/pr-comments.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Fetch and display all PR feedback in one pass:
+#   1. Inline review comments (with thread resolve status)
+#   2. Issue comments (qodo summaries, sonarcloud, etc.)
+#   3. Top-level reviews with a non-empty body (copilot overview, etc.)
+#
+# Usage: pr-comments.sh [--repo OWNER/REPO] PR_NUMBER
+
+REPO=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --repo) REPO="$2"; shift 2 ;;
+        *) break ;;
+    esac
+done
+
+PR_NUMBER="${1:?Usage: pr-comments.sh [--repo OWNER/REPO] PR_NUMBER}"
+
+if [[ -z "$REPO" ]]; then
+    REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+fi
+
+# ── Section 1: inline review comments ─────────────────────────────────────
+THREADS_JSON=$(gh api graphql -f query="
+{
+  repository(owner: \"${REPO%%/*}\", name: \"${REPO##*/}\") {
+    pullRequest(number: $PR_NUMBER) {
+      reviewThreads(first: 100) {
+        nodes {
+          id
+          isResolved
+          comments(first: 1) {
+            nodes { databaseId }
+          }
+        }
+      }
+    }
+  }
+}" --jq '.data.repository.pullRequest.reviewThreads.nodes')
+
+THREAD_MAP=$(echo "$THREADS_JSON" | jq -r '
+  [.[] | {
+    comment_id: .comments.nodes[0].databaseId,
+    thread_id: .id,
+    resolved: .isResolved
+  }]
+')
+
+INLINE=$(gh api "repos/$REPO/pulls/$PR_NUMBER/comments" --paginate)
+INLINE_COUNT=$(echo "$INLINE" | jq 'length')
+
+echo "════════════════ INLINE REVIEW COMMENTS ($INLINE_COUNT) ════════════════"
+echo "$INLINE" | jq -r --argjson threads "$THREAD_MAP" '
+  .[] | . as $c |
+  ($threads | map(select(.comment_id == $c.id)) | first // {resolved: "unknown", thread_id: "?"}) as $t |
+  "──────────────────────────────────────────────────",
+  "ID: \($c.id)  |  Thread: \(if $t.resolved == true then "RESOLVED" elif $t.resolved == false then "UNRESOLVED" else "?" end)  |  Reply-to: \($c.in_reply_to_id // "none")",
+  "File: \($c.path):\($c.original_line // $c.line // "?")",
+  "Thread ID: \($t.thread_id)",
+  "Author: \($c.user.login)",
+  "",
+  ($c.body | split("\n") | if length > 10 then .[:10] + ["... (truncated)"] else . end | join("\n")),
+  ""
+'
+
+# ── Section 2: issue comments (general PR comments) ───────────────────────
+ISSUE=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" --paginate)
+ISSUE_COUNT=$(echo "$ISSUE" | jq 'length')
+
+echo ""
+echo "════════════════ ISSUE COMMENTS ($ISSUE_COUNT) ════════════════"
+echo "$ISSUE" | jq -r '
+  .[] |
+  "──────────────────────────────────────────────────",
+  "ID: \(.id)  |  Author: \(.user.login)  |  Created: \(.created_at)",
+  "",
+  (.body | split("\n") | if length > 10 then .[:10] + ["... (truncated)"] else . end | join("\n")),
+  ""
+'
+
+# ── Section 3: top-level reviews with a body ──────────────────────────────
+REVIEWS=$(gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" --paginate)
+REVIEWS_WITH_BODY=$(echo "$REVIEWS" | jq '[.[] | select((.body // "") != "")]')
+REVIEW_COUNT=$(echo "$REVIEWS_WITH_BODY" | jq 'length')
+
+echo ""
+echo "════════════════ TOP-LEVEL REVIEWS ($REVIEW_COUNT) ════════════════"
+echo "$REVIEWS_WITH_BODY" | jq -r '
+  .[] |
+  "──────────────────────────────────────────────────",
+  "Review ID: \(.id)  |  Author: \(.user.login)  |  State: \(.state)  |  Submitted: \(.submitted_at)",
+  "",
+  (.body | split("\n") | if length > 10 then .[:10] + ["... (truncated)"] else . end | join("\n")),
+  ""
+'

--- a/.claude/skills/pr-review/scripts/pr-reply.sh
+++ b/.claude/skills/pr-review/scripts/pr-reply.sh
@@ -19,11 +19,17 @@ PR_NUMBER="${1:?Usage: pr-reply.sh [--repo OWNER/REPO] [--resolve] PR_NUMBER COM
 COMMENT_ID="${2:?Missing COMMENT_ID}"
 BODY="${3:?Missing reply body}"
 
+# PR_NUMBER and COMMENT_ID are interpolated into GraphQL / jq strings.
+# Accept only integers to prevent query breakage or injection from a
+# badly-shaped caller argument.
+[[ "$PR_NUMBER" =~ ^[0-9]+$ ]] || { echo "ERROR: PR_NUMBER must be a positive integer, got: $PR_NUMBER" >&2; exit 2; }
+[[ "$COMMENT_ID" =~ ^[0-9]+$ ]] || { echo "ERROR: COMMENT_ID must be a positive integer, got: $COMMENT_ID" >&2; exit 2; }
+
 if [[ -z "$REPO" ]]; then
     REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
 fi
 
-# Append signature
+# Append signature so recipients know the reply came from an AI assistant.
 BODY="${BODY}
 
 - Claude"
@@ -36,22 +42,41 @@ echo "Replied: $REPLY_URL"
 
 # Resolve thread if requested
 if [[ "$RESOLVE" == true ]]; then
-    # Find the thread ID for this comment
+    # Match COMMENT_ID against ANY comment in each thread, not just the
+    # root comment — replies share the thread with their root and need
+    # to resolve the same thread. `comments(first: 100)` covers realistic
+    # thread depths; deeper threads will warn below.
     THREAD_ID=$(gh api graphql -f query="
     {
       repository(owner: \"${REPO%%/*}\", name: \"${REPO##*/}\") {
         pullRequest(number: $PR_NUMBER) {
           reviewThreads(first: 100) {
+            pageInfo { hasNextPage }
             nodes {
               id
-              comments(first: 1) {
+              comments(first: 100) {
+                pageInfo { hasNextPage }
                 nodes { databaseId }
               }
             }
           }
         }
       }
-    }" --jq ".data.repository.pullRequest.reviewThreads.nodes[] | select(.comments.nodes[0].databaseId == $COMMENT_ID) | .id")
+    }" --jq ".data.repository.pullRequest.reviewThreads.nodes[] | select([.comments.nodes[].databaseId] | index($COMMENT_ID)) | .id" | head -1)
+
+    # Warn (don't fail) if the query hit the first-page cap — resolve may
+    # silently miss if the target thread is beyond thread 100 or comment 100.
+    HAS_MORE=$(gh api graphql -f query="
+    {
+      repository(owner: \"${REPO%%/*}\", name: \"${REPO##*/}\") {
+        pullRequest(number: $PR_NUMBER) {
+          reviewThreads(first: 100) { pageInfo { hasNextPage } }
+        }
+      }
+    }" --jq '.data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage')
+    if [[ "$HAS_MORE" == "true" ]]; then
+        echo "Warning: PR has >100 review threads; thread lookup may miss older threads." >&2
+    fi
 
     if [[ -n "$THREAD_ID" ]]; then
         RESOLVED=$(gh api graphql -f query="

--- a/.claude/skills/pr-review/scripts/pr-reply.sh
+++ b/.claude/skills/pr-review/scripts/pr-reply.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Reply to a PR review comment, optionally resolve its thread.
+# Usage: pr-reply.sh [--repo OWNER/REPO] [--resolve] PR_NUMBER COMMENT_ID "body"
+
+REPO=""
+RESOLVE=false
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --repo) REPO="$2"; shift 2 ;;
+        --resolve) RESOLVE=true; shift ;;
+        *) break ;;
+    esac
+done
+
+PR_NUMBER="${1:?Usage: pr-reply.sh [--repo OWNER/REPO] [--resolve] PR_NUMBER COMMENT_ID \"body\"}"
+COMMENT_ID="${2:?Missing COMMENT_ID}"
+BODY="${3:?Missing reply body}"
+
+if [[ -z "$REPO" ]]; then
+    REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+fi
+
+# Append signature
+BODY="${BODY}
+
+- Claude"
+
+# Post reply
+REPLY_URL=$(gh api "repos/$REPO/pulls/$PR_NUMBER/comments/$COMMENT_ID/replies" \
+    -f body="$BODY" \
+    --jq '.html_url')
+echo "Replied: $REPLY_URL"
+
+# Resolve thread if requested
+if [[ "$RESOLVE" == true ]]; then
+    # Find the thread ID for this comment
+    THREAD_ID=$(gh api graphql -f query="
+    {
+      repository(owner: \"${REPO%%/*}\", name: \"${REPO##*/}\") {
+        pullRequest(number: $PR_NUMBER) {
+          reviewThreads(first: 100) {
+            nodes {
+              id
+              comments(first: 1) {
+                nodes { databaseId }
+              }
+            }
+          }
+        }
+      }
+    }" --jq ".data.repository.pullRequest.reviewThreads.nodes[] | select(.comments.nodes[0].databaseId == $COMMENT_ID) | .id")
+
+    if [[ -n "$THREAD_ID" ]]; then
+        RESOLVED=$(gh api graphql -f query="
+          mutation { resolveReviewThread(input: {threadId: \"$THREAD_ID\"}) { thread { isResolved } } }
+        " --jq '.data.resolveReviewThread.thread.isResolved')
+        echo "Resolved: $RESOLVED (thread $THREAD_ID)"
+    else
+        echo "Warning: could not find thread for comment $COMMENT_ID"
+    fi
+fi


### PR DESCRIPTION
## Summary

Copies the `pr-review` skill from `~/.claude/skills/pr-review/` into this repo under `.claude/skills/pr-review/` so:

- Agents dispatched to work on this repo without the operator's home dir get the skill automatically.
- The skill version used on this repo is pinned in git — future upstream changes don't silently affect us.
- Matches the "prefer local checked-in config" convention established by `.markdownlint-cli2.yaml` on PR #3.

## Stacked on PR #3

This branch is **based on `feat/phase-1-cf-skill-foundation`** (PR #3), not `main`. Reason: the upstream `SKILL.md` has long lines (>80 chars) that lint clean only when MD013 is disabled — which happens via the local `.markdownlint-cli2.yaml` that PR #3 introduces. Merging order:

1. PR #3 → main
2. This PR rebased onto main → main

After PR #3 merges, rebase this branch onto main and re-target the PR base to `main` (or GitHub will auto-update).

## Changes

- `.claude/skills/pr-review/SKILL.md` — vendored from global. The four inline `~/.claude/skills/pr-review/scripts/...` references are rewritten to `.claude/skills/pr-review/scripts/...` so documented commands resolve from repo root.
- `.claude/skills/pr-review/scripts/pr-comments.sh` — fetch inline comments, issue comments, and top-level reviews in one pass.
- `.claude/skills/pr-review/scripts/pr-reply.sh` — reply to one comment, optionally resolve its thread.
- `.claude/skills/pr-review/scripts/pr-batch.sh` — JSONL batch reply + resolve.

## Test plan

- [x] `markdownlint-cli2 ".claude/skills/pr-review/SKILL.md"` — 0 errors
- [x] `shellcheck .claude/skills/pr-review/scripts/*.sh` — clean
- [x] Skill auto-discoverable by Claude Code: a project-scoped `.claude/skills/pr-review/` takes precedence over the global copy

## Known gaps

- **No upstream sync mechanism yet.** This is a one-time vendored copy; future updates to `~/.claude/skills/pr-review/` won't propagate. If upstream changes become relevant, we'll either re-copy manually or set up a sync script. Not solving today.

- Claude