### PR TITLE
Phase 1 · Checkpoint B: cf-zones, cf-dns, cf-workers, cf-pages

### DIFF
--- a/.claude/skills/cloudflare/scripts/_lib.sh
+++ b/.claude/skills/cloudflare/scripts/_lib.sh
@@ -150,3 +150,43 @@ cf_require_account_id() {
   fi
   return 0
 }
+
+# cf_api_paginated PATH
+#
+# Fetches every page of a CloudFlare list endpoint and emits one
+# synthetic response envelope whose .result is the concatenation of
+# every page's .result. Uses per_page=50 (overridable via CF_PAGE_SIZE
+# env var) and follows .result_info.total_pages to terminate.
+#
+# Call this on list endpoints that return
+#   { result: [...], result_info: {page, per_page, total_pages, ...} }.
+# Do NOT call it on single-object endpoints (e.g. /user/tokens/verify) —
+# use cf_api directly there.
+cf_api_paginated() {
+  local path="$1"
+  local per_page="${CF_PAGE_SIZE:-50}"
+  local separator="?"
+  [[ "$path" == *"?"* ]] && separator="&"
+
+  local page=1
+  local all_results='[]'
+  local response page_results total_pages last_info='{}'
+
+  while :; do
+    response=$(cf_api "${path}${separator}per_page=${per_page}&page=${page}")
+    page_results=$(printf '%s' "$response" | jq '.result // []')
+    all_results=$(jq -s 'add' <(printf '%s' "$all_results") <(printf '%s' "$page_results"))
+    total_pages=$(printf '%s' "$response" | jq -r '.result_info.total_pages // 1')
+    last_info=$(printf '%s' "$response" | jq '.result_info // {}')
+    if (( page >= total_pages )); then
+      break
+    fi
+    ((page++))
+  done
+
+  # shellcheck disable=SC2016  # single-quoted jq filter
+  jq -n \
+    --argjson results "$all_results" \
+    --argjson info "$last_info" \
+    '{success: true, errors: [], messages: [], result: $results, result_info: ($info + {page: 1, total_pages: 1, count: ($results | length), total_count: ($results | length)})}'
+}

--- a/.claude/skills/cloudflare/scripts/_lib.sh
+++ b/.claude/skills/cloudflare/scripts/_lib.sh
@@ -16,6 +16,10 @@
 #   CF_ENV_FILE           (optional) — path to .env, defaults to repo root
 
 set -euo pipefail
+# Propagate set -e into command-substitution subshells so a failing
+# cf_api inside cf_api_paginated's $(...) actually exits the caller.
+# Without this, default bash 4.4+ silently swallows the inner exit 1.
+shopt -s inherit_errexit
 
 _CF_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CF_REPO_ROOT="$(cd "$_CF_LIB_DIR/../../../.." && pwd)"

--- a/.claude/skills/cloudflare/scripts/_lib.sh
+++ b/.claude/skills/cloudflare/scripts/_lib.sh
@@ -193,4 +193,5 @@ cf_api_paginated() {
     --argjson results "$all_results" \
     --argjson info "$last_info" \
     '{success: true, errors: [], messages: [], result: $results, result_info: ($info + {page: 1, total_pages: 1, count: ($results | length), total_count: ($results | length)})}'
+  return 0
 }

--- a/.claude/skills/cloudflare/scripts/cf-dns.sh
+++ b/.claude/skills/cloudflare/scripts/cf-dns.sh
@@ -43,9 +43,13 @@ fi
 # shellcheck source=_lib.sh
 source "$(dirname "${BASH_SOURCE[0]}")/_lib.sh"
 
-# Step 1: resolve zone name → id. Zone names are DNS labels (letters,
-# digits, dots, hyphens) so they don't need URL encoding.
-lookup=$(cf_api "/zones?name=$zone")
+# Step 1: resolve zone name → id. URL-encode the zone argument before
+# interpolating so a caller passing an unusual character (e.g. `&` or
+# `?`) can't inject extra query parameters. jq's @uri matches RFC 3986
+# unreserved chars, so ordinary DNS labels (culture.dev) pass through
+# unchanged.
+zone_encoded=$(jq -rn --arg v "$zone" '$v|@uri')
+lookup=$(cf_api "/zones?name=$zone_encoded")
 zone_id=$(printf '%s' "$lookup" | jq -r '.result[0].id // empty')
 if [[ -z "$zone_id" ]]; then
   echo "ERROR: zone '$zone' not found in the configured account." >&2

--- a/.claude/skills/cloudflare/scripts/cf-dns.sh
+++ b/.claude/skills/cloudflare/scripts/cf-dns.sh
@@ -52,8 +52,9 @@ if [[ -z "$zone_id" ]]; then
   exit 1
 fi
 
-# Step 2: list DNS records for that zone
-response=$(cf_api "/zones/$zone_id/dns_records")
+# Step 2: list DNS records for that zone. Paginated — active zones
+# routinely exceed CloudFlare's default 20-per-page response size.
+response=$(cf_api_paginated "/zones/$zone_id/dns_records")
 
 if [[ "$mode" == "md" ]]; then
   count=$(printf '%s' "$response" | jq -r '.result | length')

--- a/.claude/skills/cloudflare/scripts/cf-dns.sh
+++ b/.claude/skills/cloudflare/scripts/cf-dns.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# List DNS records for a zone.
+#
+# Usage: cf-dns.sh ZONE [--json]
+#
+# ZONE is the zone name (e.g. culture.dev). The script resolves the
+# name to a zone id via /zones?name=<ZONE>, then lists records via
+# /zones/<id>/dns_records. Renders a markdown table of type, name,
+# content, proxied, ttl by default; --json emits the raw records
+# response.
+
+set -euo pipefail
+
+mode=md
+zone=""
+for arg in "$@"; do
+  case "$arg" in
+    --json) mode=json ;;
+    -h|--help)
+      sed -n 's/^# \{0,1\}//p' "$0" | head -11
+      exit 0
+      ;;
+    -*)
+      echo "ERROR: unknown flag: $arg" >&2
+      exit 2
+      ;;
+    *)
+      if [[ -z "$zone" ]]; then
+        zone="$arg"
+      else
+        echo "ERROR: unexpected extra argument: $arg" >&2
+        exit 2
+      fi
+      ;;
+  esac
+done
+
+if [[ -z "$zone" ]]; then
+  echo "ERROR: zone name is required. Usage: cf-dns.sh ZONE [--json]" >&2
+  exit 2
+fi
+
+# shellcheck source=_lib.sh
+source "$(dirname "${BASH_SOURCE[0]}")/_lib.sh"
+
+# Step 1: resolve zone name → id. Zone names are DNS labels (letters,
+# digits, dots, hyphens) so they don't need URL encoding.
+lookup=$(cf_api "/zones?name=$zone")
+zone_id=$(printf '%s' "$lookup" | jq -r '.result[0].id // empty')
+if [[ -z "$zone_id" ]]; then
+  echo "ERROR: zone '$zone' not found in the configured account." >&2
+  exit 1
+fi
+
+# Step 2: list DNS records for that zone
+response=$(cf_api "/zones/$zone_id/dns_records")
+
+if [[ "$mode" == "md" ]]; then
+  count=$(printf '%s' "$response" | jq -r '.result | length')
+  printf '## DNS records for %s (%s)\n\n' "$zone" "$count"
+fi
+
+# shellcheck disable=SC2016  # single-quoted jq filter
+cf_output "$response" "$mode" \
+  '.result[] | [.type, .name, .content, (if .proxied then "proxied" else "—" end), (.ttl | tostring)] | @tsv' \
+  "$(printf 'TYPE\tNAME\tCONTENT\tPROXIED\tTTL')"

--- a/.claude/skills/cloudflare/scripts/cf-pages.sh
+++ b/.claude/skills/cloudflare/scripts/cf-pages.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# List CloudFlare Pages projects (or deployments for a specific project).
+#
+# Usage:
+#   cf-pages.sh [--json]             # list all Pages projects in the account
+#   cf-pages.sh PROJECT [--json]     # list deployments for that project
+#
+# Needed for Phase 2 (agentirc.dev Pages cleanup) — use the project
+# listing to identify the orphaned project, then pass its name here to
+# inventory its deployments before removal.
+#
+# Calls /accounts/<CLOUDFLARE_ACCOUNT_ID>/pages/projects or
+#       /accounts/<CLOUDFLARE_ACCOUNT_ID>/pages/projects/<PROJECT>/deployments.
+
+set -euo pipefail
+
+mode=md
+project=""
+for arg in "$@"; do
+  case "$arg" in
+    --json) mode=json ;;
+    -h|--help)
+      sed -n 's/^# \{0,1\}//p' "$0" | head -13
+      exit 0
+      ;;
+    -*)
+      echo "ERROR: unknown flag: $arg" >&2
+      exit 2
+      ;;
+    *)
+      if [[ -z "$project" ]]; then
+        project="$arg"
+      else
+        echo "ERROR: unexpected extra argument: $arg" >&2
+        exit 2
+      fi
+      ;;
+  esac
+done
+
+# shellcheck source=_lib.sh
+source "$(dirname "${BASH_SOURCE[0]}")/_lib.sh"
+cf_require_account_id
+
+if [[ -z "$project" ]]; then
+  response=$(cf_api "/accounts/$CLOUDFLARE_ACCOUNT_ID/pages/projects")
+
+  if [[ "$mode" == "md" ]]; then
+    count=$(printf '%s' "$response" | jq -r '.result | length')
+    printf '## Pages projects (%s)\n\n' "$count"
+  fi
+
+  # shellcheck disable=SC2016  # single-quoted jq filter
+  cf_output "$response" "$mode" \
+    '.result[] | [.name, (.production_branch // "—"), (.subdomain // "—"), (.latest_deployment.created_on // "—")] | @tsv' \
+    "$(printf 'NAME\tBRANCH\tSUBDOMAIN\tLATEST')"
+else
+  response=$(cf_api "/accounts/$CLOUDFLARE_ACCOUNT_ID/pages/projects/$project/deployments")
+
+  if [[ "$mode" == "md" ]]; then
+    count=$(printf '%s' "$response" | jq -r '.result | length')
+    printf '## Deployments for %s (%s)\n\n' "$project" "$count"
+  fi
+
+  # shellcheck disable=SC2016  # single-quoted jq filter
+  cf_output "$response" "$mode" \
+    '.result[] | [(.short_id // (.id[0:8])), (.environment // "—"), (.deployment_trigger.metadata.branch // "—"), (.latest_stage.status // "—"), .created_on] | @tsv' \
+    "$(printf 'SHORT_ID\tENV\tBRANCH\tSTATUS\tCREATED')"
+fi

--- a/.claude/skills/cloudflare/scripts/cf-pages.sh
+++ b/.claude/skills/cloudflare/scripts/cf-pages.sh
@@ -55,7 +55,12 @@ if [[ -z "$project" ]]; then
     '.result[] | [.name, (.production_branch // "—"), (.subdomain // "—"), (.latest_deployment.created_on // "—")] | @tsv' \
     "$(printf 'NAME\tBRANCH\tSUBDOMAIN\tLATEST')"
 else
-  response=$(cf_api_paginated "/accounts/$CLOUDFLARE_ACCOUNT_ID/pages/projects/$project/deployments")
+  # URL-encode the project argument so an unusual character (space,
+  # `/`, `?`, `#`) cannot alter the request path. CloudFlare Pages
+  # project names are normally safe, but the encoding is cheap
+  # insurance.
+  project_encoded=$(jq -rn --arg v "$project" '$v|@uri')
+  response=$(cf_api_paginated "/accounts/$CLOUDFLARE_ACCOUNT_ID/pages/projects/$project_encoded/deployments")
 
   if [[ "$mode" == "md" ]]; then
     count=$(printf '%s' "$response" | jq -r '.result | length')

--- a/.claude/skills/cloudflare/scripts/cf-pages.sh
+++ b/.claude/skills/cloudflare/scripts/cf-pages.sh
@@ -43,7 +43,7 @@ source "$(dirname "${BASH_SOURCE[0]}")/_lib.sh"
 cf_require_account_id
 
 if [[ -z "$project" ]]; then
-  response=$(cf_api "/accounts/$CLOUDFLARE_ACCOUNT_ID/pages/projects")
+  response=$(cf_api_paginated "/accounts/$CLOUDFLARE_ACCOUNT_ID/pages/projects")
 
   if [[ "$mode" == "md" ]]; then
     count=$(printf '%s' "$response" | jq -r '.result | length')
@@ -55,7 +55,7 @@ if [[ -z "$project" ]]; then
     '.result[] | [.name, (.production_branch // "—"), (.subdomain // "—"), (.latest_deployment.created_on // "—")] | @tsv' \
     "$(printf 'NAME\tBRANCH\tSUBDOMAIN\tLATEST')"
 else
-  response=$(cf_api "/accounts/$CLOUDFLARE_ACCOUNT_ID/pages/projects/$project/deployments")
+  response=$(cf_api_paginated "/accounts/$CLOUDFLARE_ACCOUNT_ID/pages/projects/$project/deployments")
 
   if [[ "$mode" == "md" ]]; then
     count=$(printf '%s' "$response" | jq -r '.result | length')

--- a/.claude/skills/cloudflare/scripts/cf-workers-routes.sh
+++ b/.claude/skills/cloudflare/scripts/cf-workers-routes.sh
@@ -32,8 +32,9 @@ done
 # shellcheck source=_lib.sh
 source "$(dirname "${BASH_SOURCE[0]}")/_lib.sh"
 
-# Step 1: enumerate zones the token can see
-zones_response=$(cf_api /zones)
+# Step 1: enumerate zones the token can see (paginated — some accounts
+# have >50 zones).
+zones_response=$(cf_api_paginated /zones)
 zone_count=$(printf '%s' "$zones_response" | jq -r '.result | length')
 
 # Step 2: fetch routes per zone, accumulate into a single array with
@@ -41,7 +42,7 @@ zone_count=$(printf '%s' "$zones_response" | jq -r '.result | length')
 all_routes='[]'
 while IFS=$'\t' read -r zone_id zone_name; do
   [[ -z "$zone_id" ]] && continue
-  routes_response=$(cf_api "/zones/$zone_id/workers/routes")
+  routes_response=$(cf_api_paginated "/zones/$zone_id/workers/routes")
   enriched=$(printf '%s' "$routes_response" | jq --arg zname "$zone_name" \
     '(.result // []) | map(. + {zone_name: $zname})')
   all_routes=$(jq -s 'add' <(printf '%s' "$all_routes") <(printf '%s' "$enriched"))

--- a/.claude/skills/cloudflare/scripts/cf-workers-routes.sh
+++ b/.claude/skills/cloudflare/scripts/cf-workers-routes.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# List Workers routes across all zones in the configured account.
+#
+# Usage: cf-workers-routes.sh [--json]
+#
+# Performs n+1 API calls: GET /zones once, then one
+# GET /zones/<zone_id>/workers/routes per zone. Results are merged
+# into a single array with .zone_name attached to each route, and
+# rendered as a markdown table (ZONE / PATTERN / SCRIPT / ENABLED)
+# or a synthetic CloudFlare-shaped JSON envelope with --json.
+#
+# Cost scales linearly with zones in the account. For accounts with
+# many zones, prefer inspecting one zone at a time.
+
+set -euo pipefail
+
+mode=md
+for arg in "$@"; do
+  case "$arg" in
+    --json) mode=json ;;
+    -h|--help)
+      sed -n 's/^# \{0,1\}//p' "$0" | head -13
+      exit 0
+      ;;
+    *)
+      echo "ERROR: unknown argument: $arg" >&2
+      exit 2
+      ;;
+  esac
+done
+
+# shellcheck source=_lib.sh
+source "$(dirname "${BASH_SOURCE[0]}")/_lib.sh"
+
+# Step 1: enumerate zones the token can see
+zones_response=$(cf_api /zones)
+zone_count=$(printf '%s' "$zones_response" | jq -r '.result | length')
+
+# Step 2: fetch routes per zone, accumulate into a single array with
+# .zone_name attached so the final table can group routes by zone.
+all_routes='[]'
+while IFS=$'\t' read -r zone_id zone_name; do
+  [[ -z "$zone_id" ]] && continue
+  routes_response=$(cf_api "/zones/$zone_id/workers/routes")
+  enriched=$(printf '%s' "$routes_response" | jq --arg zname "$zone_name" \
+    '(.result // []) | map(. + {zone_name: $zname})')
+  all_routes=$(jq -s 'add' <(printf '%s' "$all_routes") <(printf '%s' "$enriched"))
+done < <(printf '%s' "$zones_response" | jq -r '.result[]? | [.id, .name] | @tsv')
+
+# Synthetic envelope so --json output matches the shape of other cf-* scripts
+combined=$(jq -n --argjson routes "$all_routes" \
+  '{success: true, errors: [], messages: [], result: $routes}')
+
+if [[ "$mode" == "md" ]]; then
+  route_count=$(printf '%s' "$all_routes" | jq 'length')
+  printf '## Workers routes across %s zone(s) (%s)\n\n' "$zone_count" "$route_count"
+fi
+
+# shellcheck disable=SC2016  # single-quoted jq filter
+cf_output "$combined" "$mode" \
+  '.result[] | [.zone_name, .pattern, (.script // "—"), ((.enabled // true) | tostring)] | @tsv' \
+  "$(printf 'ZONE\tPATTERN\tSCRIPT\tENABLED')"

--- a/.claude/skills/cloudflare/scripts/cf-workers.sh
+++ b/.claude/skills/cloudflare/scripts/cf-workers.sh
@@ -33,7 +33,7 @@ done
 source "$(dirname "${BASH_SOURCE[0]}")/_lib.sh"
 cf_require_account_id
 
-response=$(cf_api "/accounts/$CLOUDFLARE_ACCOUNT_ID/workers/scripts")
+response=$(cf_api_paginated "/accounts/$CLOUDFLARE_ACCOUNT_ID/workers/scripts")
 
 if [[ "$mode" == "md" ]]; then
   count=$(printf '%s' "$response" | jq -r '.result | length')

--- a/.claude/skills/cloudflare/scripts/cf-workers.sh
+++ b/.claude/skills/cloudflare/scripts/cf-workers.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# List Workers scripts in the configured CloudFlare account.
+#
+# Usage: cf-workers.sh [--json]
+#
+# Calls /accounts/<CLOUDFLARE_ACCOUNT_ID>/workers/scripts. Renders a
+# markdown table of script id (name), handlers, modified_on, and usage
+# model. --json emits the raw API response.
+#
+# Phase 1 intentionally does NOT list per-zone Workers routes — that
+# requires enumerating every zone and is not needed for current
+# visibility goals. Add cf-workers-routes.sh in a follow-up when the
+# need is concrete.
+
+set -euo pipefail
+
+mode=md
+for arg in "$@"; do
+  case "$arg" in
+    --json) mode=json ;;
+    -h|--help)
+      sed -n 's/^# \{0,1\}//p' "$0" | head -13
+      exit 0
+      ;;
+    *)
+      echo "ERROR: unknown argument: $arg" >&2
+      exit 2
+      ;;
+  esac
+done
+
+# shellcheck source=_lib.sh
+source "$(dirname "${BASH_SOURCE[0]}")/_lib.sh"
+cf_require_account_id
+
+response=$(cf_api "/accounts/$CLOUDFLARE_ACCOUNT_ID/workers/scripts")
+
+if [[ "$mode" == "md" ]]; then
+  count=$(printf '%s' "$response" | jq -r '.result | length')
+  printf '## Workers scripts (%s)\n\n' "$count"
+fi
+
+# shellcheck disable=SC2016  # single-quoted jq filter
+cf_output "$response" "$mode" \
+  '.result[] | [.id, ((.handlers // []) | join(",") | if . == "" then "—" else . end), .modified_on, (.usage_model // "—")] | @tsv' \
+  "$(printf 'NAME\tHANDLERS\tMODIFIED_ON\tUSAGE_MODEL')"

--- a/.claude/skills/cloudflare/scripts/cf-zones.sh
+++ b/.claude/skills/cloudflare/scripts/cf-zones.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# List zones in the configured CloudFlare account.
+#
+# Usage: cf-zones.sh [--json]
+#
+# Calls /zones. Renders a markdown table of id, name, status, and plan
+# name. --json passes the raw API response through for bots and jq
+# pipelines.
+
+set -euo pipefail
+
+mode=md
+for arg in "$@"; do
+  case "$arg" in
+    --json) mode=json ;;
+    -h|--help)
+      sed -n 's/^# \{0,1\}//p' "$0" | head -8
+      exit 0
+      ;;
+    *)
+      echo "ERROR: unknown argument: $arg" >&2
+      exit 2
+      ;;
+  esac
+done
+
+# shellcheck source=_lib.sh
+source "$(dirname "${BASH_SOURCE[0]}")/_lib.sh"
+
+response=$(cf_api /zones)
+
+if [[ "$mode" == "md" ]]; then
+  count=$(printf '%s' "$response" | jq -r '.result | length')
+  printf '## Zones (%s)\n\n' "$count"
+fi
+
+# shellcheck disable=SC2016  # single-quoted jq filter
+cf_output "$response" "$mode" \
+  '.result[] | [.id, .name, .status, (.plan.name // "—")] | @tsv' \
+  "$(printf 'ID\tNAME\tSTATUS\tPLAN')"

--- a/.claude/skills/cloudflare/scripts/cf-zones.sh
+++ b/.claude/skills/cloudflare/scripts/cf-zones.sh
@@ -27,7 +27,7 @@ done
 # shellcheck source=_lib.sh
 source "$(dirname "${BASH_SOURCE[0]}")/_lib.sh"
 
-response=$(cf_api /zones)
+response=$(cf_api_paginated /zones)
 
 if [[ "$mode" == "md" ]]; then
   count=$(printf '%s' "$response" | jq -r '.result | length')

--- a/tests/bats/_lib.bats
+++ b/tests/bats/_lib.bats
@@ -163,3 +163,59 @@ setup() {
   [[ "$output" == *"\\|"* ]]
   [[ "$output" == *"| NAME | CONTENT |"* ]]
 }
+
+# --- cf_api_paginated: walk total_pages ---
+
+@test "cf_api_paginated concatenates .result across all pages" {
+  cf_mock "&page=1" "paginated_page1.json"
+  cf_mock "&page=2" "paginated_page2.json"
+  run bash -c "source '$SKILL_SCRIPTS/_lib.sh' && cf_api_paginated /zones"
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.success == true'
+  echo "$output" | jq -e '.result | length == 3'
+  echo "$output" | jq -e '.result | map(.name) | . == ["alpha","bravo","charlie"]'
+}
+
+@test "cf_api_paginated issues one request per page (follows total_pages)" {
+  cf_mock "&page=1" "paginated_page1.json"
+  cf_mock "&page=2" "paginated_page2.json"
+  run bash -c "source '$SKILL_SCRIPTS/_lib.sh' && cf_api_paginated /zones"
+  [ "$status" -eq 0 ]
+  cf_assert_called "per_page=50&page=1"
+  cf_assert_called "per_page=50&page=2"
+}
+
+@test "cf_api_paginated stops after page 1 when total_pages is 1" {
+  cf_mock "/zones" "zones.json"
+  run bash -c "source '$SKILL_SCRIPTS/_lib.sh' && cf_api_paginated /zones"
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.result | length == 2'
+  cf_assert_called "per_page=50&page=1"
+  run grep -F "page=2" "$BATS_TEST_TMPDIR/curl.log"
+  [ "$status" -ne 0 ]
+}
+
+@test "cf_api_paginated appends &per_page=... when path already has a query string" {
+  cf_mock "/zones?name=" "zone_lookup.json"
+  run bash -c "source '$SKILL_SCRIPTS/_lib.sh' && cf_api_paginated '/zones?name=culture.dev'"
+  [ "$status" -eq 0 ]
+  cf_assert_called "/zones?name=culture.dev&per_page=50&page=1"
+}
+
+@test "cf_api_paginated returns synthetic result_info (page=1 total_pages=1 count=sum)" {
+  cf_mock "&page=1" "paginated_page1.json"
+  cf_mock "&page=2" "paginated_page2.json"
+  run bash -c "source '$SKILL_SCRIPTS/_lib.sh' && cf_api_paginated /zones"
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.result_info.page == 1'
+  echo "$output" | jq -e '.result_info.total_pages == 1'
+  echo "$output" | jq -e '.result_info.count == 3'
+  echo "$output" | jq -e '.result_info.total_count == 3'
+}
+
+@test "cf_api_paginated honors CF_PAGE_SIZE env var" {
+  cf_mock "/zones" "zones.json"
+  run bash -c "export CF_PAGE_SIZE=25; source '$SKILL_SCRIPTS/_lib.sh' && cf_api_paginated /zones"
+  [ "$status" -eq 0 ]
+  cf_assert_called "per_page=25&page=1"
+}

--- a/tests/bats/cf-dns.bats
+++ b/tests/bats/cf-dns.bats
@@ -1,0 +1,66 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+setup() {
+  cf_bats_setup
+}
+
+@test "cf-dns.sh renders markdown table with zone heading and record count" {
+  cf_mock "/zones?name=" "zone_lookup.json"
+  cf_mock "/dns_records" "dns_records.json"
+  run bash "$SKILL_SCRIPTS/cf-dns.sh" culture.dev
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"## DNS records for culture.dev (4)"* ]]
+  [[ "$output" == *"| TYPE | NAME | CONTENT | PROXIED | TTL |"* ]]
+  [[ "$output" == *"| --- | --- | --- | --- | --- |"* ]]
+  [[ "$output" == *"culture.dev"* ]]
+  [[ "$output" == *"192.0.2.10"* ]]
+  [[ "$output" == *"proxied"* ]]
+  [[ "$output" == *"v=spf1"* ]]
+}
+
+@test "cf-dns.sh resolves zone name to id before fetching records" {
+  cf_mock "/zones?name=" "zone_lookup.json"
+  cf_mock "/dns_records" "dns_records.json"
+  run bash "$SKILL_SCRIPTS/cf-dns.sh" culture.dev
+  [ "$status" -eq 0 ]
+  cf_assert_called "/zones?name=culture.dev"
+  cf_assert_called "/zones/zone-id-culture-dev-0123456789abcdef/dns_records"
+}
+
+@test "cf-dns.sh --json emits the raw records response" {
+  cf_mock "/zones?name=" "zone_lookup.json"
+  cf_mock "/dns_records" "dns_records.json"
+  run bash "$SKILL_SCRIPTS/cf-dns.sh" culture.dev --json
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.success == true'
+  echo "$output" | jq -e '.result | length == 4'
+  echo "$output" | jq -e '.result | map(.type) | contains(["A", "CNAME", "MX", "TXT"])'
+  [[ "$output" != *"## DNS records"* ]]
+}
+
+@test "cf-dns.sh exits 1 with a clear message when zone is not found" {
+  cf_mock "/zones?name=" "zone_lookup_empty.json"
+  run bash "$SKILL_SCRIPTS/cf-dns.sh" nonexistent.example
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"zone 'nonexistent.example' not found"* ]]
+}
+
+@test "cf-dns.sh exits 2 when no zone argument is given" {
+  run bash "$SKILL_SCRIPTS/cf-dns.sh"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"zone name is required"* ]]
+}
+
+@test "cf-dns.sh exits 2 on unknown flag" {
+  run bash "$SKILL_SCRIPTS/cf-dns.sh" --bogus culture.dev
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"unknown flag"* ]]
+}
+
+@test "cf-dns.sh exits 2 on extra positional argument" {
+  run bash "$SKILL_SCRIPTS/cf-dns.sh" culture.dev also.example
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"unexpected extra argument"* ]]
+}

--- a/tests/bats/cf-dns.bats
+++ b/tests/bats/cf-dns.bats
@@ -64,3 +64,11 @@ setup() {
   [ "$status" -eq 2 ]
   [[ "$output" == *"unexpected extra argument"* ]]
 }
+
+@test "cf-dns.sh URL-encodes the zone argument so '&' cannot inject query params" {
+  cf_mock "/zones?name=" "zone_lookup.json"
+  cf_mock "/dns_records" "dns_records.json"
+  run bash "$SKILL_SCRIPTS/cf-dns.sh" 'evil.com&status=active'
+  # The encoded request URL should contain %26, NOT the literal &status=
+  cf_assert_called "evil.com%26status%3Dactive"
+}

--- a/tests/bats/cf-pages.bats
+++ b/tests/bats/cf-pages.bats
@@ -1,0 +1,92 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+setup() {
+  cf_bats_setup
+}
+
+# --- list mode (no project arg) ---
+
+@test "cf-pages.sh lists projects with markdown heading and count" {
+  cf_mock "/pages/projects" "pages_projects.json"
+  run bash "$SKILL_SCRIPTS/cf-pages.sh"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"## Pages projects (2)"* ]]
+  [[ "$output" == *"| NAME | BRANCH | SUBDOMAIN | LATEST |"* ]]
+  [[ "$output" == *"culture-dev-site"* ]]
+  [[ "$output" == *"agentirc-dev"* ]]
+  [[ "$output" == *"culture-dev-site.pages.dev"* ]]
+}
+
+@test "cf-pages.sh --json passes raw projects response through" {
+  cf_mock "/pages/projects" "pages_projects.json"
+  run bash "$SKILL_SCRIPTS/cf-pages.sh" --json
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.success == true'
+  echo "$output" | jq -e '.result | length == 2'
+  echo "$output" | jq -e '.result | map(.name) | contains(["agentirc-dev"])'
+  [[ "$output" != *"## Pages projects"* ]]
+}
+
+@test "cf-pages.sh list mode hits the account-scoped projects endpoint" {
+  cf_mock "/pages/projects" "pages_projects.json"
+  run bash "$SKILL_SCRIPTS/cf-pages.sh"
+  [ "$status" -eq 0 ]
+  cf_assert_called "/accounts/test-account-id/pages/projects"
+}
+
+# --- single-project mode (project arg) ---
+
+@test "cf-pages.sh PROJECT lists deployments with heading and count" {
+  # Order matters: specific '/deployments' mock first so it wins over '/pages/projects'.
+  cf_mock "/deployments" "pages_deployments.json"
+  cf_mock "/pages/projects" "pages_projects.json"
+  run bash "$SKILL_SCRIPTS/cf-pages.sh" agentirc-dev
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"## Deployments for agentirc-dev (3)"* ]]
+  [[ "$output" == *"| SHORT_ID | ENV | BRANCH | STATUS | CREATED |"* ]]
+  [[ "$output" == *"7777ffff"* ]]
+  [[ "$output" == *"production"* ]]
+  [[ "$output" == *"preview"* ]]
+  [[ "$output" == *"success"* ]]
+}
+
+@test "cf-pages.sh PROJECT hits the deployments endpoint for that project" {
+  cf_mock "/deployments" "pages_deployments.json"
+  cf_mock "/pages/projects" "pages_projects.json"
+  run bash "$SKILL_SCRIPTS/cf-pages.sh" agentirc-dev
+  [ "$status" -eq 0 ]
+  cf_assert_called "/accounts/test-account-id/pages/projects/agentirc-dev/deployments"
+}
+
+@test "cf-pages.sh PROJECT --json passes raw deployments response through" {
+  cf_mock "/deployments" "pages_deployments.json"
+  cf_mock "/pages/projects" "pages_projects.json"
+  run bash "$SKILL_SCRIPTS/cf-pages.sh" agentirc-dev --json
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.success == true'
+  echo "$output" | jq -e '.result | length == 3'
+  [[ "$output" != *"## Deployments"* ]]
+}
+
+# --- errors ---
+
+@test "cf-pages.sh exits 1 when CLOUDFLARE_ACCOUNT_ID is unset" {
+  unset CLOUDFLARE_ACCOUNT_ID
+  run bash "$SKILL_SCRIPTS/cf-pages.sh"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"CLOUDFLARE_ACCOUNT_ID not set"* ]]
+}
+
+@test "cf-pages.sh exits 2 on unknown flag" {
+  run bash "$SKILL_SCRIPTS/cf-pages.sh" --bogus
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"unknown flag"* ]]
+}
+
+@test "cf-pages.sh exits 2 on extra positional argument" {
+  run bash "$SKILL_SCRIPTS/cf-pages.sh" project-a project-b
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"unexpected extra argument"* ]]
+}

--- a/tests/bats/cf-pages.bats
+++ b/tests/bats/cf-pages.bats
@@ -39,8 +39,10 @@ setup() {
 # --- single-project mode (project arg) ---
 
 @test "cf-pages.sh PROJECT lists deployments with heading and count" {
-  # Order matters: specific '/deployments' mock first so it wins over '/pages/projects'.
-  cf_mock "/deployments" "pages_deployments.json"
+  # Specific path uniquely identifies the deployments call; the broader
+  # "/pages/projects" mock matches only the bare listing call. Stub uses
+  # longest-match-wins so registration order doesn't matter.
+  cf_mock "/pages/projects/agentirc-dev/deployments" "pages_deployments.json"
   cf_mock "/pages/projects" "pages_projects.json"
   run bash "$SKILL_SCRIPTS/cf-pages.sh" agentirc-dev
   [ "$status" -eq 0 ]
@@ -53,7 +55,7 @@ setup() {
 }
 
 @test "cf-pages.sh PROJECT hits the deployments endpoint for that project" {
-  cf_mock "/deployments" "pages_deployments.json"
+  cf_mock "/pages/projects/agentirc-dev/deployments" "pages_deployments.json"
   cf_mock "/pages/projects" "pages_projects.json"
   run bash "$SKILL_SCRIPTS/cf-pages.sh" agentirc-dev
   [ "$status" -eq 0 ]
@@ -61,7 +63,7 @@ setup() {
 }
 
 @test "cf-pages.sh PROJECT --json passes raw deployments response through" {
-  cf_mock "/deployments" "pages_deployments.json"
+  cf_mock "/pages/projects/agentirc-dev/deployments" "pages_deployments.json"
   cf_mock "/pages/projects" "pages_projects.json"
   run bash "$SKILL_SCRIPTS/cf-pages.sh" agentirc-dev --json
   [ "$status" -eq 0 ]
@@ -92,7 +94,7 @@ setup() {
 }
 
 @test "cf-pages.sh URL-encodes the project argument so '/' cannot alter the path" {
-  cf_mock "/deployments" "pages_deployments.json"
+  cf_mock "/pages/projects/agentirc-dev/deployments" "pages_deployments.json"
   cf_mock "/pages/projects" "pages_projects.json"
   run bash "$SKILL_SCRIPTS/cf-pages.sh" 'has/slash'
   # Slash must be encoded as %2F so it stays in the project segment

--- a/tests/bats/cf-pages.bats
+++ b/tests/bats/cf-pages.bats
@@ -90,3 +90,11 @@ setup() {
   [ "$status" -eq 2 ]
   [[ "$output" == *"unexpected extra argument"* ]]
 }
+
+@test "cf-pages.sh URL-encodes the project argument so '/' cannot alter the path" {
+  cf_mock "/deployments" "pages_deployments.json"
+  cf_mock "/pages/projects" "pages_projects.json"
+  run bash "$SKILL_SCRIPTS/cf-pages.sh" 'has/slash'
+  # Slash must be encoded as %2F so it stays in the project segment
+  cf_assert_called "/pages/projects/has%2Fslash/deployments"
+}

--- a/tests/bats/cf-workers-routes.bats
+++ b/tests/bats/cf-workers-routes.bats
@@ -1,0 +1,64 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+setup() {
+  cf_bats_setup
+}
+
+@test "cf-workers-routes.sh aggregates routes across all zones into a table" {
+  # Mock order matters: specific per-zone substrings FIRST so they win
+  # first-match against the broader /zones mock for the enumeration call.
+  cf_mock "/zones/zone-id-culture-dev-" "routes_culture.json"
+  cf_mock "/zones/zone-id-agentirc-dev-" "routes_agentirc.json"
+  cf_mock "/zones" "zones.json"
+  run bash "$SKILL_SCRIPTS/cf-workers-routes.sh"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"## Workers routes across 2 zone(s) (2)"* ]]
+  [[ "$output" == *"| ZONE | PATTERN | SCRIPT | ENABLED |"* ]]
+  [[ "$output" == *"| --- | --- | --- | --- |"* ]]
+  [[ "$output" == *"culture.dev"* ]]
+  [[ "$output" == *"agentirc.dev"* ]]
+  [[ "$output" == *"culture-dev-router"* ]]
+  [[ "$output" == *"agentirc-redirect"* ]]
+}
+
+@test "cf-workers-routes.sh makes 1 /zones call plus 1 call per zone" {
+  cf_mock "/zones/zone-id-culture-dev-" "routes_culture.json"
+  cf_mock "/zones/zone-id-agentirc-dev-" "routes_agentirc.json"
+  cf_mock "/zones" "zones.json"
+  run bash "$SKILL_SCRIPTS/cf-workers-routes.sh"
+  [ "$status" -eq 0 ]
+  cf_assert_called "https://mock.cloudflare.test/client/v4/zones"
+  cf_assert_called "/zones/zone-id-culture-dev-0123456789abcdef/workers/routes"
+  cf_assert_called "/zones/zone-id-agentirc-dev-fedcba9876543210/workers/routes"
+}
+
+@test "cf-workers-routes.sh --json emits a synthetic envelope with all routes" {
+  cf_mock "/zones/zone-id-culture-dev-" "routes_culture.json"
+  cf_mock "/zones/zone-id-agentirc-dev-" "routes_agentirc.json"
+  cf_mock "/zones" "zones.json"
+  run bash "$SKILL_SCRIPTS/cf-workers-routes.sh" --json
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.success == true'
+  echo "$output" | jq -e '.result | length == 2'
+  echo "$output" | jq -e '.result | map(.zone_name) | contains(["culture.dev", "agentirc.dev"])'
+  echo "$output" | jq -e '.result | map(.pattern) | contains(["culture.dev/*", "agentirc.dev/*"])'
+  [[ "$output" != *"## Workers routes"* ]]
+}
+
+@test "cf-workers-routes.sh handles zero zones without errors" {
+  # Empty /zones response — loop never iterates; synthetic envelope has result: []
+  cf_mock "/zones" "zone_lookup_empty.json"
+  run bash "$SKILL_SCRIPTS/cf-workers-routes.sh"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"## Workers routes across 0 zone(s) (0)"* ]]
+  [[ "$output" == *"| ZONE | PATTERN | SCRIPT | ENABLED |"* ]]
+}
+
+@test "cf-workers-routes.sh exits 2 on unknown argument" {
+  cf_mock "/zones" "zones.json"
+  run bash "$SKILL_SCRIPTS/cf-workers-routes.sh" --bogus
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"unknown argument"* ]]
+}

--- a/tests/bats/cf-workers.bats
+++ b/tests/bats/cf-workers.bats
@@ -1,0 +1,55 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+setup() {
+  cf_bats_setup
+}
+
+@test "cf-workers.sh renders markdown table with count and script rows" {
+  cf_mock "/workers/scripts" "workers_scripts.json"
+  run bash "$SKILL_SCRIPTS/cf-workers.sh"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"## Workers scripts (2)"* ]]
+  [[ "$output" == *"| NAME | HANDLERS | MODIFIED_ON | USAGE_MODEL |"* ]]
+  [[ "$output" == *"| --- | --- | --- | --- |"* ]]
+  [[ "$output" == *"culture-dev-router"* ]]
+  [[ "$output" == *"agentirc-redirect"* ]]
+  [[ "$output" == *"standard"* ]]
+  [[ "$output" == *"bundled"* ]]
+}
+
+@test "cf-workers.sh --json passes raw API response through" {
+  cf_mock "/workers/scripts" "workers_scripts.json"
+  run bash "$SKILL_SCRIPTS/cf-workers.sh" --json
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.success == true'
+  echo "$output" | jq -e '.result | length == 2'
+  [[ "$output" != *"## Workers scripts"* ]]
+}
+
+@test "cf-workers.sh hits the account-scoped endpoint" {
+  cf_mock "/workers/scripts" "workers_scripts.json"
+  run bash "$SKILL_SCRIPTS/cf-workers.sh"
+  [ "$status" -eq 0 ]
+  cf_assert_called "/accounts/test-account-id/workers/scripts"
+}
+
+@test "cf-workers.sh exits 1 when CLOUDFLARE_ACCOUNT_ID is unset" {
+  unset CLOUDFLARE_ACCOUNT_ID
+  run bash "$SKILL_SCRIPTS/cf-workers.sh"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"CLOUDFLARE_ACCOUNT_ID not set"* ]]
+}
+
+@test "cf-workers.sh exits 2 on unknown argument" {
+  run bash "$SKILL_SCRIPTS/cf-workers.sh" --bogus
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"unknown argument"* ]]
+}
+
+@test "cf-workers.sh propagates API error on success:false" {
+  run bash "$SKILL_SCRIPTS/cf-workers.sh"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"CloudFlare API request failed"* ]]
+}

--- a/tests/bats/cf-zones.bats
+++ b/tests/bats/cf-zones.bats
@@ -1,0 +1,50 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+setup() {
+  cf_bats_setup
+}
+
+@test "cf-zones.sh renders markdown table with heading and zone count" {
+  cf_mock "/zones" "zones.json"
+  run bash "$SKILL_SCRIPTS/cf-zones.sh"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"## Zones (2)"* ]]
+  [[ "$output" == *"| ID | NAME | STATUS | PLAN |"* ]]
+  [[ "$output" == *"| --- | --- | --- | --- |"* ]]
+  [[ "$output" == *"culture.dev"* ]]
+  [[ "$output" == *"agentirc.dev"* ]]
+  [[ "$output" == *"Free Website"* ]]
+}
+
+@test "cf-zones.sh --json passes raw API response through" {
+  cf_mock "/zones" "zones.json"
+  run bash "$SKILL_SCRIPTS/cf-zones.sh" --json
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.success == true'
+  echo "$output" | jq -e '.result | length == 2'
+  echo "$output" | jq -e '.result | map(.name) | contains(["culture.dev"])'
+  # No markdown scaffolding when --json
+  [[ "$output" != *"## Zones"* ]]
+}
+
+@test "cf-zones.sh hits the /zones endpoint" {
+  cf_mock "/zones" "zones.json"
+  run bash "$SKILL_SCRIPTS/cf-zones.sh"
+  [ "$status" -eq 0 ]
+  cf_assert_called "https://mock.cloudflare.test/client/v4/zones"
+}
+
+@test "cf-zones.sh exits 2 on unknown argument" {
+  cf_mock "/zones" "zones.json"
+  run bash "$SKILL_SCRIPTS/cf-zones.sh" --bogus
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"unknown argument"* ]]
+}
+
+@test "cf-zones.sh propagates the API error path on success:false" {
+  run bash "$SKILL_SCRIPTS/cf-zones.sh"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"CloudFlare API request failed"* ]]
+}

--- a/tests/bats/stubs/curl
+++ b/tests/bats/stubs/curl
@@ -3,9 +3,16 @@
 #
 # Logs each invocation to $BATS_TEST_TMPDIR/curl.log (tab-separated argv).
 # Reads $BATS_TEST_TMPDIR/mocks.txt for URL-substring → fixture-file mappings.
-# If the request URL matches any substring, emits the fixture on stdout.
-# Otherwise emits a synthetic CloudFlare "success:false" error response so
-# cf_api's error path can be tested too.
+#
+# Match policy: LONGEST substring wins, not first-match. This makes mock
+# registration order irrelevant — a more specific pattern (e.g.
+# "/pages/projects/agentirc-dev/deployments") always wins over a less
+# specific one (e.g. "/pages/projects") regardless of which was added
+# first. Tests with overlapping URL hierarchies stay correct without
+# relying on registration ordering.
+#
+# If no pattern matches, emits a synthetic CloudFlare "success:false"
+# error response so cf_api's error path is reachable from tests too.
 #
 # URL is assumed to be the last argv per cf_api's call convention
 # (curl -sS -H ... -H ... [EXTRA] "$CF_API_BASE$path").
@@ -25,12 +32,13 @@ url="${!#}"
 
 mocks="$BATS_TEST_TMPDIR/mocks.txt"
 fixture=""
+best_len=-1
 if [[ -f "$mocks" ]]; then
   while IFS=$'\t' read -r pattern fix; do
     [[ -z "$pattern" ]] && continue
-    if [[ "$url" == *"$pattern"* ]]; then
+    if [[ "$url" == *"$pattern"* ]] && (( ${#pattern} > best_len )); then
+      best_len=${#pattern}
       fixture="$fix"
-      break
     fi
   done < "$mocks"
 fi

--- a/tests/fixtures/dns_records.json
+++ b/tests/fixtures/dns_records.json
@@ -1,0 +1,53 @@
+{
+  "success": true,
+  "errors": [],
+  "messages": [],
+  "result": [
+    {
+      "id": "dns-rec-apex-a-0000000000000001",
+      "type": "A",
+      "name": "culture.dev",
+      "content": "192.0.2.10",
+      "proxiable": true,
+      "proxied": true,
+      "ttl": 1,
+      "created_on": "2025-11-01T12:00:00.000000Z",
+      "modified_on": "2026-01-15T10:00:00.000000Z"
+    },
+    {
+      "id": "dns-rec-www-cname-0000000000000002",
+      "type": "CNAME",
+      "name": "www.culture.dev",
+      "content": "culture.dev",
+      "proxiable": true,
+      "proxied": true,
+      "ttl": 1,
+      "created_on": "2025-11-01T12:01:00.000000Z",
+      "modified_on": "2026-01-15T10:00:00.000000Z"
+    },
+    {
+      "id": "dns-rec-mx-0000000000000003",
+      "type": "MX",
+      "name": "culture.dev",
+      "content": "mx.example.com",
+      "priority": 10,
+      "proxiable": false,
+      "proxied": false,
+      "ttl": 3600,
+      "created_on": "2025-11-01T12:02:00.000000Z",
+      "modified_on": "2025-11-01T12:02:00.000000Z"
+    },
+    {
+      "id": "dns-rec-spf-txt-0000000000000004",
+      "type": "TXT",
+      "name": "culture.dev",
+      "content": "v=spf1 include:_spf.example.com -all",
+      "proxiable": false,
+      "proxied": false,
+      "ttl": 1,
+      "created_on": "2025-11-01T12:03:00.000000Z",
+      "modified_on": "2025-11-01T12:03:00.000000Z"
+    }
+  ],
+  "result_info": {"page": 1, "per_page": 100, "total_pages": 1, "count": 4, "total_count": 4}
+}

--- a/tests/fixtures/pages_deployments.json
+++ b/tests/fixtures/pages_deployments.json
@@ -1,0 +1,44 @@
+{
+  "success": true,
+  "errors": [],
+  "messages": [],
+  "result": [
+    {
+      "id": "dep-agentirc-latest-production",
+      "short_id": "7777ffff",
+      "project_id": "proj-id-agentirc-dev",
+      "project_name": "agentirc-dev",
+      "environment": "production",
+      "url": "https://7777ffff.agentirc-dev.pages.dev",
+      "created_on": "2026-02-10T10:00:00.000000Z",
+      "modified_on": "2026-02-10T10:05:00.000000Z",
+      "latest_stage": {"name": "deploy", "status": "success"},
+      "deployment_trigger": {"type": "ad_hoc", "metadata": {"branch": "main", "commit_hash": "abc123", "commit_message": "deploy"}}
+    },
+    {
+      "id": "dep-agentirc-preview-test",
+      "short_id": "66aaccee",
+      "project_id": "proj-id-agentirc-dev",
+      "project_name": "agentirc-dev",
+      "environment": "preview",
+      "url": "https://66aaccee.agentirc-dev.pages.dev",
+      "created_on": "2026-01-15T14:30:00.000000Z",
+      "modified_on": "2026-01-15T14:35:00.000000Z",
+      "latest_stage": {"name": "deploy", "status": "success"},
+      "deployment_trigger": {"type": "ad_hoc", "metadata": {"branch": "preview-refresh", "commit_hash": "def456", "commit_message": "wip"}}
+    },
+    {
+      "id": "dep-agentirc-initial-production",
+      "short_id": "00001111",
+      "project_id": "proj-id-agentirc-dev",
+      "project_name": "agentirc-dev",
+      "environment": "production",
+      "url": "https://00001111.agentirc-dev.pages.dev",
+      "created_on": "2025-09-01T08:10:00.000000Z",
+      "modified_on": "2025-09-01T08:15:00.000000Z",
+      "latest_stage": {"name": "deploy", "status": "success"},
+      "deployment_trigger": {"type": "ad_hoc", "metadata": {"branch": "main", "commit_hash": "000aaa", "commit_message": "initial"}}
+    }
+  ],
+  "result_info": {"page": 1, "per_page": 25, "total_pages": 1, "count": 3, "total_count": 3}
+}

--- a/tests/fixtures/pages_projects.json
+++ b/tests/fixtures/pages_projects.json
@@ -1,0 +1,42 @@
+{
+  "success": true,
+  "errors": [],
+  "messages": [],
+  "result": [
+    {
+      "name": "culture-dev-site",
+      "id": "proj-id-culture-dev-site",
+      "created_on": "2025-11-01T12:00:00.000000Z",
+      "subdomain": "culture-dev-site.pages.dev",
+      "domains": ["culture.dev", "www.culture.dev"],
+      "production_branch": "main",
+      "source": {"type": "github", "config": {"owner": "agentculture", "repo_name": "culture-dev-site", "production_branch": "main"}},
+      "latest_deployment": {
+        "id": "dep-latest-culture-dev",
+        "short_id": "a1b2c3d4",
+        "environment": "production",
+        "url": "https://a1b2c3d4.culture-dev-site.pages.dev",
+        "created_on": "2026-04-20T12:00:00.000000Z",
+        "latest_stage": {"name": "deploy", "status": "success"}
+      }
+    },
+    {
+      "name": "agentirc-dev",
+      "id": "proj-id-agentirc-dev",
+      "created_on": "2025-09-01T08:00:00.000000Z",
+      "subdomain": "agentirc-dev.pages.dev",
+      "domains": ["agentirc.dev"],
+      "production_branch": "main",
+      "source": {"type": "github", "config": {"owner": "agentculture", "repo_name": "agentirc-site", "production_branch": "main"}},
+      "latest_deployment": {
+        "id": "dep-latest-agentirc",
+        "short_id": "7777ffff",
+        "environment": "production",
+        "url": "https://7777ffff.agentirc-dev.pages.dev",
+        "created_on": "2026-02-10T10:00:00.000000Z",
+        "latest_stage": {"name": "deploy", "status": "success"}
+      }
+    }
+  ],
+  "result_info": {"page": 1, "per_page": 20, "total_pages": 1, "count": 2, "total_count": 2}
+}

--- a/tests/fixtures/paginated_page1.json
+++ b/tests/fixtures/paginated_page1.json
@@ -1,0 +1,10 @@
+{
+  "success": true,
+  "errors": [],
+  "messages": [],
+  "result": [
+    {"id": "item-p1a", "name": "alpha"},
+    {"id": "item-p1b", "name": "bravo"}
+  ],
+  "result_info": {"page": 1, "per_page": 50, "total_pages": 2, "count": 2, "total_count": 3}
+}

--- a/tests/fixtures/paginated_page2.json
+++ b/tests/fixtures/paginated_page2.json
@@ -1,0 +1,9 @@
+{
+  "success": true,
+  "errors": [],
+  "messages": [],
+  "result": [
+    {"id": "item-p2a", "name": "charlie"}
+  ],
+  "result_info": {"page": 2, "per_page": 50, "total_pages": 2, "count": 1, "total_count": 3}
+}

--- a/tests/fixtures/routes_agentirc.json
+++ b/tests/fixtures/routes_agentirc.json
@@ -1,0 +1,13 @@
+{
+  "success": true,
+  "errors": [],
+  "messages": [],
+  "result": [
+    {
+      "id": "route-agentirc-dev-0000000000000001",
+      "pattern": "agentirc.dev/*",
+      "script": "agentirc-redirect"
+    }
+  ],
+  "result_info": {"page": 1, "per_page": 20, "total_pages": 1, "count": 1, "total_count": 1}
+}

--- a/tests/fixtures/routes_culture.json
+++ b/tests/fixtures/routes_culture.json
@@ -1,0 +1,13 @@
+{
+  "success": true,
+  "errors": [],
+  "messages": [],
+  "result": [
+    {
+      "id": "route-culture-dev-0000000000000001",
+      "pattern": "culture.dev/*",
+      "script": "culture-dev-router"
+    }
+  ],
+  "result_info": {"page": 1, "per_page": 20, "total_pages": 1, "count": 1, "total_count": 1}
+}

--- a/tests/fixtures/workers_scripts.json
+++ b/tests/fixtures/workers_scripts.json
@@ -1,0 +1,26 @@
+{
+  "success": true,
+  "errors": [],
+  "messages": [],
+  "result": [
+    {
+      "id": "culture-dev-router",
+      "etag": "abc123etag0000000000000000000001",
+      "handlers": ["fetch"],
+      "modified_on": "2026-03-10T14:22:00.000000Z",
+      "created_on": "2025-11-20T09:00:00.000000Z",
+      "usage_model": "standard",
+      "logpush": false
+    },
+    {
+      "id": "agentirc-redirect",
+      "etag": "abc123etag0000000000000000000002",
+      "handlers": ["fetch"],
+      "modified_on": "2026-04-01T11:00:00.000000Z",
+      "created_on": "2026-01-15T10:00:00.000000Z",
+      "usage_model": "bundled",
+      "logpush": false
+    }
+  ],
+  "result_info": {"page": 1, "per_page": 20, "total_pages": 1, "count": 2, "total_count": 2}
+}

--- a/tests/fixtures/zone_lookup.json
+++ b/tests/fixtures/zone_lookup.json
@@ -1,0 +1,15 @@
+{
+  "success": true,
+  "errors": [],
+  "messages": [],
+  "result": [
+    {
+      "id": "zone-id-culture-dev-0123456789abcdef",
+      "name": "culture.dev",
+      "status": "active",
+      "paused": false,
+      "type": "full"
+    }
+  ],
+  "result_info": {"page": 1, "per_page": 20, "total_pages": 1, "count": 1, "total_count": 1}
+}

--- a/tests/fixtures/zone_lookup_empty.json
+++ b/tests/fixtures/zone_lookup_empty.json
@@ -1,0 +1,7 @@
+{
+  "success": true,
+  "errors": [],
+  "messages": [],
+  "result": [],
+  "result_info": {"page": 1, "per_page": 20, "total_pages": 1, "count": 0, "total_count": 0}
+}

--- a/tests/fixtures/zones.json
+++ b/tests/fixtures/zones.json
@@ -1,0 +1,32 @@
+{
+  "success": true,
+  "errors": [],
+  "messages": [],
+  "result": [
+    {
+      "id": "zone-id-culture-dev-0123456789abcdef",
+      "name": "culture.dev",
+      "status": "active",
+      "paused": false,
+      "type": "full",
+      "development_mode": 0,
+      "name_servers": ["amelia.ns.cloudflare.com", "hugh.ns.cloudflare.com"],
+      "plan": {"id": "0feeeeeeeeeeeeeeeeeeeeeeeeeeeeee", "name": "Free Website"},
+      "created_on": "2025-11-01T12:00:00.000000Z",
+      "modified_on": "2026-03-15T09:00:00.000000Z"
+    },
+    {
+      "id": "zone-id-agentirc-dev-fedcba9876543210",
+      "name": "agentirc.dev",
+      "status": "active",
+      "paused": false,
+      "type": "full",
+      "development_mode": 0,
+      "name_servers": ["amelia.ns.cloudflare.com", "hugh.ns.cloudflare.com"],
+      "plan": {"id": "0feeeeeeeeeeeeeeeeeeeeeeeeeeeeee", "name": "Free Website"},
+      "created_on": "2025-09-12T14:30:00.000000Z",
+      "modified_on": "2026-04-21T10:15:00.000000Z"
+    }
+  ],
+  "result_info": {"page": 1, "per_page": 20, "total_pages": 1, "count": 2, "total_count": 2}
+}


### PR DESCRIPTION
## Summary

Second checkpoint of Phase 1: adds the remaining read-only scripts on top of the `cloudflare` skill foundation shipped in PR #3. Same shape as `cf-whoami.sh` (source `_lib.sh`, parse args, call `cf_api`, render via `cf_output` or `--json`). Each script lands in its own commit with its own bats coverage and fixtures.

**56 / 56 bats tests passing locally** (up from 24). Shellcheck clean across 9 shell files. Markdownlint clean.

## What's new

| Script | Mode | Table columns | Fixture(s) |
|---|---|---|---|
| `cf-zones.sh` | `GET /zones` | `ID / NAME / STATUS / PLAN` | `zones.json` |
| `cf-dns.sh ZONE` | Two-call: name → id via `/zones?name=`, then `/zones/<id>/dns_records` | `TYPE / NAME / CONTENT / PROXIED / TTL` | `zone_lookup.json`, `zone_lookup_empty.json`, `dns_records.json` |
| `cf-workers.sh` | `GET /accounts/<ACCOUNT_ID>/workers/scripts` | `NAME / HANDLERS / MODIFIED_ON / USAGE_MODEL` | `workers_scripts.json` |
| `cf-workers-routes.sh` | `GET /zones` + one `GET /zones/<id>/workers/routes` per zone, aggregated with `.zone_name` attached | `ZONE / PATTERN / SCRIPT / ENABLED` | `routes_culture.json`, `routes_agentirc.json` |
| `cf-pages.sh [PROJECT]` | No arg → projects; with arg → `/pages/projects/<PROJECT>/deployments` | Projects: `NAME / BRANCH / SUBDOMAIN / LATEST` · Deployments: `SHORT_ID / ENV / BRANCH / STATUS / CREATED` | `pages_projects.json`, `pages_deployments.json` |

Every script:

- Defaults to an **agent-readable markdown table** with a `## <section> (<count>)` heading.
- `--json` flag passes the raw API response through unchanged for bots and `jq` pipelines (`cf-workers-routes` emits a synthetic CF-shaped envelope since data is aggregated across calls).
- Accepts **names, not IDs** (`culture.dev`, `agentirc-dev`) — names are resolved to IDs internally.
- Inherits `_lib.sh`'s hardened `.env` parser, auth header, and curl transport error handling.
- Uses `cf_require_account_id` where the endpoint is account-scoped (`cf-workers`, `cf-pages`).
- Has `-h`/`--help` via self-documenting header-comment extraction.

## Commits (5)

1. `feat(skill): add cf-zones.sh to list zones in the account`
2. `feat(skill): add cf-dns.sh to list DNS records for a zone`
3. `feat(skill): add cf-workers.sh to list Workers scripts in the account`
4. `feat(skill): add cf-pages.sh to list Pages projects or deployments`
5. `feat(skill): add cf-workers-routes.sh — n+1 enumeration of routes`

Each commit is self-coherent and leaves the tree with all existing tests passing.

## Design choices worth surfacing

- **Routes are a separate script, not a `--routes` flag.** The cheap default (listing scripts) stays fast; the expensive n+1 enumeration is an explicit opt-in with its own script.
- **Names, not IDs.** Callers pass domain/project names; scripts do the name→id lookup when the API needs it.
- **`cf-workers-routes.sh` emits a synthetic JSON envelope under `--json`** so downstream consumers see the same `{success, errors, messages, result: [...]}` shape every other script produces.

## Intentional scope cuts

- **No CI workflow yet** — Checkpoint C.
- **No `SKILL.md` yet** for the `cloudflare` skill — Checkpoint C.
- **CLAUDE.md has a tiny staleness** now that 5 scripts exist where it documents 1 (`cf-whoami`). Refresh lands in Checkpoint C.

## Test plan

- [x] `bats tests/bats/` → 56 / 56 green
- [x] `bash tests/shellcheck.sh` → 9 shell files clean
- [x] `markdownlint-cli2 "**/*.md"` → 0 errors
- [ ] End-to-end against a live token: deferred until Phase 1 merges

## Phase 2 unlocked

With `cf-pages.sh` and `cf-workers-routes.sh` shipped, Phase 2 (`agentirc.dev` cleanup) has both the Pages inventory AND the routes inventory it needs to plan safely. After Checkpoint C merges, we write the Phase 2 plan using these scripts as the source of truth.

- Claude