### PR TITLE
Phase 1 · Checkpoint C: CI workflow + SKILL.md + docs refresh

### DIFF
--- a/.claude/skills/cloudflare/SKILL.md
+++ b/.claude/skills/cloudflare/SKILL.md
@@ -1,0 +1,146 @@
+---
+name: cloudflare
+description: >
+  Read-only visibility into CloudFlare state for the AgentCulture
+  organization: zones, DNS records, Workers scripts and routes, Pages
+  projects and deployments. Use when: checking CloudFlare state,
+  verifying DNS, inventorying Pages or Workers deployments, auditing
+  before a cleanup, or the user says "check cloudflare", "list
+  zones", "dns records", "pages deployments", "workers scripts",
+  "workers routes", "cf-whoami", "inventory agentirc", "verify the
+  cloudflare token".
+---
+
+# cloudflare
+
+Read-only skill for inspecting CloudFlare state. Every script is a
+thin wrapper around the CloudFlare REST API that renders an
+agent-readable markdown table (or key-value list for single-object
+responses) by default, and emits raw JSON with `--json` for bots and
+`jq` pipelines.
+
+No write operations yet — this is the inventory half of the skill.
+Write operations land here later in the same directory.
+
+## 1. Pre-flight
+
+Before running anything else, confirm credentials are wired:
+
+```sh
+bash .claude/skills/cloudflare/scripts/cf-whoami.sh
+```
+
+Expected output: a `**CloudFlare token**` section with the token id,
+`status: active`, `not_before`, and `expires_on`. If you see
+`CLOUDFLARE_API_TOKEN not set`, copy `.env.example` → `.env` and paste
+the token (see repo README for scope list). `cf-whoami` does NOT list
+the token's granted scopes — `/user/tokens/verify` doesn't return
+them; consult the dashboard for scopes if needed.
+
+## 2. Read recipes
+
+Question → script:
+
+| Question | Script |
+|---|---|
+| What zones does the token see? | `bash .claude/skills/cloudflare/scripts/cf-zones.sh` |
+| What DNS records exist on `<zone>`? | `bash .claude/skills/cloudflare/scripts/cf-dns.sh <zone>` |
+| What Workers scripts are deployed? | `bash .claude/skills/cloudflare/scripts/cf-workers.sh` |
+| Which Workers routes exist across all zones? | `bash .claude/skills/cloudflare/scripts/cf-workers-routes.sh` |
+| What Pages projects exist? | `bash .claude/skills/cloudflare/scripts/cf-pages.sh` |
+| What deployments does `<project>` have? | `bash .claude/skills/cloudflare/scripts/cf-pages.sh <project>` |
+
+Every script accepts `--json` to emit the raw CloudFlare response
+envelope (for Workers routes, a synthetic envelope — the script
+aggregates across per-zone calls).
+
+## 3. Targeting culture.dev
+
+The typical pattern for inspecting the primary zone:
+
+```sh
+# What's attached to culture.dev?
+bash .claude/skills/cloudflare/scripts/cf-dns.sh culture.dev
+
+# What Workers are behind culture.dev?
+bash .claude/skills/cloudflare/scripts/cf-workers-routes.sh | grep culture.dev
+
+# What Pages projects point at culture.dev?
+bash .claude/skills/cloudflare/scripts/cf-pages.sh --json | jq '.result[] | select(.domains | any(test("culture.dev")))'
+```
+
+Scripts take zone/project **names**, not IDs — names are resolved
+internally.
+
+## 4. Inventorying agentirc.dev (Phase 2 prep)
+
+`agentirc.dev` is the deprecated domain that's been folded into
+`culture.dev/agentirc`. The Pages deployment needs cleanup; this
+skill is the inventory tool before any removal.
+
+```sh
+# Confirm the Pages project still exists and find its exact name
+bash .claude/skills/cloudflare/scripts/cf-pages.sh | grep -i agentirc
+
+# Dump all deployments for that project
+bash .claude/skills/cloudflare/scripts/cf-pages.sh <project-name>
+
+# Check DNS records still attached to agentirc.dev
+bash .claude/skills/cloudflare/scripts/cf-dns.sh agentirc.dev
+
+# Check whether any Workers routes still point at agentirc.dev
+bash .claude/skills/cloudflare/scripts/cf-workers-routes.sh | grep agentirc.dev
+```
+
+Save the outputs before the Phase 2 removal plan is written — they
+become the audit trail.
+
+## 5. Output modes
+
+Default is markdown:
+
+- **List data** → table (`| COL | COL |` + `| --- | --- |`) preceded by a `## <section> (<count>)` heading.
+- **Single-object data** (only `cf-whoami` today) → key-value list (`- **key:** value`).
+
+`--json` bypasses all formatting:
+
+```sh
+# Pipe JSON into jq
+bash .claude/skills/cloudflare/scripts/cf-zones.sh --json | jq '.result[].name'
+
+# Check how many DNS records culture.dev has
+bash .claude/skills/cloudflare/scripts/cf-dns.sh culture.dev --json | jq '.result | length'
+```
+
+Pagination: handled transparently for every list endpoint via
+`cf_api_paginated` in `_lib.sh`. You get every page concatenated into
+one `.result` array; override the per-page size with
+`CF_PAGE_SIZE=25 cf-zones.sh` if needed.
+
+## 6. What this skill does NOT do (yet)
+
+- **Write operations.** No create / update / delete. Added in a
+  later phase with the same `.claude/skills/cloudflare/scripts/`
+  layout (new `cf-*-create.sh` / `cf-*-delete.sh` scripts).
+- **Scope enumeration.** `cf-whoami.sh` reports token status and
+  expiry but not granted scopes — the verify endpoint doesn't return
+  them. Check the dashboard.
+- **Account switching.** One `CLOUDFLARE_ACCOUNT_ID` per `.env`; no
+  multi-account support.
+- **Live token testing in CI.** The bats suite mocks curl via a
+  PATH stub so tests run offline. The real token is only exercised
+  manually or in a separately-configured workflow.
+
+## 7. Adding new read scripts
+
+Follow the pattern every existing script uses:
+
+1. Parse args with a `for arg in "$@"; case "$arg" in ... esac` loop. Support `--json` and `-h`/`--help`.
+2. `source "$(dirname "${BASH_SOURCE[0]}")/_lib.sh"` — this loads `.env`, verifies `CLOUDFLARE_API_TOKEN`, and exposes `cf_api`, `cf_api_paginated`, `cf_output`, `cf_output_kv`, `cf_require_account_id`.
+3. Call `cf_require_account_id` if the endpoint is account-scoped (`/accounts/:id/...`).
+4. Fetch with `cf_api_paginated` for list endpoints; `cf_api` for single-object endpoints.
+5. In `md` mode, emit a `## <section> (<count>)\n\n` heading, then hand off to `cf_output` (table) or `cf_output_kv` (single object).
+6. URL-encode any user-supplied argument before interpolation: `jq -rn --arg v "$input" '$v|@uri'`.
+7. Add a fixture under `tests/fixtures/`, a bats file under `tests/bats/`, and cover at minimum: md rendering, `--json` passthrough, correct URL target, unknown-arg exit 2, API error exit 1.
+
+Run `bash tests/shellcheck.sh` and `bats tests/bats/` before committing.

--- a/.claude/skills/cloudflare/SKILL.md
+++ b/.claude/skills/cloudflare/SKILL.md
@@ -114,8 +114,9 @@ bash .claude/skills/cloudflare/scripts/cf-dns.sh culture.dev --json | jq '.resul
 
 Pagination: handled transparently for every list endpoint via
 `cf_api_paginated` in `_lib.sh`. You get every page concatenated into
-one `.result` array; override the per-page size with
-`CF_PAGE_SIZE=25 cf-zones.sh` if needed.
+one `.result` array; override the per-page size by exporting
+`CF_PAGE_SIZE` in the environment of any script invocation, e.g.
+`CF_PAGE_SIZE=25 bash .claude/skills/cloudflare/scripts/cf-zones.sh`.
 
 ## 6. What this skill does NOT do (yet)
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,39 @@
+name: Tests
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+
+      # ubuntu-latest already has bash, curl, jq, shellcheck, and node.
+      # bats and markdownlint-cli2 need installing.
+      - name: Install bats and markdownlint-cli2
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq bats
+          npm install -g markdownlint-cli2@0.21.0
+
+      - name: Print tool versions
+        run: |
+          shellcheck --version | head -2
+          bats --version
+          jq --version
+          markdownlint-cli2 --version
+
+      - name: Shellcheck
+        run: bash tests/shellcheck.sh
+
+      - name: Markdownlint
+        run: bash tests/markdownlint.sh
+
+      - name: Bats
+        run: bats tests/bats/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,8 +14,15 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
-      # ubuntu-latest already has bash, curl, jq, shellcheck, and node.
-      # bats and markdownlint-cli2 need installing.
+      # Pin Node to a specific major so markdownlint-cli2 runs on the same
+      # runtime locally and in CI, regardless of what node version
+      # ubuntu-latest happens to ship with on any given day.
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
+        with:
+          node-version: '20'
+
+      # ubuntu-latest already has bash, curl, jq, and shellcheck.
+      # bats (apt) and markdownlint-cli2 (npm, version-pinned) need installing.
       - name: Install bats and markdownlint-cli2
         run: |
           sudo apt-get update -qq

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,21 +10,32 @@ Parent workspace context lives in `../CLAUDE.md`. The global workspace uses uv f
 
 ## Current state
 
-Phase 1 (read-only skills) is in progress. The repo contains one skill, `cloudflare`, with a verify script (`cf-whoami.sh`) and a bats test harness. Remaining Phase 1 scripts (`cf-zones`, `cf-dns`, `cf-workers`, `cf-pages`) and the CI workflow land in subsequent checkpoints. See `/home/spark/.claude/plans/ethereal-munching-porcupine.md` for the full plan (lives in the owning agent's workspace, not in this repo).
+Phase 1 (read-only skills) is complete. See `.claude/skills/cloudflare/SKILL.md` for the user-facing skill documentation (what each script does, when it runs, how to add new read scripts).
 
 Layout:
 
 ```text
 .claude/skills/cloudflare/        # one skill; read-only ops today, write ops will land here
-  SKILL.md                        # (pending — Checkpoint C)
+  SKILL.md                        # user-facing skill instructions + trigger phrases
   scripts/
-    _lib.sh                       # shared helpers: cf_api, cf_output, cf_output_kv, cf_require_account_id
+    _lib.sh                       # shared helpers: env load, cf_api, cf_api_paginated,
+                                  # cf_output, cf_output_kv, cf_require_account_id
     cf-whoami.sh                  # verify token status and expiry
-.claude/skills/pr-review/         # vendored from ~/.claude/skills (PR #4)
+    cf-zones.sh                   # list zones the token can see
+    cf-dns.sh ZONE                # list DNS records for a zone (resolves name → id)
+    cf-workers.sh                 # list Workers scripts in the account
+    cf-workers-routes.sh          # aggregate Workers routes across every zone
+    cf-pages.sh [PROJECT]         # list Pages projects (or a project's deployments)
+.claude/skills/pr-review/         # vendored from ~/.claude/skills — fetch/reply/resolve PR comments
 tests/
   bats/                           # bats-core unit tests; PATH-injected curl stub for offline mocking
   fixtures/                       # canned API responses
+  shellcheck.sh                   # shellcheck every shell script in the repo
+  markdownlint.sh                 # markdownlint-cli2 every .md file in the repo
+.github/workflows/test.yml        # CI: shellcheck + markdownlint + bats on every PR
 ```
+
+Pagination is transparent: `cf_api_paginated` in `_lib.sh` walks every page of a list endpoint so scripts see one aggregated `.result`. `shopt -s inherit_errexit` is enabled in `_lib.sh` so `exit 1` inside `cf_api` propagates through the `$(...)` layer `cf_api_paginated` adds — removing this breaks error-path tests silently.
 
 ## Hard constraints
 
@@ -43,9 +54,17 @@ Bash + `curl` + `jq`, no runtime Python deps. Matches the house style in `cultur
 
 ## Roadmap
 
-1. **Phase 1 — read-only skills** for the `culture.dev` zone. Verify auth end-to-end by listing zones first (cheapest call). Then DNS records, Workers scripts/routes, Pages projects/deployments.
-2. **Phase 2 — `agentirc.dev` Pages cleanup.** `agentirc.dev` is deprecated and folded into `culture.dev/agentirc` with a redirect. The orphaned Pages deployment needs a documented removal plan, then execution.
-3. **Later:** write ops, multi-domain support, mesh integration, expansion to R2 / Access / Zero Trust and potentially mixed CloudFlare–AWS workflows.
+1. **Phase 1 — read-only skills** ✓ Done. All six scripts (`cf-whoami`, `cf-zones`, `cf-dns`, `cf-workers`, `cf-workers-routes`, `cf-pages`) plus pagination, CI, and docs.
+2. **Phase 2 — `agentirc.dev` Pages cleanup.** `agentirc.dev` is deprecated and folded into `culture.dev/agentirc` with a redirect. Phase 1's `cf-pages.sh` and `cf-workers-routes.sh` are the inventory tools for the removal plan; Phase 2 introduces the first write operations (delete endpoints).
+3. **Later:** multi-domain support, mesh integration, expansion to R2 / Access / Zero Trust, and potentially mixed CloudFlare–AWS workflows.
+
+## Conventions for adding code
+
+- **Names, not IDs.** Scripts accept domain / project / script names and resolve to IDs internally (e.g. `cf-dns.sh culture.dev`, not a zone id). One extra API call is the price of ergonomics.
+- **URL-encode any user-supplied argument** before interpolating into a URL (`jq -rn --arg v "$input" '$v|@uri'`).
+- **Every list script uses `cf_api_paginated`.** Single-object endpoints (e.g. `/user/tokens/verify`) use `cf_api` directly.
+- **Agent-readable default, `--json` opt-in.** Markdown tables for lists, markdown key-value for single objects, raw JSON only when explicitly requested.
+- **Every new script ships with a bats file under `tests/bats/` and at least one fixture under `tests/fixtures/`.** CI runs them all on every PR.
 
 ## Active design context
 

--- a/README.md
+++ b/README.md
@@ -16,13 +16,14 @@ CloudFlare management for the [AgentCulture OSS](https://culture.dev) organizati
 
 ## Tests
 
-Pipeline tests will run in CI on every PR once `.github/workflows/test.yml` lands (Checkpoint C). Today, run them locally:
-
 ```sh
-bash tests/shellcheck.sh   # static analysis across all shell scripts
-bats tests/bats/           # unit tests (mocked curl, real jq, no live token required)
+bash tests/shellcheck.sh     # static analysis across all shell scripts
+bash tests/markdownlint.sh   # lint every markdown file against .markdownlint-cli2.yaml
+bats tests/bats/             # unit tests (mocked curl, real jq, no live token required)
 ```
 
-Required tools on the developer machine: `bash`, `curl`, `jq`, `shellcheck`, `bats`.
+All three run in CI on every PR (see `.github/workflows/test.yml`).
+
+Required tools on the developer machine: `bash`, `curl`, `jq`, `shellcheck`, `bats`, `markdownlint-cli2`.
 
 See `CLAUDE.md` for architecture, constraints, and the phase roadmap.

--- a/tests/markdownlint.sh
+++ b/tests/markdownlint.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Run markdownlint-cli2 across every markdown file in the repo.
+#
+# Uses the local .markdownlint-cli2.yaml at the repo root (mirrors the
+# workspace global — MD013 and MD060 disabled). Clones include this
+# config by default, so CI and local runs use identical rules without
+# depending on per-machine setup.
+#
+# Skips vendored dirs (.git, node_modules, .local) via the config's
+# own `ignores` list.
+
+set -euo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+if ! command -v markdownlint-cli2 >/dev/null 2>&1; then
+  echo "ERROR: markdownlint-cli2 is not installed." >&2
+  echo "Install with: npm install -g markdownlint-cli2" >&2
+  exit 127
+fi
+
+# markdownlint-cli2 accepts globs directly and honours .markdownlint-cli2.yaml
+# in the current directory (or any ancestor). Running from repo root ensures
+# it finds the checked-in config.
+exec markdownlint-cli2 "**/*.md"

--- a/tests/markdownlint.sh
+++ b/tests/markdownlint.sh
@@ -15,7 +15,7 @@ cd "$(dirname "${BASH_SOURCE[0]}")/.."
 
 if ! command -v markdownlint-cli2 >/dev/null 2>&1; then
   echo "ERROR: markdownlint-cli2 is not installed." >&2
-  echo "Install with: npm install -g markdownlint-cli2" >&2
+  echo "Install with: npm install -g markdownlint-cli2@0.21.0  # same version CI pins" >&2
   exit 127
 fi
 


### PR DESCRIPTION
## Summary

Final checkpoint of Phase 1: lands the CI workflow, the user-facing `SKILL.md` for the `cloudflare` skill, and a `CLAUDE.md` refresh that catches up to what's actually on disk after Checkpoints A and B. After this merges, Phase 1 is fully done and the `cloudflare` skill is discoverable, documented, and gated by automation.

**64 / 64 bats green locally · shellcheck clean · markdownlint clean.**

## Commits (3)

1. **`test: add markdownlint runner alongside shellcheck`** — `tests/markdownlint.sh` (counterpart to `tests/shellcheck.sh`) plus README "Tests" block update.
2. **`docs: add SKILL.md for cloudflare skill; refresh CLAUDE.md`** — the skill's user-facing entry point with trigger phrases, recipes, and the "adding new read scripts" cookbook; CLAUDE.md updated to reflect that all six scripts exist, pagination is wired, and `inherit_errexit` is load-bearing.
3. **`ci: add Tests workflow`** — `.github/workflows/test.yml` runs the three local gates on every PR + push to main. Action SHA pinned per workspace house style.

## What's in `SKILL.md`

Trigger phrases (in `description`) cover: "check cloudflare", "list zones", "dns records", "pages deployments", "workers scripts", "workers routes", "cf-whoami", "inventory agentirc", "verify the cloudflare token". Body sections: pre-flight, recipes table, culture.dev workflow, agentirc.dev Phase 2 prep, output modes (with pagination note), what-this-skill-does-NOT-do, and a 7-step recipe for adding new read scripts.

## CLAUDE.md changes worth flagging

- "Current state: pre-scaffold" → "Phase 1 complete" with full layout enumeration of all six scripts + tests + lint runners + CI.
- New paragraph documenting the **`shopt -s inherit_errexit` foot-gun** in `_lib.sh` so a future Claude doesn't remove it and silently break the error-propagation tests (PR #5 review surfaced this).
- New "Conventions for adding code" section codifying what we've actually been doing across PRs #3–#5: names-over-IDs, URL-encode user inputs, `cf_api_paginated` for lists, agent-readable defaults, every-script-needs-a-bats-file.

## CI workflow shape

Single `test` job on `ubuntu-latest`. Installs only what the runner doesn't already have (`bats` from apt, `markdownlint-cli2@0.21.0` from npm — pinned to the version we develop against locally). Runs the three local gates verbatim — no special CI logic, so a clean local run = a clean CI run.

## Intentional cuts

- **No `version-check` job** (the workspace pattern). This repo has no version field yet (no `pyproject.toml`, no plugin manifest); add the check when the skill is published.
- **No live-token end-to-end job.** The bats suite mocks `curl` via the PATH stub for hermetic offline testing; live verification is a manual one-off after Ori provisions the token.
- **No follow-up on the `_lib.sh` refactor (issue #6)** — Ori asked to stay focused; the refactor lives in its own discussion and lands later.

## Test plan

- [x] `bash tests/shellcheck.sh` → clean
- [x] `bash tests/markdownlint.sh` → clean
- [x] `bats tests/bats/` → 64 / 64
- [ ] CI workflow runs green on this PR (verifying the workflow itself for the first time)

## What unlocks once this merges

- Phase 1 is fully done; the skill is discoverable via its trigger phrases and gated by CI.
- Phase 2 plan ("agentirc.dev Pages cleanup") can be written using `cf-pages.sh` and `cf-workers-routes.sh` as the inventory source-of-truth, plus introducing the first write operations into `_lib.sh`.
- Issue #6 (`_lib.sh` refactor discussion) becomes the natural next conversation when write helpers start growing the file.

- Claude