### PR TITLE
pr-review skill: one-call SonarCloud fetch + auto-poll after PR create

### DIFF
--- a/.claude/skills/poll/SKILL.md
+++ b/.claude/skills/poll/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: poll
+description: >
+  Spawn a background subagent that polls a GitHub PR every 60 seconds
+  via pr-comments.sh and notifies you ONLY when both automated
+  reviewers (qodo and Copilot) have finished, or when the PR is
+  merged/closed. Cheaper than self-paced ScheduleWakeup because the
+  main session does NOT wake on every heartbeat. Use when: right
+  after `gh pr create`, the user says "poll", "/poll", "wait for
+  reviewers", "babysit the PR", or anything else where the point is
+  to hand off until reviewer feedback is ready. Args:
+  PR_NUMBER [OWNER/REPO].
+---
+
+# poll
+
+Spawns a background subagent that owns the wait. The main session
+returns immediately and gets a single completion notification when the
+subagent decides reviews are ready.
+
+## When to use
+
+- **Right after `gh pr create`.** The pr-review skill's *Auto-poll
+  after PR creation* section delegates here — invoke once, then
+  resume other work.
+- Whenever the user wants to wait for automated reviewer feedback
+  without burning main-session context on heartbeat polls.
+
+## Why a subagent instead of `/loop` + ScheduleWakeup
+
+`/loop` in dynamic mode wakes the main session every iteration: each
+ScheduleWakeup tick replays the conversation, calls a bash command,
+checks state, and reschedules. For a 5–15 minute wait that's a lot of
+cache-window churn for "still waiting."
+
+A background subagent owns its own context. It polls with
+`bash .claude/skills/pr-review/scripts/pr-comments.sh` (the same
+single-call fetcher the pr-review skill uses), only emits a
+notification when the wait is over, and the main session pays the
+context cost once — at the end.
+
+## Args
+
+```text
+/poll PR_NUMBER [OWNER/REPO]
+```
+
+`OWNER/REPO` defaults to the current `gh repo view --json nameWithOwner -q .nameWithOwner`.
+
+## Behavior
+
+1. Parse `PR_NUMBER` (required positional). If absent, print usage and stop.
+2. Resolve `OWNER/REPO` (second positional or `gh repo view`).
+3. Invoke the **Agent** tool with:
+    - `subagent_type: general-purpose`
+    - `run_in_background: true`
+    - `description: "Poll PR <N> for reviewer readiness"`
+    - `prompt`: the subagent prompt template below, with the PR number and repo substituted.
+4. Confirm to the user in one line: *"Background poller spawned for PR (N) at OWNER/REPO. Will notify when qodo and Copilot are both done (or the PR closes)."*
+5. **Stop.** Do not poll further from the main session, do not call ScheduleWakeup. The subagent's completion is the next event.
+
+## Subagent prompt template
+
+Copy this into the `Agent` tool's `prompt` parameter, with the PR
+number and `OWNER/REPO` substituted in:
+
+````text
+You are a background poller for GitHub PR PR_NUMBER at OWNER/REPO. Your
+only job is to wait until both automated reviewers
+(qodo-code-review and Copilot) have posted their full reviews, or
+until the PR is merged/closed. Then return a short outcome summary.
+
+Use the project's own fetch script — do NOT hand-roll gh api calls:
+
+```sh
+cd /home/spark/git/cloudflare
+bash .claude/skills/pr-review/scripts/pr-comments.sh PR_NUMBER
+```
+
+Loop up to 30 times with `sleep 60` between iterations (~30-minute
+hard cap). Each iteration:
+
+1. Check PR state:
+   `gh pr view PR_NUMBER --repo OWNER/REPO --json state -q .state`
+   If state is MERGED or CLOSED, stop and report.
+
+2. Fetch comments via pr-comments.sh and inspect the output for
+   readiness signals:
+
+   - **qodo ready** when the ISSUE COMMENTS section contains a qodo
+     comment whose body includes "Code Review by Qodo" AND does NOT
+     include "Looking for bugs?" (qodo's placeholder while analysis
+     runs). The first qodo "Walkthroughs" summary comment alone is
+     not enough.
+
+   - **Copilot ready** when the TOP-LEVEL REVIEWS section header
+     reports a count > 0 (e.g. `TOP-LEVEL REVIEWS (1)`).
+
+3. If both ready: stop and report success.
+
+4. Otherwise sleep 60 seconds and try again.
+
+Final report (≤10 lines):
+
+- PR URL: https://github.com/OWNER/REPO/pull/PR_NUMBER
+- Final state: OPEN / MERGED / CLOSED / TIMEOUT (after 30 iterations)
+- qodo: ready / placeholder-only / not-posted
+- Copilot: ready / not-posted
+- SonarCloud (from the script's section 4): N issues / quality gate passed
+- Iterations used / 30
+- Suggested next step: "Run /pr-review for PR PR_NUMBER" if both ready;
+  "PR was merged before reviewers finished" if MERGED; "Hit
+  30-iteration cap, may need to re-poll" if TIMEOUT.
+
+DO NOT do triage or fixes — that's the parent agent's job once you
+return. You only verify readiness and report.
+````
+
+## What the parent does on completion
+
+When the subagent's notification arrives, the parent should:
+
+1. Run `bash .claude/skills/pr-review/scripts/pr-comments.sh PR_NUMBER` to refetch the now-ready feedback (the subagent's report is just headlines).
+2. Invoke the `pr-review` skill to triage, fix, push, reply, and resolve.
+
+## Stopping early
+
+The user can interrupt the subagent at any time with "stop" / "cancel"
+/ "that's enough." Use `TaskList` to find the background task ID and
+`TaskStop` to terminate it.

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -20,21 +20,17 @@ Fetch, reply to, and resolve PR review comments via `gh` CLI.
 
 ## Auto-poll after PR creation
 
-When a new PR has just been created, do **not** wait for the user to say "check for comments." Invoke the `loop` skill with a self-paced polling prompt so qodo, Copilot, and SonarCloud feedback gets picked up automatically:
+When a new PR has just been created, do **not** wait for the user to say "check for comments." Hand off to the `poll` skill (project-local) with the new PR number:
 
 ```text
-Skill loop   args: |
-  Poll PR #<N> at <owner>/<repo> for review activity. Each iteration run
-  bash .claude/skills/pr-review/scripts/pr-comments.sh <N>. If there are
-  new comments since the last check, invoke this pr-review skill to
-  triage FIX vs PUSHBACK, implement fixes with bats + shellcheck +
-  markdownlint green, push, reply, and resolve threads. If the PR is
-  merged, stop polling. Cadence: first two polls ~3min (automated
-  reviewers usually land in 2–5min), then back off to 20–30min until
-  something changes.
+Skill poll   args: "PR_NUMBER"
 ```
 
-The user can interrupt the poll any time with "stop" / "cancel" / "that's enough."
+`poll` spawns a background subagent that runs `pr-comments.sh` every 60 seconds and notifies the main session ONLY when both qodo and Copilot have posted their full reviews (or the PR is merged/closed). The main session does not wake on heartbeats — it only pays context once, when the wait is over.
+
+When the subagent's notification arrives, refetch via `pr-comments.sh` and run this skill to triage, fix, push, reply, and resolve.
+
+The user can interrupt the background poller at any time with "stop" / "cancel" / "that's enough."
 
 ## Workflow
 

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -13,21 +13,45 @@ Fetch, reply to, and resolve PR review comments via `gh` CLI.
 
 ## When to Use
 
-- Before fixing PR review comments (fetch first to understand them)
-- After fixing issues flagged in a PR review (reply and resolve)
-- When the user asks to handle, respond to, or resolve PR comments
+- **Immediately after creating a PR** (e.g. after `gh pr create`): start polling the PR for automated-reviewer activity without waiting for the user to ask — see [Auto-poll after PR creation](#auto-poll-after-pr-creation) below.
+- Before fixing PR review comments (fetch first to understand them).
+- After fixing issues flagged in a PR review (reply and resolve).
+- When the user asks to handle, respond to, or resolve PR comments.
+
+## Auto-poll after PR creation
+
+When a new PR has just been created, do **not** wait for the user to say "check for comments." Invoke the `loop` skill with a self-paced polling prompt so qodo, Copilot, and SonarCloud feedback gets picked up automatically:
+
+```text
+Skill loop   args: |
+  Poll PR #<N> at <owner>/<repo> for review activity. Each iteration run
+  bash .claude/skills/pr-review/scripts/pr-comments.sh <N>. If there are
+  new comments since the last check, invoke this pr-review skill to
+  triage FIX vs PUSHBACK, implement fixes with bats + shellcheck +
+  markdownlint green, push, reply, and resolve threads. If the PR is
+  merged, stop polling. Cadence: first two polls ~3min (automated
+  reviewers usually land in 2–5min), then back off to 20–30min until
+  something changes.
+```
+
+The user can interrupt the poll any time with "stop" / "cancel" / "that's enough."
 
 ## Workflow
 
 ### 1. Fetch comments
 
-Read all PR feedback before acting. One call returns inline review comments,
-issue comments (qodo code reviews, sonarcloud quality gate, etc.), and
-top-level review bodies (copilot overviews):
+**Always use `pr-comments.sh` as the single entry point.** It fetches everything in one call: inline review comments (with thread resolve status), issue comments (qodo summaries + sonarcloud quality-gate), top-level review bodies (copilot overviews), **and** SonarCloud new issues from the public API. Do not hand-roll separate `gh api` or `curl https://sonarcloud.io/...` calls — the script already does it.
 
 ```bash
 bash .claude/skills/pr-review/scripts/pr-comments.sh PR_NUMBER
 ```
+
+Sections the script prints, in order:
+
+1. `INLINE REVIEW COMMENTS` — file/line comments with thread IDs (resolvable via `pr-reply.sh` / `pr-batch.sh`).
+2. `ISSUE COMMENTS` — general PR comments (qodo review summary + bug list, SonarCloud quality-gate bot comment).
+3. `TOP-LEVEL REVIEWS` — PR-level review bodies (Copilot's overview).
+4. `SONARCLOUD NEW ISSUES` — issues from sonarcloud.io filtered to this PR. Silently skipped if the project isn't registered on SonarCloud. Project key is derived from `<owner>_<repo>`; override with `SONAR_PROJECT_KEY=<key>` for non-standard naming.
 
 ### 2. Triage
 
@@ -61,15 +85,12 @@ bash .claude/skills/pr-review/scripts/pr-reply.sh --resolve PR_NUMBER COMMENT_ID
 
 ### pr-comments.sh
 
-Fetch and display all PR feedback in one pass, grouped into three sections:
+Fetch and display all PR feedback in one pass, grouped into four sections:
 
-1. **Inline review comments** — file/line comments on the diff, with thread
-   resolve status and thread ID (these are what `pr-reply.sh` acts on).
-2. **Issue comments** — general PR comments (qodo summary + code review,
-   sonarcloud quality gate, cloudflare pages deploy preview, etc.).
-3. **Top-level reviews** — PR-level review bodies with content (e.g. copilot
-   PR overviews). Reviews whose only content is inline comments are skipped
-   to avoid duplicating section 1.
+1. **Inline review comments** — file/line comments on the diff, with thread resolve status and thread ID (these are what `pr-reply.sh` acts on).
+2. **Issue comments** — general PR comments (qodo summary + code review, sonarcloud quality-gate, cloudflare pages deploy preview, etc.).
+3. **Top-level reviews** — PR-level review bodies with content (e.g. copilot PR overviews). Reviews whose only content is inline comments are skipped to avoid duplicating section 1.
+4. **SonarCloud new issues** — fetched from `sonarcloud.io/api/issues/search`. Silently skipped when the project isn't on SonarCloud (API returns no `issues` field). Project key defaults to the GitHub `<owner>_<repo>` convention; override via `SONAR_PROJECT_KEY` env var.
 
 ```bash
 bash .claude/skills/pr-review/scripts/pr-comments.sh [--repo OWNER/REPO] PR_NUMBER

--- a/.claude/skills/pr-review/scripts/pr-comments.sh
+++ b/.claude/skills/pr-review/scripts/pr-comments.sh
@@ -128,17 +128,39 @@ echo "$REVIEWS_WITH_BODY" | jq -r '
 # Saves one manual curl per review cycle. Silently skipped if SonarCloud
 # isn't configured for this repo (API returns an error, which we detect
 # by the absence of an .issues field in the response).
+#
+# Hardening:
+# - --get + --data-urlencode: SONAR_KEY is user-controlled (env var or
+#   GitHub repo name); URL-encoding prevents query-string injection
+#   from chars like & or ? in non-standard project keys.
+# - --connect-timeout/--max-time/--retry: a stalled SonarCloud network
+#   call must NOT block the rest of the feedback fetch. Hard cap at
+#   ~17s per attempt (5s connect + ≤15s overall + 1 retry).
+# - .paging.total: SonarCloud caps page size at 100; if a PR has more
+#   issues than that, we report the true total and warn that the
+#   listing below is truncated.
 SONAR_KEY="${SONAR_PROJECT_KEY:-${REPO/\//_}}"
-SONAR_URL="https://sonarcloud.io/api/issues/search?componentKeys=${SONAR_KEY}&pullRequest=${PR_NUMBER}&resolved=false&ps=100"
-SONAR_JSON=$(curl -sSf "$SONAR_URL" 2>/dev/null || true)
+SONAR_JSON=$(curl -sSf --get \
+    --connect-timeout 5 --max-time 15 --retry 1 --retry-delay 1 \
+    "https://sonarcloud.io/api/issues/search" \
+    --data-urlencode "componentKeys=${SONAR_KEY}" \
+    --data-urlencode "pullRequest=${PR_NUMBER}" \
+    --data-urlencode "resolved=false" \
+    --data-urlencode "ps=100" \
+    2>/dev/null || true)
 
 if [[ -n "$SONAR_JSON" ]] && echo "$SONAR_JSON" | jq -e '.issues' >/dev/null 2>&1; then
-    SONAR_COUNT=$(echo "$SONAR_JSON" | jq '.issues | length')
+    SONAR_FETCHED=$(echo "$SONAR_JSON" | jq '.issues | length')
+    SONAR_TOTAL=$(echo "$SONAR_JSON" | jq '.paging.total // (.issues | length)')
     echo ""
-    echo "════════════════ SONARCLOUD NEW ISSUES ($SONAR_COUNT) ════════════════"
-    if (( SONAR_COUNT == 0 )); then
+    echo "════════════════ SONARCLOUD NEW ISSUES ($SONAR_TOTAL) ════════════════"
+    if (( SONAR_TOTAL == 0 )); then
         echo "(quality gate passed — no new issues on this PR)"
     else
+        if (( SONAR_TOTAL > SONAR_FETCHED )); then
+            echo "(showing first $SONAR_FETCHED of $SONAR_TOTAL — see SonarCloud directly for the rest)"
+            echo ""
+        fi
         echo "$SONAR_JSON" | jq -r '.issues[] |
           "──────────────────────────────────────────────────",
           "File: \(.component | sub(".*:"; ""))  |  Line: \(.line // "?")",

--- a/.claude/skills/pr-review/scripts/pr-comments.sh
+++ b/.claude/skills/pr-review/scripts/pr-comments.sh
@@ -3,10 +3,16 @@ set -euo pipefail
 
 # Fetch and display all PR feedback in one pass:
 #   1. Inline review comments (with thread resolve status)
-#   2. Issue comments (qodo summaries, sonarcloud, etc.)
-#   3. Top-level reviews with a non-empty body (copilot overview, etc.)
+#   2. Issue comments (qodo summaries, sonarcloud quality-gate, etc.)
+#   3. Top-level reviews with a non-empty body (copilot overviews, etc.)
+#   4. SonarCloud new issues (public API; skipped if the project isn't
+#      registered or the network call fails).
 #
 # Usage: pr-comments.sh [--repo OWNER/REPO] PR_NUMBER
+#
+# SonarCloud project key is derived from the GitHub convention
+# "<org>_<repo>" (e.g. agentculture_cloudflare). Override with
+# SONAR_PROJECT_KEY=<key> for non-standard naming.
 
 REPO=""
 
@@ -117,3 +123,27 @@ echo "$REVIEWS_WITH_BODY" | jq -r '
   (.body | split("\n") | if length > 10 then .[:10] + ["... (truncated)"] else . end | join("\n")),
   ""
 '
+
+# ── Section 4: SonarCloud new issues (optional) ────────────────────────
+# Saves one manual curl per review cycle. Silently skipped if SonarCloud
+# isn't configured for this repo (API returns an error, which we detect
+# by the absence of an .issues field in the response).
+SONAR_KEY="${SONAR_PROJECT_KEY:-${REPO/\//_}}"
+SONAR_URL="https://sonarcloud.io/api/issues/search?componentKeys=${SONAR_KEY}&pullRequest=${PR_NUMBER}&resolved=false&ps=100"
+SONAR_JSON=$(curl -sSf "$SONAR_URL" 2>/dev/null || true)
+
+if [[ -n "$SONAR_JSON" ]] && echo "$SONAR_JSON" | jq -e '.issues' >/dev/null 2>&1; then
+    SONAR_COUNT=$(echo "$SONAR_JSON" | jq '.issues | length')
+    echo ""
+    echo "════════════════ SONARCLOUD NEW ISSUES ($SONAR_COUNT) ════════════════"
+    if (( SONAR_COUNT == 0 )); then
+        echo "(quality gate passed — no new issues on this PR)"
+    else
+        echo "$SONAR_JSON" | jq -r '.issues[] |
+          "──────────────────────────────────────────────────",
+          "File: \(.component | sub(".*:"; ""))  |  Line: \(.line // "?")",
+          "Severity: \(.severity // "?")  |  Type: \(.type // "?")  |  Rule: \(.rule // "?")",
+          "Message: \(.message // "?")",
+          ""'
+    fi
+fi

--- a/.gitignore
+++ b/.gitignore
@@ -165,6 +165,9 @@ dmypy.json
 # pytype static type analyzer
 .pytype/
 
+# Claude Code scheduled-task state
+.claude/scheduled_tasks.lock
+
 # Cython debug symbols
 cython_debug/
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,7 +68,17 @@ Bash + `curl` + `jq`, no runtime Python deps. Matches the house style in `cultur
 
 ## PR workflow
 
-All work goes through a feature branch + PR + automated review cycle (qodo, Copilot, SonarCloud). The vendored `pr-review` skill at `.claude/skills/pr-review/` owns the details — read its `SKILL.md` for the full workflow. Three cheat-sheet points:
+All work goes through a feature branch + PR + automated review cycle (qodo, Copilot, SonarCloud). The vendored `pr-review` skill at `.claude/skills/pr-review/` owns the details — read its `SKILL.md` for the full workflow. Four cheat-sheet points:
+
+- **Before you start: pull latest `main` and fork the branch from there.**
+
+  ```sh
+  git fetch origin
+  git switch main && git pull --ff-only
+  git switch -c feat/<short-descriptive-name>
+  ```
+
+  Do this even if you think you're up to date. PRs in this repo squash-merge, which collapses their commits into a single new commit on `main`; any branch forked before that squash still carries the original commits and will hit spurious add/add conflicts on rebase. Starting fresh from the latest `main` avoids the whole class of problem.
 
 - **After `gh pr create`, immediately invoke the `poll` skill.** It spawns a background subagent that watches the PR and notifies you only when both qodo and Copilot have finished. Cheaper than self-paced wakeups because the main session doesn't burn context on heartbeats. See `.claude/skills/poll/SKILL.md`.
 - **Fetch ALL review feedback with one call:** `bash .claude/skills/pr-review/scripts/pr-comments.sh <PR>`. It returns inline comments, issue comments, top-level reviews, and SonarCloud new issues in a single pass — don't hand-roll `gh api` / `curl sonarcloud.io` calls.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,6 +66,13 @@ Bash + `curl` + `jq`, no runtime Python deps. Matches the house style in `cultur
 - **Agent-readable default, `--json` opt-in.** Markdown tables for lists, markdown key-value for single objects, raw JSON only when explicitly requested.
 - **Every new script ships with a bats file under `tests/bats/` and at least one fixture under `tests/fixtures/`.** CI runs them all on every PR.
 
+## PR workflow
+
+All work goes through a feature branch + PR + automated review cycle (qodo, Copilot, SonarCloud). The vendored `pr-review` skill at `.claude/skills/pr-review/` owns the details — read its `SKILL.md` for the full workflow. Two cheat-sheet points:
+
+- **After `gh pr create`, immediately start polling.** Invoke the `loop` skill with a self-paced polling prompt for the new PR — don't wait for the user to ask. See `.claude/skills/pr-review/SKILL.md` § *Auto-poll after PR creation*.
+- **Fetch ALL review feedback with one call:** `bash .claude/skills/pr-review/scripts/pr-comments.sh <PR>`. It returns inline comments, issue comments, top-level reviews, and SonarCloud new issues in a single pass — don't hand-roll `gh api` / `curl sonarcloud.io` calls.
+
 ## Active design context
 
 Live design decisions (scope, auth shape, skill layout, phase-1 targets) are tracked in `/home/spark/.claude/projects/-home-spark-git-cloudflare/memory/` — read `MEMORY.md` there at the start of a session if you need the current state of the conversation's working agreements.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,10 +68,11 @@ Bash + `curl` + `jq`, no runtime Python deps. Matches the house style in `cultur
 
 ## PR workflow
 
-All work goes through a feature branch + PR + automated review cycle (qodo, Copilot, SonarCloud). The vendored `pr-review` skill at `.claude/skills/pr-review/` owns the details — read its `SKILL.md` for the full workflow. Two cheat-sheet points:
+All work goes through a feature branch + PR + automated review cycle (qodo, Copilot, SonarCloud). The vendored `pr-review` skill at `.claude/skills/pr-review/` owns the details — read its `SKILL.md` for the full workflow. Three cheat-sheet points:
 
-- **After `gh pr create`, immediately start polling.** Invoke the `loop` skill with a self-paced polling prompt for the new PR — don't wait for the user to ask. See `.claude/skills/pr-review/SKILL.md` § *Auto-poll after PR creation*.
+- **After `gh pr create`, immediately invoke the `poll` skill.** It spawns a background subagent that watches the PR and notifies you only when both qodo and Copilot have finished. Cheaper than self-paced wakeups because the main session doesn't burn context on heartbeats. See `.claude/skills/poll/SKILL.md`.
 - **Fetch ALL review feedback with one call:** `bash .claude/skills/pr-review/scripts/pr-comments.sh <PR>`. It returns inline comments, issue comments, top-level reviews, and SonarCloud new issues in a single pass — don't hand-roll `gh api` / `curl sonarcloud.io` calls.
+- **Triage / reply / resolve** via the `pr-review` skill once the poll wakes you.
 
 ## Active design context
 


### PR DESCRIPTION
## Summary

Reduces per-session manual effort on PR reviews, motivated by Ori's observation: *"Make sure the project pr-review skill has a script to get all comments, and that you use it. The skill / CLAUDE.md should guide you to use it — reduce effort for you."*

Two concrete changes and one doc-pointer:

1. **`pr-comments.sh` now fetches SonarCloud in the same call.** A fourth section `SONARCLOUD NEW ISSUES` prints alongside the existing inline / issue / top-level-review sections. Previously every review cycle required a separate `curl https://sonarcloud.io/...` on the side. Project key defaults to the GitHub `<owner>_<repo>` convention (override via `SONAR_PROJECT_KEY`). Section silently skipped when the repo isn't on SonarCloud.
2. **`SKILL.md` tells any Claude session to auto-poll after `gh pr create`.** New *Auto-poll after PR creation* section ships an embedded `loop` skill invocation template (cadence: first two polls ~3min, then 20–30min). No more "want me to poll?" exchange at the end of every PR creation.
3. **`CLAUDE.md` gains a PR-workflow pointer** so the auto-poll convention and the one-call-fetch are discoverable from the repo root without having to open the skill first.

## Commits (1)

- `feat(skill): pr-review fetches SonarCloud in one call, auto-polls after PR create`

## Test plan

- [x] `shellcheck` clean across all shell files including the extended `pr-comments.sh`.
- [x] `markdownlint-cli2` clean on SKILL.md and CLAUDE.md.
- [x] Script dogfooded against PR #7: prints `SONARCLOUD NEW ISSUES (0) — (quality gate passed)` correctly.
- [x] Header comment + script body + SKILL.md all list four sections consistently.
- [ ] End-to-end auto-poll trial on the next PR Claude opens.

## Originally stacked on PR #7

This branch was developed against `feat/phase-1-checkpoint-c-ci-docs` so the CLAUDE.md edit could build on PR #7's *Conventions for adding code* section. PR #7 merged before I opened this PR; GitHub now sees the diff cleanly against `main`.

- Claude