### PR TITLE
Split skills: add cloudflare-write with cf-redirect-create.sh (#2)

### DIFF
--- a/.claude/skills/cloudflare-write/SKILL.md
+++ b/.claude/skills/cloudflare-write/SKILL.md
@@ -71,7 +71,7 @@ Every write script in this skill follows the same shape:
 
 | Question → action | Script |
 |---|---|
-| Create a Single Redirect for a zone | `bash .claude/skills/cloudflare-write/scripts/cf-redirect-create.sh FROM_HOST TO_HOST [--www] [--status 301] [--apply] [--json]` |
+| Create a Single Redirect for a zone | `bash .claude/skills/cloudflare-write/scripts/cf-redirect-create.sh FROM_HOST TO_HOST [--www] [--status=301] [--apply] [--json]` |
 
 ### cf-redirect-create.sh
 
@@ -95,8 +95,9 @@ Flags:
 
 - `--www` — match both `FROM_HOST` and `www.FROM_HOST`. Use when the
   zone has both apex and `www.` DNS records.
-- `--status N` — HTTP status code for the redirect. Defaults to `301`
-  (permanent, SEO-safe). `302` for testing.
+- `--status=N` — HTTP status code for the redirect. Defaults to `301`
+  (permanent, SEO-safe). `--status=302` for testing. The `=` is
+  required; `--status 302` (space-separated) is **not** accepted.
 - `--apply` — actually POST. Without this, the script is a dry-run.
 - `--json` — emit the raw CloudFlare response envelope instead of
   markdown. Works in both dry-run (simulated body) and `--apply`

--- a/.claude/skills/cloudflare-write/SKILL.md
+++ b/.claude/skills/cloudflare-write/SKILL.md
@@ -1,0 +1,183 @@
+---
+name: cloudflare-write
+description: >
+  Write / edit / delete operations against CloudFlare state for the
+  AgentCulture organization — create redirects, modify rules, delete
+  resources. Use when: creating a CloudFlare redirect, adding a
+  Single Redirect rule, editing / modifying CloudFlare state,
+  deleting a Pages project / Worker / DNS record, or the user says
+  "create redirect", "add cloudflare redirect", "edit cloudflare",
+  "write cloudflare", "modify dns", "delete pages project",
+  "cf-redirect-create", "cf-redirect". For **read-only** inventory
+  (list zones / DNS / Workers / Pages, verify token), use the
+  separate `cloudflare` skill — this skill never runs GET-only
+  queries.
+---
+
+# cloudflare-write
+
+Write-side companion to the read-only `cloudflare` skill. Every script
+here mutates CloudFlare state (creates, updates, or deletes a
+resource) and defaults to **dry-run** — the live API call only fires
+with an explicit `--apply` flag.
+
+Shared library: `_lib.sh` is a symlink to the read skill's copy at
+`../../cloudflare/scripts/_lib.sh`, so env loading, `cf_api`,
+`cf_api_paginated`, `cf_output`, `cf_output_kv`, and
+`cf_require_account_id` are all available without duplicating code.
+Fixes to the shared helpers apply to both skills automatically.
+
+## 1. Pre-flight
+
+Write operations need a **different token** than the read skill uses.
+The read skill's token is scoped `Read` only; attempting a POST /
+PUT / DELETE with it will fail with `code 10000 Authentication error`.
+
+Provision a second token (see `docs/SETUP.md` §1.5 **Write-ops
+token**) with these *additional* scopes on top of the read scopes:
+
+- **Zone · Dynamic Redirect · Edit** (All zones from AgentCulture) —
+  required by `cf-redirect-create.sh`
+
+Swap the token into `.env` when you're about to run a write script,
+then swap back. One token at a time.
+
+Verify the write-capable token is active:
+
+```sh
+bash .claude/skills/cloudflare/scripts/cf-whoami.sh
+```
+
+(Reuses the read skill — the `/user/tokens/verify` endpoint works on
+any token.)
+
+## 2. Safety model
+
+Every write script in this skill follows the same shape:
+
+- **Dry-run by default.** Running without `--apply` resolves names,
+  performs read-only pre-flight checks (does the zone exist? does the
+  resource already exist?), prints the exact JSON body the script
+  would POST / PUT / DELETE, and exits 0. No mutation.
+- **`--apply` makes it real.** Only with `--apply` does the script
+  call the mutating endpoint.
+- **Idempotency is enforced locally.** Scripts query for existing
+  matching resources before creating and exit 1 with a clear error if
+  one already exists — they never silently overwrite.
+- **Names, not IDs.** Args are zone / project / resource names;
+  scripts resolve to IDs internally via `cf_api_paginated`.
+
+## 3. Scripts
+
+| Question → action | Script |
+|---|---|
+| Create a Single Redirect for a zone | `bash .claude/skills/cloudflare-write/scripts/cf-redirect-create.sh FROM_HOST TO_HOST [--www] [--status 301] [--apply] [--json]` |
+
+### cf-redirect-create.sh
+
+Creates a zone-level Single Redirect ruleset in the
+`http_request_dynamic_redirect` phase. Path and query string are
+preserved; the target URL is built as
+`concat("https://TO_HOST", http.request.uri.path)` so the redirect
+works for any sub-path.
+
+```sh
+# Dry-run (prints what would happen, does not touch the API mutating path):
+bash .claude/skills/cloudflare-write/scripts/cf-redirect-create.sh \
+  agentculture.org culture.dev --www
+
+# Apply for real:
+bash .claude/skills/cloudflare-write/scripts/cf-redirect-create.sh \
+  agentculture.org culture.dev --www --apply
+```
+
+Flags:
+
+- `--www` — match both `FROM_HOST` and `www.FROM_HOST`. Use when the
+  zone has both apex and `www.` DNS records.
+- `--status N` — HTTP status code for the redirect. Defaults to `301`
+  (permanent, SEO-safe). `302` for testing.
+- `--apply` — actually POST. Without this, the script is a dry-run.
+- `--json` — emit the raw CloudFlare response envelope instead of
+  markdown. Works in both dry-run (simulated body) and `--apply`
+  (real response) modes.
+
+Exit codes: `0` success (dry-run or apply), `1` API error / already
+exists / zone not found, `2` usage error (missing args, unknown flag).
+
+### Prerequisites for the redirect to actually fire
+
+The redirect rule only runs if traffic reaches CloudFlare's edge.
+That means `FROM_HOST` must have **proxied** DNS records (A / AAAA /
+CNAME, orange-cloud in the dashboard). Check with the read skill
+before applying:
+
+```sh
+bash .claude/skills/cloudflare/scripts/cf-dns.sh agentculture.org
+```
+
+If every record is "—" (DNS-only) or the zone has no apex record,
+the redirect won't fire. Fix DNS first — a `cf-dns-create.sh` script
+for that write path is not yet built.
+
+## 4. Output modes
+
+Default markdown (`cf_output_kv` for the result block):
+
+```text
+**Redirect created**
+- **zone:** agentculture.org
+- **from:** agentculture.org (apex + www)
+- **to:** https://culture.dev
+- **status:** 301
+- **preserve_query_string:** true
+- **ruleset_id:** <new-id>
+```
+
+Dry-run prefixes with `**Dry-run — no changes applied**` and shows
+the `would POST` JSON body.
+
+`--json` passes the CloudFlare response envelope
+(`{success, errors, messages, result}`) through unchanged — same
+shape as the read skill's `--json` output for consistency with
+downstream jq pipelines.
+
+## 5. What this skill does NOT do yet
+
+- **Updates (PUT).** No `cf-*-update.sh` scripts — resources either
+  exist (keep them) or don't (create new).
+- **Deletes (DELETE).** Phase 2 territory: `agentirc.dev` Pages /
+  Workers / DNS cleanup will land as `cf-*-delete.sh` scripts in
+  this skill.
+- **Account-wide rulesets.** This skill only creates zone-level
+  rulesets. Account-level rulesets (applied across many zones) are
+  out of scope.
+- **Bulk Redirects.** For one-host-to-one-host redirects, Single
+  Redirects are simpler and cheaper. Bulk Redirects (lists of
+  URL-to-URL mappings) will get their own script if we ever need one.
+
+## 6. Adding new write scripts
+
+Follow the pattern `cf-redirect-create.sh` sets:
+
+1. Parse args with the same `for arg in "$@"; case "$arg" in … esac`
+   loop shape used by read scripts. Support `--apply`, `--json`,
+   `-h`/`--help`, plus script-specific flags.
+2. `source "$(dirname "${BASH_SOURCE[0]}")/_lib.sh"` — symlink
+   resolves to the read skill's copy.
+3. **Resolve names to IDs first** with `cf_api_paginated` and exit 1
+   with a clear message if the name doesn't match anything.
+4. **Pre-flight idempotency check** with `cf_api` (GET) against the
+   list endpoint for the resource you're about to create / modify.
+   Exit 1 if a matching resource already exists.
+5. Build the mutating request body as JSON with `jq -n --arg … '…'`
+   (never string concatenation — injection risk).
+6. Gate the mutating call on `"$apply" == "1"`. In dry-run, print the
+   body and exit 0. In apply, `cf_api "$path" -X POST --data "$body"`
+   (or PUT / DELETE) and render the response.
+7. Add a bats file under `tests/bats/` covering dry-run, apply,
+   idempotency, name resolution, unknown flag, and the `--json`
+   passthrough. Fixtures go in `tests/fixtures/`.
+
+Run `bash tests/shellcheck.sh`, `bash tests/markdownlint.sh`, and
+`bats tests/bats/` before committing.

--- a/.claude/skills/cloudflare-write/scripts/_lib.sh
+++ b/.claude/skills/cloudflare-write/scripts/_lib.sh
@@ -1,0 +1,1 @@
+../../cloudflare/scripts/_lib.sh

--- a/.claude/skills/cloudflare-write/scripts/cf-redirect-create.sh
+++ b/.claude/skills/cloudflare-write/scripts/cf-redirect-create.sh
@@ -74,8 +74,21 @@ for h in "$from_host" "$to_host"; do
   fi
 done
 
-if ! [[ "$status" =~ ^[0-9]+$ ]] || (( status < 300 || status > 399 )); then
+if ! [[ "$status" =~ ^[0-9]+$ ]] || (( 10#$status < 300 || 10#$status > 399 )); then
   echo "ERROR: --status must be a 3xx HTTP code, got: $status" >&2
+  exit 2
+fi
+# Normalize leading zeros (e.g. "0302" → 302) so jq --argjson below
+# never sees a JSON-invalid leading-zero number.
+status=$((10#$status))
+
+# --www blindly prepends "www." to FROM_HOST, so passing
+# www.example.com with --www would produce www.www.example.com in the
+# wirefilter expression. Reject instead of silently stripping — a
+# loud error is easier to debug than a subtly-wrong redirect rule.
+if (( www )) && [[ "$from_host" == www.* ]]; then
+  echo "ERROR: --www cannot be combined with a FROM_HOST that already starts with 'www.'" >&2
+  echo "       drop the 'www.' prefix from FROM_HOST (the --www flag adds it for you)" >&2
   exit 2
 fi
 
@@ -85,8 +98,12 @@ source "$(dirname "${BASH_SOURCE[0]}")/_lib.sh"
 # Resolve FROM_HOST to a zone ID. cf_api_paginated handles every page
 # automatically; the zone list is small in practice but stay honest.
 zones_json=$(cf_api_paginated /zones)
+# Use `.[0]` inside jq rather than `jq | head -n 1`. Under pipefail,
+# head closing the pipe after one line can send SIGPIPE to jq and make
+# the whole pipeline exit non-zero even though the match succeeded.
+# shellcheck disable=SC2016  # single-quoted jq filter
 zone_id=$(printf '%s' "$zones_json" | jq -r --arg name "$from_host" \
-  '.result[] | select(.name == $name) | .id' | head -n 1)
+  '[.result[] | select(.name == $name) | .id] | .[0] // ""')
 
 if [[ -z "$zone_id" ]]; then
   echo "ERROR: zone $from_host not found in this account" >&2
@@ -97,12 +114,15 @@ fi
 # One zone can have at most one ruleset per phase, so POST would fail
 # with a CF error anyway — we want a friendlier message instead.
 rulesets_json=$(cf_api_paginated "/zones/$zone_id/rulesets")
+# shellcheck disable=SC2016  # single-quoted jq filter
 existing_redirect_id=$(printf '%s' "$rulesets_json" | jq -r '
-  .result[]
-  | select(.phase == "http_request_dynamic_redirect")
-  | select(.kind == "zone")
-  | .id
-' | head -n 1)
+  [
+    .result[]
+    | select(.phase == "http_request_dynamic_redirect")
+    | select(.kind == "zone")
+    | .id
+  ] | .[0] // ""
+')
 
 if [[ -n "$existing_redirect_id" ]]; then
   echo "ERROR: redirect ruleset already exists on zone $from_host (id=$existing_redirect_id)" >&2

--- a/.claude/skills/cloudflare-write/scripts/cf-redirect-create.sh
+++ b/.claude/skills/cloudflare-write/scripts/cf-redirect-create.sh
@@ -1,0 +1,191 @@
+#!/usr/bin/env bash
+# Create a zone-level Single Redirect in the
+# http_request_dynamic_redirect phase.
+#
+# Usage:
+#   cf-redirect-create.sh FROM_HOST TO_HOST [--www] [--status=N] [--apply] [--json]
+#
+# Default is DRY-RUN: resolves the zone, checks no redirect ruleset
+# already exists on it, prints the JSON body that would be POSTed,
+# and exits 0 WITHOUT mutating anything. Pass --apply to actually
+# create the redirect.
+#
+# Path + query string are preserved:
+#   target_url = concat("https://TO_HOST", http.request.uri.path)
+#   preserve_query_string = true
+#
+# Flags:
+#   --www        match both FROM_HOST and www.FROM_HOST
+#   --status=N   redirect status code (default 301)
+#   --apply      actually POST (without it, this is a dry-run)
+#   --json       raw CloudFlare response envelope (or simulated body in dry-run)
+#
+# Exits 1 on: zone not found, existing redirect ruleset (idempotency),
+#   or any API error. Exits 2 on usage error.
+
+set -euo pipefail
+shopt -s inherit_errexit
+
+mode=md
+apply=0
+www=0
+status=301
+positional=()
+
+for arg in "$@"; do
+  case "$arg" in
+    --json)   mode=json ;;
+    --apply)  apply=1 ;;
+    --www)    www=1 ;;
+    --status=*) status="${arg#*=}" ;;
+    -h|--help)
+      # Print the leading comment block only:
+      #   skip line 1 (shebang), strip `# ?`, stop at the first
+      #   non-comment line. No magic `head -N` constant to drift.
+      awk 'NR==1{next} /^#/{sub(/^# ?/, ""); print; next} {exit}' "$0"
+      exit 0
+      ;;
+    -*)
+      echo "ERROR: unknown flag: $arg" >&2
+      exit 2
+      ;;
+    *)
+      positional+=("$arg")
+      ;;
+  esac
+done
+
+if (( ${#positional[@]} != 2 )); then
+  echo "ERROR: expected FROM_HOST and TO_HOST positional args, got ${#positional[@]}" >&2
+  echo "usage: cf-redirect-create.sh FROM_HOST TO_HOST [--www] [--status=N] [--apply] [--json]" >&2
+  exit 2
+fi
+from_host="${positional[0]}"
+to_host="${positional[1]}"
+
+# Validate hostnames early — they interpolate into the wirefilter
+# expression and target URL, so anything containing quotes / backticks
+# / backslashes would escape the surrounding string literal.
+host_re='^[a-zA-Z0-9][a-zA-Z0-9.-]*$'
+for h in "$from_host" "$to_host"; do
+  if [[ ! "$h" =~ $host_re ]]; then
+    echo "ERROR: invalid hostname: $h" >&2
+    exit 2
+  fi
+done
+
+if ! [[ "$status" =~ ^[0-9]+$ ]] || (( status < 300 || status > 399 )); then
+  echo "ERROR: --status must be a 3xx HTTP code, got: $status" >&2
+  exit 2
+fi
+
+# shellcheck source=../../cloudflare/scripts/_lib.sh
+source "$(dirname "${BASH_SOURCE[0]}")/_lib.sh"
+
+# Resolve FROM_HOST to a zone ID. cf_api_paginated handles every page
+# automatically; the zone list is small in practice but stay honest.
+zones_json=$(cf_api_paginated /zones)
+zone_id=$(printf '%s' "$zones_json" | jq -r --arg name "$from_host" \
+  '.result[] | select(.name == $name) | .id' | head -n 1)
+
+if [[ -z "$zone_id" ]]; then
+  echo "ERROR: zone $from_host not found in this account" >&2
+  exit 1
+fi
+
+# Idempotency: bail if any redirect ruleset already exists on the zone.
+# One zone can have at most one ruleset per phase, so POST would fail
+# with a CF error anyway — we want a friendlier message instead.
+rulesets_json=$(cf_api_paginated "/zones/$zone_id/rulesets")
+existing_redirect_id=$(printf '%s' "$rulesets_json" | jq -r '
+  .result[]
+  | select(.phase == "http_request_dynamic_redirect")
+  | select(.kind == "zone")
+  | .id
+' | head -n 1)
+
+if [[ -n "$existing_redirect_id" ]]; then
+  echo "ERROR: redirect ruleset already exists on zone $from_host (id=$existing_redirect_id)" >&2
+  echo "Delete it in the CF dashboard or wait for cf-redirect-update.sh (not yet implemented)." >&2
+  exit 1
+fi
+
+# Build the wirefilter expression. If --www, match apex OR www subdomain.
+if (( www )); then
+  expression="(http.host eq \"$from_host\") or (http.host eq \"www.$from_host\")"
+  from_display="$from_host (apex + www)"
+else
+  expression="(http.host eq \"$from_host\")"
+  from_display="$from_host"
+fi
+
+target_expression="concat(\"https://$to_host\", http.request.uri.path)"
+
+# shellcheck disable=SC2016  # single-quoted jq filter
+body=$(jq -n \
+  --arg expression "$expression" \
+  --arg target     "$target_expression" \
+  --argjson status_code "$status" \
+  '{
+    kind: "zone",
+    phase: "http_request_dynamic_redirect",
+    name: "claudeflare managed redirect",
+    description: "Managed by cf-redirect-create.sh in agentculture/cloudflare",
+    rules: [{
+      expression: $expression,
+      action: "redirect",
+      action_parameters: {
+        from_value: {
+          target_url: {
+            expression: $target
+          },
+          status_code: $status_code,
+          preserve_query_string: true
+        }
+      }
+    }]
+  }')
+
+if (( apply == 0 )); then
+  # Dry-run. Emit a synthetic envelope in --json mode so downstream
+  # consumers always see the same shape; in md mode, preface the body
+  # with a clear "no changes applied" banner.
+  if [[ "$mode" == "json" ]]; then
+    # shellcheck disable=SC2016  # single-quoted jq filter
+    jq -n --argjson body "$body" --arg zone_id "$zone_id" \
+      '{success: true, errors: [], messages: ["dry-run: no changes applied"],
+        result: {dry_run: true, zone_id: $zone_id, would_post: $body}}'
+    exit 0
+  fi
+  printf '**Dry-run — no changes applied**\n\n'
+  printf -- '- **zone:** %s (id=%s)\n' "$from_host" "$zone_id"
+  printf -- '- **from:** %s\n' "$from_display"
+  printf -- '- **to:** https://%s\n' "$to_host"
+  printf -- '- **status:** %s\n' "$status"
+  printf -- '- **preserve_query_string:** true\n'
+  # shellcheck disable=SC2016  # single-quoted literal backticks wrap markdown inline code
+  printf '\n**would POST** `/zones/%s/rulesets`:\n\n' "$zone_id"
+  printf '```json\n'
+  printf '%s\n' "$body"
+  printf '```\n'
+  exit 0
+fi
+
+# Apply path: POST the ruleset. cf_api forwards trailing curl opts,
+# so we pass -X POST + --data directly. The body goes via
+# --data-binary to avoid any curl munging of \n inside the JSON.
+response=$(cf_api "/zones/$zone_id/rulesets" -X POST --data-binary "$body")
+
+if [[ "$mode" == "json" ]]; then
+  printf '%s\n' "$response"
+  exit 0
+fi
+
+new_id=$(printf '%s' "$response" | jq -r '.result.id // "—"')
+printf '**Redirect created**\n\n'
+printf -- '- **zone:** %s (id=%s)\n' "$from_host" "$zone_id"
+printf -- '- **from:** %s\n' "$from_display"
+printf -- '- **to:** https://%s\n' "$to_host"
+printf -- '- **status:** %s\n' "$status"
+printf -- '- **preserve_query_string:** true\n'
+printf -- '- **ruleset_id:** %s\n' "$new_id"

--- a/.claude/skills/cloudflare/SKILL.md
+++ b/.claude/skills/cloudflare/SKILL.md
@@ -20,8 +20,9 @@ agent-readable markdown table (or key-value list for single-object
 responses) by default, and emits raw JSON with `--json` for bots and
 `jq` pipelines.
 
-No write operations yet — this is the inventory half of the skill.
-Write operations land here later in the same directory.
+**Read-only.** For create / update / delete, use the companion
+[`cloudflare-write`](../cloudflare-write/SKILL.md) skill — it lives
+next to this one and shares `_lib.sh` via symlink.
 
 ## 1. Pre-flight
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,30 +10,39 @@ Parent workspace context lives in `../CLAUDE.md`. The global workspace uses uv f
 
 ## Current state
 
-Phase 1 (read-only skills) is complete. See `.claude/skills/cloudflare/SKILL.md` for the user-facing skill documentation (what each script does, when it runs, how to add new read scripts).
+Phase 1 (read-only skills) is complete, and the first write-ops script (Single Redirect creation) has landed in a **separate skill** so read and write stay decoupled. See each skill's `SKILL.md` for user-facing docs (what each script does, when it runs, how to add new scripts).
 
 Layout:
 
 ```text
-.claude/skills/cloudflare/        # one skill; read-only ops today, write ops will land here
-  SKILL.md                        # user-facing skill instructions + trigger phrases
+.claude/skills/cloudflare/           # read-only inventory skill
+  SKILL.md                           # user-facing skill instructions + trigger phrases
   scripts/
-    _lib.sh                       # shared helpers: env load, cf_api, cf_api_paginated,
-                                  # cf_output, cf_output_kv, cf_require_account_id
-    cf-whoami.sh                  # verify token status and expiry
-    cf-zones.sh                   # list zones the token can see
-    cf-dns.sh ZONE                # list DNS records for a zone (resolves name → id)
-    cf-workers.sh                 # list Workers scripts in the account
-    cf-workers-routes.sh          # aggregate Workers routes across every zone
-    cf-pages.sh [PROJECT]         # list Pages projects (or a project's deployments)
-.claude/skills/pr-review/         # vendored from ~/.claude/skills — fetch/reply/resolve PR comments
+    _lib.sh                          # shared helpers: env load, cf_api, cf_api_paginated,
+                                     # cf_output, cf_output_kv, cf_require_account_id
+    cf-whoami.sh                     # verify token status and expiry
+    cf-zones.sh                      # list zones the token can see
+    cf-dns.sh ZONE                   # list DNS records for a zone (resolves name → id)
+    cf-workers.sh                    # list Workers scripts in the account
+    cf-workers-routes.sh             # aggregate Workers routes across every zone
+    cf-pages.sh [PROJECT]            # list Pages projects (or a project's deployments)
+    cf-status.sh                     # single-shot digest of all of the above
+.claude/skills/cloudflare-write/     # write/edit/delete skill — NEEDS SEPARATE TOKEN
+  SKILL.md
+  scripts/
+    _lib.sh                          # symlink → ../../cloudflare/scripts/_lib.sh (DRY)
+    cf-redirect-create.sh            # create a zone Single Redirect (dry-run default, --apply to commit)
+.claude/skills/pr-review/            # vendored from ~/.claude/skills — fetch/reply/resolve PR comments
 tests/
-  bats/                           # bats-core unit tests; PATH-injected curl stub for offline mocking
-  fixtures/                       # canned API responses
-  shellcheck.sh                   # shellcheck every shell script in the repo
-  markdownlint.sh                 # markdownlint-cli2 every .md file in the repo
-.github/workflows/test.yml        # CI: shellcheck + markdownlint + bats on every PR
+  bats/                              # bats-core unit tests; PATH-injected curl stub for offline mocking
+  fixtures/                          # canned API responses
+  shellcheck.sh                      # shellcheck every shell script in the repo
+  markdownlint.sh                    # markdownlint-cli2 every .md file in the repo
+docs/SETUP.md                        # token creation walkthrough (read token in §1, write token in §1.5)
+.github/workflows/test.yml           # CI: shellcheck + markdownlint + bats on every PR
 ```
+
+**Skills split:** `cloudflare` (read) and `cloudflare-write` (write) are discrete skills with separate discovery triggers so agents can't accidentally mutate state while answering an inventory question. Both share `_lib.sh` via symlink — fixes to the helpers apply to both. Write scripts default to dry-run and require `--apply` to actually POST/PUT/DELETE.
 
 Pagination is transparent: `cf_api_paginated` in `_lib.sh` walks every page of a list endpoint so scripts see one aggregated `.result`. `shopt -s inherit_errexit` is enabled in `_lib.sh` so `exit 1` inside `cf_api` propagates through the `$(...)` layer `cf_api_paginated` adds — removing this breaks error-path tests silently.
 
@@ -54,9 +63,10 @@ Bash + `curl` + `jq`, no runtime Python deps. Matches the house style in `cultur
 
 ## Roadmap
 
-1. **Phase 1 — read-only skills** ✓ Done. All six scripts (`cf-whoami`, `cf-zones`, `cf-dns`, `cf-workers`, `cf-workers-routes`, `cf-pages`) plus pagination, CI, and docs.
-2. **Phase 2 — `agentirc.dev` Pages cleanup.** `agentirc.dev` is deprecated and folded into `culture.dev/agentirc` with a redirect. Phase 1's `cf-pages.sh` and `cf-workers-routes.sh` are the inventory tools for the removal plan; Phase 2 introduces the first write operations (delete endpoints).
-3. **Later:** multi-domain support, mesh integration, expansion to R2 / Access / Zero Trust, and potentially mixed CloudFlare–AWS workflows.
+1. **Phase 1 — read-only skills** ✓ Done. All seven scripts (`cf-whoami`, `cf-zones`, `cf-dns`, `cf-workers`, `cf-workers-routes`, `cf-pages`, `cf-status`) plus pagination, CI, and docs.
+2. **Phase 2 — write skill bootstrap + first redirect** ✓ In progress. Introduces the `cloudflare-write` skill and `cf-redirect-create.sh` (issue #2 — `agentculture.org → culture.dev`). Establishes the dry-run-by-default / `--apply`-to-commit safety pattern that all future `cf-*-create.sh` / `cf-*-update.sh` / `cf-*-delete.sh` scripts will follow.
+3. **Phase 3 — `agentirc.dev` cleanup.** `agentirc.dev` is deprecated. Uses the inventory scripts (`cf-pages`, `cf-dns`, `cf-workers-routes`) as the audit trail, then deletes via new `cf-*-delete.sh` scripts in `cloudflare-write`.
+4. **Later:** multi-domain support, mesh integration, expansion to R2 / Access / Zero Trust, and potentially mixed CloudFlare–AWS workflows.
 
 ## Conventions for adding code
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ Long version (dashboard walkthrough, scope-to-script mapping, common errors): se
 
 ## Skills
 
-- [`cloudflare`](.claude/skills/cloudflare/SKILL.md) — read-only visibility into DNS, Workers, and Pages for zones in the AgentCulture account.
+- [`cloudflare`](.claude/skills/cloudflare/SKILL.md) — **read-only** visibility into DNS, Workers, and Pages for zones in the AgentCulture account.
+- [`cloudflare-write`](.claude/skills/cloudflare-write/SKILL.md) — **create / update / delete** operations (e.g. Single Redirect rules). Dry-run by default; `--apply` is required to mutate. Needs a separate API token with Edit scopes (see [`docs/SETUP.md`](docs/SETUP.md) §1.5).
 
 ## Tests
 

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -53,6 +53,32 @@ account**. Scoping to a single zone is the most common setup mistake —
 it silently passes `cf-zones.sh` (account-level) while failing every
 per-zone call with the same `code 10000` error.
 
+### 1.5 Write-ops token (optional, for the `cloudflare-write` skill)
+
+The table above lists **Read** scopes only. Scripts in the companion
+`cloudflare-write` skill (create / update / delete operations) need
+**Edit** scopes, which are intentionally gated behind a separate
+token.
+
+Create a **second** token — keep it distinct from your read token so
+the mutating credential isn't lying around on machines that only need
+inventory access. Suggested name: `claudeflare-write`. Give it every
+scope from the Read table above (so `cf-whoami.sh` / `cf-zones.sh`
+still work) **plus** the Edit scopes below. Scope to the AgentCulture
+account and "All zones from an account" exactly like the read token.
+
+| Scope (CloudFlare dashboard label)       | Level | Access | Powers                                                             |
+|------------------------------------------|-------|--------|--------------------------------------------------------------------|
+| **Zone · Dynamic Redirect** (All zones)  | Zone  | Edit   | `cf-redirect-create.sh` — creates the zone-level Single Redirect ruleset |
+
+Swap tokens by editing `.env`'s `CLOUDFLARE_API_TOKEN` when you're
+about to run a write script, then swap back. `.env` only stores one
+token at a time; there is no per-script token selection.
+
+You do not need this token to follow the rest of this guide, develop
+read scripts, or run the test suite — the bats harness mocks `curl`
+and never touches the live API.
+
 ## 2. Find the account ID
 
 The account ID is required for account-scoped endpoints (Workers,
@@ -100,6 +126,20 @@ bash .claude/skills/cloudflare/scripts/cf-status.sh
 - `cf-status.sh` exercises every remaining scope (DNS, Workers
   Scripts, Workers Routes, Pages) in one shot — if this succeeds, the
   token is fully provisioned.
+
+If you also provisioned a write-ops token (§1.5), swap it into `.env`
+and run a dry-run against a real zone to exercise the Edit scope
+without mutating anything:
+
+```sh
+bash .claude/skills/cloudflare-write/scripts/cf-redirect-create.sh \
+  agentculture.org culture.dev --www
+```
+
+This should print a "Dry-run — no changes applied" banner followed
+by the JSON body it would POST. If it instead errors with
+`code 10000`, the token is missing the **Zone · Dynamic Redirect ·
+Edit** scope (or it's scoped to the wrong zones).
 
 ## 5. Common errors
 

--- a/tests/bats/cf-redirect-create.bats
+++ b/tests/bats/cf-redirect-create.bats
@@ -156,6 +156,34 @@ _assert_no_post() {
   [[ "$output" == *"3xx HTTP code"* ]]
 }
 
+@test "cf-redirect-create.sh accepts --status with leading zeros and normalizes to a JSON-valid int" {
+  cf_mock "/zones?per_page"     "zones_with_agentculture.json"
+  cf_mock "/rulesets?per_page"  "rulesets_empty.json"
+  run bash "$WRITE_SCRIPTS/cf-redirect-create.sh" agentculture.org culture.dev --status=0302
+  [ "$status" -eq 0 ]
+  # Body must contain the normalized integer, NOT the leading-zero form.
+  [[ "$output" == *'"status_code": 302'* ]]
+  [[ "$output" != *'"status_code": 0302'* ]]
+  [[ "$output" == *"**status:** 302"* ]]
+}
+
+@test "cf-redirect-create.sh exits 2 when --www is combined with a FROM_HOST starting with 'www.'" {
+  run bash "$WRITE_SCRIPTS/cf-redirect-create.sh" www.agentculture.org culture.dev --www
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"--www cannot be combined"* ]]
+  [[ "$output" == *"drop the 'www.' prefix"* ]]
+}
+
+@test "cf-redirect-create.sh accepts FROM_HOST starting with 'www.' WITHOUT --www" {
+  # Mocks won't match this hostname (not in zones fixture) but we're only
+  # verifying the pre-validation passes; the zone lookup will fail after
+  # that with exit 1, which is the expected downstream behaviour.
+  cf_mock "/zones?per_page"  "zones_with_agentculture.json"
+  run bash "$WRITE_SCRIPTS/cf-redirect-create.sh" www.agentculture.org culture.dev
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"zone www.agentculture.org not found"* ]]
+}
+
 # --- zone lookup uses pagination ---
 
 @test "cf-redirect-create.sh resolves FROM_HOST via paginated /zones" {

--- a/tests/bats/cf-redirect-create.bats
+++ b/tests/bats/cf-redirect-create.bats
@@ -1,0 +1,167 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+setup() {
+  cf_bats_setup
+  # Every happy-path test needs at least: zones list, rulesets list, ruleset create.
+  # GET URLs include `?per_page=...` via cf_api_paginated; POST is a bare path.
+  # Longest-substring-wins differentiates the rulesets GET vs POST mocks
+  # without teaching the stub about HTTP methods.
+  WRITE_SCRIPTS="$SKILL_DIR/../cloudflare-write/scripts"
+}
+
+# Helper — asserts curl was NEVER invoked with `-X POST`.
+_assert_no_post() {
+  if grep -qF '	-X	POST	' "$BATS_TEST_TMPDIR/curl.log" 2>/dev/null; then
+    echo "expected no POST, but curl.log contains one:" >&2
+    cat "$BATS_TEST_TMPDIR/curl.log" >&2
+    return 1
+  fi
+  return 0
+}
+
+# --- dry-run (default, no --apply) ---
+
+@test "cf-redirect-create.sh dry-run prints banner, resolved zone, and would-POST body" {
+  cf_mock "/zones?per_page"     "zones_with_agentculture.json"
+  cf_mock "/rulesets?per_page"  "rulesets_empty.json"
+  run bash "$WRITE_SCRIPTS/cf-redirect-create.sh" agentculture.org culture.dev --www
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"**Dry-run — no changes applied**"* ]]
+  [[ "$output" == *"zone-id-agentculture-org-aaaaaaaaaaaaaaaa"* ]]
+  [[ "$output" == *"agentculture.org (apex + www)"* ]]
+  [[ "$output" == *"https://culture.dev"* ]]
+  [[ "$output" == *"**would POST**"* ]]
+  [[ "$output" == *'"http_request_dynamic_redirect"'* ]]
+  [[ "$output" == *'"preserve_query_string": true'* ]]
+  _assert_no_post
+}
+
+@test "cf-redirect-create.sh dry-run without --www only matches apex" {
+  cf_mock "/zones?per_page"     "zones_with_agentculture.json"
+  cf_mock "/rulesets?per_page"  "rulesets_empty.json"
+  run bash "$WRITE_SCRIPTS/cf-redirect-create.sh" agentculture.org culture.dev
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'(http.host eq \"agentculture.org\")'* ]]
+  [[ "$output" != *"www."* ]]
+  _assert_no_post
+}
+
+@test "cf-redirect-create.sh --json dry-run emits a synthetic envelope" {
+  cf_mock "/zones?per_page"     "zones_with_agentculture.json"
+  cf_mock "/rulesets?per_page"  "rulesets_empty.json"
+  run bash "$WRITE_SCRIPTS/cf-redirect-create.sh" agentculture.org culture.dev --www --json
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.success == true'
+  echo "$output" | jq -e '.result.dry_run == true'
+  echo "$output" | jq -e '.result.zone_id == "zone-id-agentculture-org-aaaaaaaaaaaaaaaa"'
+  echo "$output" | jq -e '.result.would_post.phase == "http_request_dynamic_redirect"'
+  echo "$output" | jq -e '.result.would_post.rules[0].action_parameters.from_value.status_code == 301'
+  [[ "$output" != *"Dry-run — no changes applied"* ]]
+  _assert_no_post
+}
+
+# --- apply path ---
+
+@test "cf-redirect-create.sh --apply POSTs the ruleset and reports the new id" {
+  cf_mock "/zones?per_page"     "zones_with_agentculture.json"
+  cf_mock "/rulesets?per_page"  "rulesets_empty.json"
+  cf_mock "/rulesets"           "ruleset_create_ok.json"
+  run bash "$WRITE_SCRIPTS/cf-redirect-create.sh" agentculture.org culture.dev --www --apply
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"**Redirect created**"* ]]
+  [[ "$output" == *"new-ruleset-id-77777777"* ]]
+  cf_assert_called "-X	POST"
+  cf_assert_called "/zones/zone-id-agentculture-org-aaaaaaaaaaaaaaaa/rulesets"
+}
+
+@test "cf-redirect-create.sh --apply sends a body with apex+www expression when --www set" {
+  cf_mock "/zones?per_page"     "zones_with_agentculture.json"
+  cf_mock "/rulesets?per_page"  "rulesets_empty.json"
+  cf_mock "/rulesets"           "ruleset_create_ok.json"
+  run bash "$WRITE_SCRIPTS/cf-redirect-create.sh" agentculture.org culture.dev --www --apply
+  [ "$status" -eq 0 ]
+  # curl.log captures the full argv (tab-separated). The --data-binary
+  # argument contains the JSON body; we grep for the apex+www or-clause.
+  grep -qF 'or (http.host eq \"www.agentculture.org\")' "$BATS_TEST_TMPDIR/curl.log"
+}
+
+@test "cf-redirect-create.sh --apply --json passes the CF response envelope through" {
+  cf_mock "/zones?per_page"     "zones_with_agentculture.json"
+  cf_mock "/rulesets?per_page"  "rulesets_empty.json"
+  cf_mock "/rulesets"           "ruleset_create_ok.json"
+  run bash "$WRITE_SCRIPTS/cf-redirect-create.sh" agentculture.org culture.dev --www --apply --json
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.success == true'
+  echo "$output" | jq -e '.result.id == "new-ruleset-id-77777777"'
+  [[ "$output" != *"Redirect created"* ]]
+}
+
+@test "cf-redirect-create.sh --status=302 overrides the default" {
+  cf_mock "/zones?per_page"     "zones_with_agentculture.json"
+  cf_mock "/rulesets?per_page"  "rulesets_empty.json"
+  run bash "$WRITE_SCRIPTS/cf-redirect-create.sh" agentculture.org culture.dev --status=302
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"status_code": 302'* ]]
+  [[ "$output" == *"**status:** 302"* ]]
+}
+
+# --- idempotency & errors ---
+
+@test "cf-redirect-create.sh exits 1 when a redirect ruleset already exists on the zone" {
+  cf_mock "/zones?per_page"     "zones_with_agentculture.json"
+  cf_mock "/rulesets?per_page"  "rulesets_existing_redirect.json"
+  run bash "$WRITE_SCRIPTS/cf-redirect-create.sh" agentculture.org culture.dev --www --apply
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"redirect ruleset already exists"* ]]
+  [[ "$output" == *"existing-redirect-ruleset-id-0001"* ]]
+  _assert_no_post
+}
+
+@test "cf-redirect-create.sh exits 1 when the FROM_HOST zone is not in the account" {
+  cf_mock "/zones?per_page"     "zones_with_agentculture.json"
+  run bash "$WRITE_SCRIPTS/cf-redirect-create.sh" nosuch.dev culture.dev --apply
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"zone nosuch.dev not found"* ]]
+}
+
+@test "cf-redirect-create.sh exits 2 when positional args are missing" {
+  run bash "$WRITE_SCRIPTS/cf-redirect-create.sh"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"expected FROM_HOST and TO_HOST"* ]]
+}
+
+@test "cf-redirect-create.sh exits 2 when only one positional arg is given" {
+  run bash "$WRITE_SCRIPTS/cf-redirect-create.sh" agentculture.org
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"expected FROM_HOST and TO_HOST"* ]]
+}
+
+@test "cf-redirect-create.sh exits 2 on unknown flag" {
+  run bash "$WRITE_SCRIPTS/cf-redirect-create.sh" agentculture.org culture.dev --bogus
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"unknown flag"* ]]
+}
+
+@test "cf-redirect-create.sh exits 2 on invalid hostname" {
+  run bash "$WRITE_SCRIPTS/cf-redirect-create.sh" 'has"quote' culture.dev
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"invalid hostname"* ]]
+}
+
+@test "cf-redirect-create.sh exits 2 on out-of-range --status" {
+  run bash "$WRITE_SCRIPTS/cf-redirect-create.sh" agentculture.org culture.dev --status=200
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"3xx HTTP code"* ]]
+}
+
+# --- zone lookup uses pagination ---
+
+@test "cf-redirect-create.sh resolves FROM_HOST via paginated /zones" {
+  cf_mock "/zones?per_page"     "zones_with_agentculture.json"
+  cf_mock "/rulesets?per_page"  "rulesets_empty.json"
+  run bash "$WRITE_SCRIPTS/cf-redirect-create.sh" agentculture.org culture.dev
+  [ "$status" -eq 0 ]
+  cf_assert_called "/zones?per_page=50&page=1"
+}

--- a/tests/bats/test_helper.bash
+++ b/tests/bats/test_helper.bash
@@ -31,7 +31,9 @@ cf_mock() {
 
 cf_assert_called() {
   local pattern="$1"
-  if ! grep -qF "$pattern" "$BATS_TEST_TMPDIR/curl.log" 2>/dev/null; then
+  # `--` separator so patterns starting with `-` (e.g. `-X\tPOST`) aren't
+  # parsed as grep flags.
+  if ! grep -qF -- "$pattern" "$BATS_TEST_TMPDIR/curl.log" 2>/dev/null; then
     echo "expected curl invocation matching '$pattern', got:" >&2
     cat "$BATS_TEST_TMPDIR/curl.log" >&2 || true
     return 1

--- a/tests/fixtures/ruleset_create_ok.json
+++ b/tests/fixtures/ruleset_create_ok.json
@@ -1,0 +1,32 @@
+{
+  "success": true,
+  "errors": [],
+  "messages": [],
+  "result": {
+    "id": "new-ruleset-id-77777777",
+    "name": "claudeflare managed redirect",
+    "description": "Managed by cf-redirect-create.sh in agentculture/cloudflare",
+    "kind": "zone",
+    "phase": "http_request_dynamic_redirect",
+    "source": "firewall_custom",
+    "version": "1",
+    "last_updated": "2026-04-21T23:00:00.000000Z",
+    "rules": [
+      {
+        "id": "new-rule-id-99999999",
+        "version": "1",
+        "action": "redirect",
+        "expression": "(http.host eq \"agentculture.org\") or (http.host eq \"www.agentculture.org\")",
+        "enabled": true,
+        "ref": "new-ref",
+        "action_parameters": {
+          "from_value": {
+            "target_url": {"expression": "concat(\"https://culture.dev\", http.request.uri.path)"},
+            "status_code": 301,
+            "preserve_query_string": true
+          }
+        }
+      }
+    ]
+  }
+}

--- a/tests/fixtures/rulesets_empty.json
+++ b/tests/fixtures/rulesets_empty.json
@@ -1,0 +1,7 @@
+{
+  "success": true,
+  "errors": [],
+  "messages": [],
+  "result": [],
+  "result_info": {"page": 1, "per_page": 20, "total_pages": 1, "count": 0, "total_count": 0}
+}

--- a/tests/fixtures/rulesets_existing_redirect.json
+++ b/tests/fixtures/rulesets_existing_redirect.json
@@ -1,0 +1,35 @@
+{
+  "success": true,
+  "errors": [],
+  "messages": [],
+  "result": [
+    {
+      "id": "existing-redirect-ruleset-id-0001",
+      "name": "default",
+      "description": "",
+      "kind": "zone",
+      "phase": "http_request_dynamic_redirect",
+      "source": "firewall_custom",
+      "version": "1",
+      "last_updated": "2026-04-01T00:00:00.000000Z",
+      "rules": [
+        {
+          "id": "existing-rule-id-0001",
+          "version": "1",
+          "action": "redirect",
+          "expression": "(http.host eq \"agentculture.org\")",
+          "enabled": true,
+          "ref": "existing-ref",
+          "action_parameters": {
+            "from_value": {
+              "target_url": {"expression": "concat(\"https://culture.dev\", http.request.uri.path)"},
+              "status_code": 301,
+              "preserve_query_string": true
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "result_info": {"page": 1, "per_page": 20, "total_pages": 1, "count": 1, "total_count": 1}
+}

--- a/tests/fixtures/zones_with_agentculture.json
+++ b/tests/fixtures/zones_with_agentculture.json
@@ -1,0 +1,32 @@
+{
+  "success": true,
+  "errors": [],
+  "messages": [],
+  "result": [
+    {
+      "id": "zone-id-agentculture-org-aaaaaaaaaaaaaaaa",
+      "name": "agentculture.org",
+      "status": "active",
+      "paused": false,
+      "type": "full",
+      "development_mode": 0,
+      "name_servers": ["amelia.ns.cloudflare.com", "hugh.ns.cloudflare.com"],
+      "plan": {"id": "0feeeeeeeeeeeeeeeeeeeeeeeeeeeeee", "name": "Free Website"},
+      "created_on": "2025-08-01T12:00:00.000000Z",
+      "modified_on": "2026-03-15T09:00:00.000000Z"
+    },
+    {
+      "id": "zone-id-culture-dev-bbbbbbbbbbbbbbbbbbbb",
+      "name": "culture.dev",
+      "status": "active",
+      "paused": false,
+      "type": "full",
+      "development_mode": 0,
+      "name_servers": ["amelia.ns.cloudflare.com", "hugh.ns.cloudflare.com"],
+      "plan": {"id": "0feeeeeeeeeeeeeeeeeeeeeeeeeeeeee", "name": "Free Website"},
+      "created_on": "2025-11-01T12:00:00.000000Z",
+      "modified_on": "2026-03-15T09:00:00.000000Z"
+    }
+  ],
+  "result_info": {"page": 1, "per_page": 20, "total_pages": 1, "count": 2, "total_count": 2}
+}


### PR DESCRIPTION
## Summary

Resolves #2 — creates the `agentculture.org → culture.dev` redirect (once someone runs the script with `--apply` and a write-capable token).

Two things at once, because #2 was the natural trigger:

1. **Skills split.** Introduces `.claude/skills/cloudflare-write/` as a separate skill from the existing `cloudflare` read-only skill. Separate discovery triggers mean agents can't accidentally mutate state while answering an inventory question. Both skills share `_lib.sh` via git symlink (`mode 120000`), so helper fixes apply to both without duplication.
2. **First write script: `cf-redirect-create.sh`.** Creates a zone-level Single Redirect in the `http_request_dynamic_redirect` phase (CloudFlare's modern replacement for Page Rules). Preserves path + query string; default status 301.

### Safety model (sets the pattern for all future write scripts)

- **Dry-run by default.** Running without `--apply` resolves the zone, runs the idempotency check, and prints the exact JSON body that would be POSTed — without calling the mutating endpoint.
- **`--apply` to commit.** Only then does the script POST.
- **Idempotency guard.** Fails loudly (exit 1) if a redirect ruleset already exists on the zone. CloudFlare only allows one ruleset per phase per zone, so this matches what the API would enforce anyway, with a friendlier message.
- **Hostname + status validation** before building the request body (defence in depth against expression injection).
- **Names, not IDs.** `cf-redirect-create.sh agentculture.org culture.dev --www` — the script resolves names via the existing `cf_api_paginated /zones` helper.

### Requires a second API token

The existing read token can't run this script. `docs/SETUP.md` grows a §1.5 **Write-ops token** section explaining how to provision one with the **Zone · Dynamic Redirect · Edit** scope added on top of the existing read scopes. `.env` only holds one token at a time — swap before running, swap back after.

### Live smoke test (partial)

```text
$ bash .claude/skills/cloudflare-write/scripts/cf-redirect-create.sh \
    agentculture.org culture.dev --www
ERROR: CloudFlare API request failed: /zones/02969f1ac3da7107eb54a0b12a992cbc/rulesets?per_page=50&page=1
  code 10000 Authentication error
```

Zone resolution works (correct zone ID). The `code 10000` is the expected "current token lacks Dynamic Redirect scope" — exactly the scenario §1.5 tells the user to fix. Full correctness is covered by the offline bats suite.

## Test plan

- [x] `bats tests/bats/` — 87/87 (was 72; +15 new cases in `cf-redirect-create.bats`)
- [x] `bash tests/shellcheck.sh` — clean across 16 scripts (the new one + existing; `_lib.sh` symlink correctly skipped by `-type f`)
- [x] `bash tests/markdownlint.sh` — clean across 7 markdown files
- [x] Help output: `cf-redirect-create.sh --help` stops cleanly at the end of the docstring (uses awk, not `sed | head -N`)
- [x] Live zone resolution works against the AgentCulture account
- [ ] Qodo + Copilot review
- [ ] SonarCloud quality gate
- [ ] Swap in write-capable token, dry-run, then `--apply`, then `curl -I https://agentculture.org` to confirm the 301 (post-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)