### PR TITLE
Add cf-dns-create.sh — DNS record write script for the cloudflare-write skill

### DIFF
--- a/.claude/skills/cloudflare-write/SKILL.md
+++ b/.claude/skills/cloudflare-write/SKILL.md
@@ -38,6 +38,8 @@ token**) with these *additional* scopes on top of the read scopes:
 
 - **Zone · Dynamic Redirect · Edit** (All zones from AgentCulture) —
   required by `cf-redirect-create.sh`
+- **Zone · DNS · Edit** (All zones from AgentCulture) —
+  required by `cf-dns-create.sh`
 
 Swap the token into `.env` when you're about to run a write script,
 then swap back. One token at a time.
@@ -72,6 +74,7 @@ Every write script in this skill follows the same shape:
 | Question → action | Script |
 |---|---|
 | Create a Single Redirect for a zone | `bash .claude/skills/cloudflare-write/scripts/cf-redirect-create.sh FROM_HOST TO_HOST [--www] [--status=301] [--apply] [--json]` |
+| Create a DNS record in a zone | `bash .claude/skills/cloudflare-write/scripts/cf-dns-create.sh ZONE TYPE NAME CONTENT [--proxied] [--ttl=N] [--comment=STR] [--apply] [--json]` |
 
 ### cf-redirect-create.sh
 
@@ -118,8 +121,47 @@ bash .claude/skills/cloudflare/scripts/cf-dns.sh agentculture.org
 ```
 
 If every record is "—" (DNS-only) or the zone has no apex record,
-the redirect won't fire. Fix DNS first — a `cf-dns-create.sh` script
-for that write path is not yet built.
+the redirect won't fire. Use `cf-dns-create.sh` (below) to add the
+apex and `www` records first, then create the redirect.
+
+### cf-dns-create.sh
+
+Creates a DNS record in a zone. Same safety model as
+`cf-redirect-create.sh`: dry-run by default, `--apply` to commit,
+idempotency enforced before the POST.
+
+```sh
+# Canonical setup for a redirect-only zone — apex + www, both proxied.
+# 192.0.2.1 is TEST-NET-1; CF intercepts at the edge before forwarding,
+# so the origin IP is irrelevant for a pure-redirect zone.
+bash .claude/skills/cloudflare-write/scripts/cf-dns-create.sh \
+  agentculture.org A agentculture.org 192.0.2.1 --proxied --apply
+bash .claude/skills/cloudflare-write/scripts/cf-dns-create.sh \
+  agentculture.org A www.agentculture.org 192.0.2.1 --proxied --apply
+```
+
+Flags:
+
+- `--proxied` — orange-cloud the record so CF intercepts HTTP
+  traffic. Required for Single Redirects to fire on the record's
+  hostname.
+- `--ttl=N` — TTL in seconds. Default `1` (automatic). Manual TTLs
+  must be in `60..86400`. Proxied records are forced to `1` by CF;
+  combining `--proxied` with `--ttl=N` (N≠1) is rejected up-front.
+- `--comment=STR` — free-text note attached to the record (visible
+  in the CF dashboard).
+- `--apply` — actually POST. Without this, the script is a dry-run.
+- `--json` — raw CloudFlare response envelope, same shape as the
+  read skill's `--json` output.
+
+Supported record types: A, AAAA, CNAME, TXT, MX, NS, SRV, CAA.
+Extend the case statement in the script if you need PTR / URI /
+TLSA / etc.
+
+Idempotency key: **type + name + content**. Two A records at the
+same name with different IPs are allowed (CF supports round-robin);
+two records with identical type+name+content are refused as
+duplicates.
 
 ## 4. Output modes
 

--- a/.claude/skills/cloudflare-write/SKILL.md
+++ b/.claude/skills/cloudflare-write/SKILL.md
@@ -36,8 +36,11 @@ PUT / DELETE with it will fail with `code 10000 Authentication error`.
 Provision a second token (see `docs/SETUP.md` §1.5 **Write-ops
 token**) with these *additional* scopes on top of the read scopes:
 
-- **Zone · Dynamic Redirect · Edit** (All zones from AgentCulture) —
-  required by `cf-redirect-create.sh`
+- **Zone · Single Redirect · Edit** (All zones from AgentCulture) —
+  required by `cf-redirect-create.sh`. (The CloudFlare Rulesets API
+  still uses `http_request_dynamic_redirect` as the phase
+  identifier, but the dashboard's token-scope label is "Single
+  Redirect".)
 - **Zone · DNS · Edit** (All zones from AgentCulture) —
   required by `cf-dns-create.sh`
 

--- a/.claude/skills/cloudflare-write/scripts/cf-dns-create.sh
+++ b/.claude/skills/cloudflare-write/scripts/cf-dns-create.sh
@@ -1,0 +1,195 @@
+#!/usr/bin/env bash
+# Create a DNS record in a CloudFlare zone.
+#
+# Usage:
+#   cf-dns-create.sh ZONE TYPE NAME CONTENT [--proxied] [--ttl=N] [--comment=STR] [--apply] [--json]
+#
+# Default is DRY-RUN: resolves the zone, checks no matching
+# type+name+content record already exists, prints the JSON body
+# it would POST, and exits 0 WITHOUT mutating anything. Pass
+# --apply to actually create the record.
+#
+# Common use cases:
+#   # Proxied A record at the apex (canonical "redirect-only" zone trick —
+#   # 192.0.2.1 is TEST-NET-1, which CF intercepts at the edge before
+#   # forwarding, so the origin IP is irrelevant):
+#   cf-dns-create.sh agentculture.org A agentculture.org 192.0.2.1 --proxied --apply
+#
+#   # Proxied www subdomain pointing at the same edge:
+#   cf-dns-create.sh agentculture.org A www.agentculture.org 192.0.2.1 --proxied --apply
+#
+# Flags:
+#   --proxied       orange-cloud the record (CF intercepts HTTP traffic)
+#   --ttl=N         TTL in seconds (default 1 = "automatic"; proxied records are forced to 1 by CF)
+#   --comment=STR   free-text note attached to the record (shows in dashboard)
+#   --apply         actually POST (without it, this is a dry-run)
+#   --json          raw CloudFlare response envelope (or simulated body in dry-run)
+#
+# Idempotency key is type+name+content. Exits 1 if a record with the
+# same three fields already exists on the zone. Records with the same
+# type+name but different content (e.g. round-robin A records) are
+# allowed — CF itself supports that shape.
+#
+# Exits 1 on: zone not found, matching record already exists, API
+# error. Exits 2 on usage error.
+
+set -euo pipefail
+shopt -s inherit_errexit
+
+mode=md
+apply=0
+proxied=0
+ttl=1
+comment="Managed by cf-dns-create.sh in agentculture/cloudflare"
+positional=()
+
+for arg in "$@"; do
+  case "$arg" in
+    --json)      mode=json ;;
+    --apply)     apply=1 ;;
+    --proxied)   proxied=1 ;;
+    --ttl=*)     ttl="${arg#*=}" ;;
+    --comment=*) comment="${arg#*=}" ;;
+    -h|--help)
+      # Skip line 1 (shebang), strip `# ?`, stop at the first non-comment line.
+      awk 'NR==1{next} /^#/{sub(/^# ?/, ""); print; next} {exit}' "$0"
+      exit 0
+      ;;
+    -*)
+      echo "ERROR: unknown flag: $arg" >&2
+      exit 2
+      ;;
+    *)
+      positional+=("$arg")
+      ;;
+  esac
+done
+
+if (( ${#positional[@]} != 4 )); then
+  echo "ERROR: expected 4 positional args (ZONE TYPE NAME CONTENT), got ${#positional[@]}" >&2
+  echo "usage: cf-dns-create.sh ZONE TYPE NAME CONTENT [--proxied] [--ttl=N] [--comment=STR] [--apply] [--json]" >&2
+  exit 2
+fi
+zone_name="${positional[0]}"
+record_type="${positional[1]}"
+record_name="${positional[2]}"
+record_content="${positional[3]}"
+
+# Validate record type against CF's supported set. Not exhaustive —
+# this is the subset that covers the redirect/web/mail use cases we
+# actually hit. If you need SRV, CAA, PTR, etc., extend here.
+case "$record_type" in
+  A|AAAA|CNAME|TXT|MX|NS|SRV|CAA) ;;
+  *)
+    echo "ERROR: unsupported record type: $record_type (allowed: A AAAA CNAME TXT MX NS SRV CAA)" >&2
+    exit 2
+    ;;
+esac
+
+# Validate TTL: CF accepts 1 ("automatic") or 60-86400 for manual TTLs.
+if ! [[ "$ttl" =~ ^[0-9]+$ ]]; then
+  echo "ERROR: --ttl must be an integer, got: $ttl" >&2
+  exit 2
+fi
+ttl=$((10#$ttl))
+if (( ttl != 1 && (ttl < 60 || ttl > 86400) )); then
+  echo "ERROR: --ttl must be 1 (automatic) or between 60 and 86400, got: $ttl" >&2
+  exit 2
+fi
+
+# Proxied records must use TTL=1 per CF. Fail loudly instead of
+# silently overriding the user's choice.
+if (( proxied && ttl != 1 )); then
+  echo "ERROR: --proxied records must use --ttl=1 (CloudFlare ignores manual TTL on proxied records)" >&2
+  exit 2
+fi
+
+# shellcheck source=../../cloudflare/scripts/_lib.sh
+source "$(dirname "${BASH_SOURCE[0]}")/_lib.sh"
+
+# Resolve ZONE to a zone ID.
+zones_json=$(cf_api_paginated /zones)
+# shellcheck disable=SC2016  # single-quoted jq filter
+zone_id=$(printf '%s' "$zones_json" | jq -r --arg name "$zone_name" \
+  '[.result[] | select(.name == $name) | .id] | .[0] // ""')
+
+if [[ -z "$zone_id" ]]; then
+  echo "ERROR: zone $zone_name not found in this account" >&2
+  exit 1
+fi
+
+# Idempotency: bail if a record with the same type+name+content
+# already exists on the zone. CF accepts a `match=all` query string
+# that narrows server-side; we use it to keep the response small even
+# on zones with hundreds of records.
+name_encoded=$(jq -rn --arg v "$record_name"    '$v|@uri')
+content_encoded=$(jq -rn --arg v "$record_content" '$v|@uri')
+existing_json=$(cf_api_paginated \
+  "/zones/$zone_id/dns_records?type=$record_type&name=$name_encoded&content=$content_encoded&match=all")
+
+# shellcheck disable=SC2016  # single-quoted jq filter
+existing_id=$(printf '%s' "$existing_json" | jq -r '[.result[].id] | .[0] // ""')
+
+if [[ -n "$existing_id" ]]; then
+  echo "ERROR: DNS record already exists on $zone_name: $record_type $record_name $record_content (id=$existing_id)" >&2
+  echo "       nothing to do. Use cf-dns-update.sh (not yet implemented) to change content." >&2
+  exit 1
+fi
+
+# Build the request body.
+# shellcheck disable=SC2016  # single-quoted jq filter
+body=$(jq -n \
+  --arg type    "$record_type" \
+  --arg name    "$record_name" \
+  --arg content "$record_content" \
+  --argjson ttl "$ttl" \
+  --argjson proxied "$([[ $proxied -eq 1 ]] && echo true || echo false)" \
+  --arg comment "$comment" \
+  '{
+    type: $type,
+    name: $name,
+    content: $content,
+    ttl: $ttl,
+    proxied: $proxied,
+    comment: $comment
+  }')
+
+render_summary_kv() {
+  printf -- '- **zone:** %s (id=%s)\n' "$zone_name" "$zone_id"
+  printf -- '- **type:** %s\n' "$record_type"
+  printf -- '- **name:** %s\n' "$record_name"
+  printf -- '- **content:** %s\n' "$record_content"
+  printf -- '- **ttl:** %s%s\n' "$ttl" "$([[ $ttl -eq 1 ]] && echo ' (automatic)')"
+  printf -- '- **proxied:** %s\n' "$([[ $proxied -eq 1 ]] && echo true || echo false)"
+}
+
+if (( apply == 0 )); then
+  if [[ "$mode" == "json" ]]; then
+    # shellcheck disable=SC2016  # single-quoted jq filter
+    jq -n --argjson body "$body" --arg zone_id "$zone_id" \
+      '{success: true, errors: [], messages: ["dry-run: no changes applied"],
+        result: {dry_run: true, zone_id: $zone_id, would_post: $body}}'
+    exit 0
+  fi
+  printf '**Dry-run — no changes applied**\n\n'
+  render_summary_kv
+  # shellcheck disable=SC2016  # single-quoted literal backticks wrap markdown inline code
+  printf '\n**would POST** `/zones/%s/dns_records`:\n\n' "$zone_id"
+  printf '```json\n'
+  printf '%s\n' "$body"
+  printf '```\n'
+  exit 0
+fi
+
+# Apply path.
+response=$(cf_api "/zones/$zone_id/dns_records" -X POST --data-binary "$body")
+
+if [[ "$mode" == "json" ]]; then
+  printf '%s\n' "$response"
+  exit 0
+fi
+
+new_id=$(printf '%s' "$response" | jq -r '.result.id // "—"')
+printf '**DNS record created**\n\n'
+render_summary_kv
+printf -- '- **record_id:** %s\n' "$new_id"

--- a/.claude/skills/cloudflare-write/scripts/cf-dns-create.sh
+++ b/.claude/skills/cloudflare-write/scripts/cf-dns-create.sh
@@ -24,6 +24,9 @@
 #   --comment=STR   free-text note attached to the record (shows in dashboard)
 #   --apply         actually POST (without it, this is a dry-run)
 #   --json          raw CloudFlare response envelope (or simulated body in dry-run)
+#   --              end-of-options marker. Use when NAME or CONTENT legitimately
+#                   starts with a dash (e.g. some TXT values). Anything after `--`
+#                   is positional, regardless of leading characters.
 #
 # Idempotency key is type+name+content. Exits 1 if a record with the
 # same three fields already exists on the zone. Records with the same
@@ -42,9 +45,19 @@ proxied=0
 ttl=1
 comment="Managed by cf-dns-create.sh in agentculture/cloudflare"
 positional=()
+# `--` end-of-options marker: any arg after it is treated as
+# positional, even if it begins with `-`. Needed for TXT record
+# values (and occasionally content) that legitimately start with a
+# dash — without this, the `-*` case arm would reject them.
+after_ddash=0
 
 for arg in "$@"; do
+  if (( after_ddash )); then
+    positional+=("$arg")
+    continue
+  fi
   case "$arg" in
+    --)          after_ddash=1 ;;
     --json)      mode=json ;;
     --apply)     apply=1 ;;
     --proxied)   proxied=1 ;;
@@ -76,8 +89,8 @@ record_name="${positional[2]}"
 record_content="${positional[3]}"
 
 # Validate record type against CF's supported set. Not exhaustive —
-# this is the subset that covers the redirect/web/mail use cases we
-# actually hit. If you need SRV, CAA, PTR, etc., extend here.
+# this is the subset that covers the redirect/web/mail/auth use cases
+# we actually hit. If you need PTR, URI, TLSA, etc., extend here.
 case "$record_type" in
   A|AAAA|CNAME|TXT|MX|NS|SRV|CAA) ;;
   *)
@@ -121,11 +134,15 @@ fi
 # Idempotency: bail if a record with the same type+name+content
 # already exists on the zone. CF accepts a `match=all` query string
 # that narrows server-side; we use it to keep the response small even
-# on zones with hundreds of records.
-name_encoded=$(jq -rn --arg v "$record_name"    '$v|@uri')
+# on zones with hundreds of records. Every user-supplied value that
+# ends up in the query string is URL-encoded — even `record_type`,
+# which is already allowlist-validated, so we stay consistent with
+# the repo-wide "encode everything from outside" convention.
+type_encoded=$(jq -rn --arg v "$record_type"       '$v|@uri')
+name_encoded=$(jq -rn --arg v "$record_name"       '$v|@uri')
 content_encoded=$(jq -rn --arg v "$record_content" '$v|@uri')
 existing_json=$(cf_api_paginated \
-  "/zones/$zone_id/dns_records?type=$record_type&name=$name_encoded&content=$content_encoded&match=all")
+  "/zones/$zone_id/dns_records?type=$type_encoded&name=$name_encoded&content=$content_encoded&match=all")
 
 # shellcheck disable=SC2016  # single-quoted jq filter
 existing_id=$(printf '%s' "$existing_json" | jq -r '[.result[].id] | .[0] // ""')

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,7 @@ Layout:
   scripts/
     _lib.sh                          # symlink → ../../cloudflare/scripts/_lib.sh (DRY)
     cf-redirect-create.sh            # create a zone Single Redirect (dry-run default, --apply to commit)
+    cf-dns-create.sh                 # create a DNS record in a zone (same safety pattern)
 .claude/skills/pr-review/            # vendored from ~/.claude/skills — fetch/reply/resolve PR comments
 tests/
   bats/                              # bats-core unit tests; PATH-injected curl stub for offline mocking

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -67,9 +67,10 @@ scope from the Read table above (so `cf-whoami.sh` / `cf-zones.sh`
 still work) **plus** the Edit scopes below. Scope to the AgentCulture
 account and "All zones from an account" exactly like the read token.
 
-| Scope (CloudFlare dashboard label)       | Level | Access | Powers                                                             |
-|------------------------------------------|-------|--------|--------------------------------------------------------------------|
+| Scope (CloudFlare dashboard label)       | Level | Access | Powers                                                                   |
+|------------------------------------------|-------|--------|--------------------------------------------------------------------------|
 | **Zone · Dynamic Redirect** (All zones)  | Zone  | Edit   | `cf-redirect-create.sh` — creates the zone-level Single Redirect ruleset |
+| **Zone · DNS** (All zones)               | Zone  | Edit   | `cf-dns-create.sh` — creates a DNS record (A / AAAA / CNAME / TXT / MX / …) |
 
 Swap tokens by editing `.env`'s `CLOUDFLARE_API_TOKEN` when you're
 about to run a write script, then swap back. `.env` only stores one
@@ -128,18 +129,23 @@ bash .claude/skills/cloudflare/scripts/cf-status.sh
   token is fully provisioned.
 
 If you also provisioned a write-ops token (§1.5), swap it into `.env`
-and run a dry-run against a real zone to exercise the Edit scope
+and run dry-runs against a real zone to exercise the Edit scopes
 without mutating anything:
 
 ```sh
+# Dynamic Redirect · Edit
 bash .claude/skills/cloudflare-write/scripts/cf-redirect-create.sh \
   agentculture.org culture.dev --www
+
+# DNS · Edit
+bash .claude/skills/cloudflare-write/scripts/cf-dns-create.sh \
+  agentculture.org A agentculture.org 192.0.2.1 --proxied
 ```
 
-This should print a "Dry-run — no changes applied" banner followed
-by the JSON body it would POST. If it instead errors with
-`code 10000`, the token is missing the **Zone · Dynamic Redirect ·
-Edit** scope (or it's scoped to the wrong zones).
+Both should print a "Dry-run — no changes applied" banner followed
+by the JSON body each would POST. If either errors with `code 10000`,
+the token is missing the corresponding Edit scope (or it's scoped to
+the wrong zones).
 
 ## 5. Common errors
 

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -69,7 +69,7 @@ account and "All zones from an account" exactly like the read token.
 
 | Scope (CloudFlare dashboard label)       | Level | Access | Powers                                                                   |
 |------------------------------------------|-------|--------|--------------------------------------------------------------------------|
-| **Zone · Dynamic Redirect** (All zones)  | Zone  | Edit   | `cf-redirect-create.sh` — creates the zone-level Single Redirect ruleset |
+| **Zone · Single Redirect** (All zones)  | Zone  | Edit   | `cf-redirect-create.sh` — creates the zone-level Single Redirect ruleset |
 | **Zone · DNS** (All zones)               | Zone  | Edit   | `cf-dns-create.sh` — creates a DNS record (A / AAAA / CNAME / TXT / MX / …) |
 
 Swap tokens by editing `.env`'s `CLOUDFLARE_API_TOKEN` when you're
@@ -133,7 +133,7 @@ and run dry-runs against a real zone to exercise the Edit scopes
 without mutating anything:
 
 ```sh
-# Dynamic Redirect · Edit
+# Single Redirect · Edit
 bash .claude/skills/cloudflare-write/scripts/cf-redirect-create.sh \
   agentculture.org culture.dev --www
 

--- a/tests/bats/cf-dns-create.bats
+++ b/tests/bats/cf-dns-create.bats
@@ -162,7 +162,7 @@ _assert_no_post() {
   [[ "$output" == *"--proxied records must use --ttl=1"* ]]
 }
 
-# --- URL encoding of record name + content ---
+# --- URL encoding of record type, name, and content ---
 
 @test "cf-dns-create.sh URL-encodes record name and content in the existence check" {
   cf_mock "/zones?per_page"        "zones_with_agentculture.json"
@@ -171,4 +171,42 @@ _assert_no_post() {
   [ "$status" -eq 0 ]
   # `;`, `=`, and space must all be percent-encoded in the existence-check URL.
   grep -qF 'v%3DDMARC1%3B%20p%3Dnone%3B' "$BATS_TEST_TMPDIR/curl.log"
+}
+
+@test "cf-dns-create.sh URL-encodes the record type in the existence check" {
+  # record_type is allowlist-validated so it's already safe, but we encode
+  # it anyway to stay consistent with the repo-wide convention.
+  cf_mock "/zones?per_page"      "zones_with_agentculture.json"
+  cf_mock "/dns_records?type=A"  "dns_records_empty.json"
+  run bash "$WRITE_SCRIPTS/cf-dns-create.sh" agentculture.org A agentculture.org 192.0.2.1 --proxied
+  [ "$status" -eq 0 ]
+  # Literal "type=A" still shows up (A encodes to itself) but importantly
+  # the assignment has passed through jq's @uri filter — the assertion
+  # here is really "the URL is well-formed with the encoded value".
+  cf_assert_called "/dns_records?type=A&name="
+}
+
+# --- `--` end-of-options marker (content/name starting with `-`) ---
+
+@test "cf-dns-create.sh accepts a TXT value starting with '-' when preceded by '--'" {
+  cf_mock "/zones?per_page"        "zones_with_agentculture.json"
+  cf_mock "/dns_records?type=TXT"  "dns_records_empty.json"
+  # Without `--`, the `-foo=bar` token would hit the `-*` case arm and exit 2.
+  run bash "$WRITE_SCRIPTS/cf-dns-create.sh" --proxied=false -- agentculture.org TXT _acme.agentculture.org '-foo=bar'
+  [ "$status" -eq 2 ]  # --proxied=false is still an unknown flag — testing that --proxied-style flags before `--` are still parsed
+  [[ "$output" == *"unknown flag: --proxied=false"* ]]
+}
+
+@test "cf-dns-create.sh '--' after positional args lets content start with dash" {
+  cf_mock "/zones?per_page"        "zones_with_agentculture.json"
+  cf_mock "/dns_records?type=TXT"  "dns_records_empty.json"
+  run bash "$WRITE_SCRIPTS/cf-dns-create.sh" agentculture.org TXT _acme.agentculture.org -- '-starts-with-dash'
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"content": "-starts-with-dash"'* ]]
+}
+
+@test "cf-dns-create.sh rejects dash-prefixed content WITHOUT '--' (shows users they need the marker)" {
+  run bash "$WRITE_SCRIPTS/cf-dns-create.sh" agentculture.org TXT _acme.agentculture.org '-starts-with-dash'
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"unknown flag: -starts-with-dash"* ]]
 }

--- a/tests/bats/cf-dns-create.bats
+++ b/tests/bats/cf-dns-create.bats
@@ -1,0 +1,174 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+setup() {
+  cf_bats_setup
+  WRITE_SCRIPTS="$SKILL_DIR/../cloudflare-write/scripts"
+}
+
+# Helper — asserts curl was NEVER invoked with `-X POST`.
+_assert_no_post() {
+  if grep -qF -- '	-X	POST	' "$BATS_TEST_TMPDIR/curl.log" 2>/dev/null; then
+    echo "expected no POST, but curl.log contains one:" >&2
+    cat "$BATS_TEST_TMPDIR/curl.log" >&2
+    return 1
+  fi
+  return 0
+}
+
+# --- dry-run (default) ---
+
+@test "cf-dns-create.sh dry-run prints banner, resolved zone, and would-POST body" {
+  cf_mock "/zones?per_page"        "zones_with_agentculture.json"
+  cf_mock "/dns_records?type=A"    "dns_records_empty.json"
+  run bash "$WRITE_SCRIPTS/cf-dns-create.sh" agentculture.org A agentculture.org 192.0.2.1 --proxied
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"**Dry-run — no changes applied**"* ]]
+  [[ "$output" == *"zone-id-agentculture-org-aaaaaaaaaaaaaaaa"* ]]
+  [[ "$output" == *"**type:** A"* ]]
+  [[ "$output" == *"**name:** agentculture.org"* ]]
+  [[ "$output" == *"**content:** 192.0.2.1"* ]]
+  [[ "$output" == *"**proxied:** true"* ]]
+  [[ "$output" == *"**ttl:** 1 (automatic)"* ]]
+  [[ "$output" == *"**would POST**"* ]]
+  [[ "$output" == *'"type": "A"'* ]]
+  [[ "$output" == *'"proxied": true'* ]]
+  _assert_no_post
+}
+
+@test "cf-dns-create.sh --json dry-run emits a synthetic envelope" {
+  cf_mock "/zones?per_page"        "zones_with_agentculture.json"
+  cf_mock "/dns_records?type=A"    "dns_records_empty.json"
+  run bash "$WRITE_SCRIPTS/cf-dns-create.sh" agentculture.org A agentculture.org 192.0.2.1 --proxied --json
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.success == true'
+  echo "$output" | jq -e '.result.dry_run == true'
+  echo "$output" | jq -e '.result.would_post.type == "A"'
+  echo "$output" | jq -e '.result.would_post.proxied == true'
+  echo "$output" | jq -e '.result.would_post.ttl == 1'
+  _assert_no_post
+}
+
+# --- apply path ---
+
+@test "cf-dns-create.sh --apply POSTs the record and reports the new id" {
+  cf_mock "/zones?per_page"        "zones_with_agentculture.json"
+  cf_mock "/dns_records?type=A"    "dns_records_empty.json"
+  cf_mock "/dns_records"           "dns_record_create_ok.json"
+  run bash "$WRITE_SCRIPTS/cf-dns-create.sh" agentculture.org A agentculture.org 192.0.2.1 --proxied --apply
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"**DNS record created**"* ]]
+  [[ "$output" == *"new-dns-record-id-bbbb1234"* ]]
+  cf_assert_called "-X	POST"
+  cf_assert_called "/zones/zone-id-agentculture-org-aaaaaaaaaaaaaaaa/dns_records"
+}
+
+@test "cf-dns-create.sh --apply sends a body with type, name, content, proxied, ttl" {
+  cf_mock "/zones?per_page"        "zones_with_agentculture.json"
+  cf_mock "/dns_records?type=A"    "dns_records_empty.json"
+  cf_mock "/dns_records"           "dns_record_create_ok.json"
+  run bash "$WRITE_SCRIPTS/cf-dns-create.sh" agentculture.org A agentculture.org 192.0.2.1 --proxied --apply
+  [ "$status" -eq 0 ]
+  grep -qF '"type": "A"'         "$BATS_TEST_TMPDIR/curl.log"
+  grep -qF '"name": "agentculture.org"' "$BATS_TEST_TMPDIR/curl.log"
+  grep -qF '"content": "192.0.2.1"' "$BATS_TEST_TMPDIR/curl.log"
+  grep -qF '"proxied": true'     "$BATS_TEST_TMPDIR/curl.log"
+  grep -qF '"ttl": 1'            "$BATS_TEST_TMPDIR/curl.log"
+}
+
+@test "cf-dns-create.sh --apply --json passes the CF response through" {
+  cf_mock "/zones?per_page"        "zones_with_agentculture.json"
+  cf_mock "/dns_records?type=A"    "dns_records_empty.json"
+  cf_mock "/dns_records"           "dns_record_create_ok.json"
+  run bash "$WRITE_SCRIPTS/cf-dns-create.sh" agentculture.org A agentculture.org 192.0.2.1 --proxied --apply --json
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.success == true'
+  echo "$output" | jq -e '.result.id == "new-dns-record-id-bbbb1234"'
+  [[ "$output" != *"DNS record created"* ]]
+}
+
+@test "cf-dns-create.sh without --proxied emits proxied:false in the body" {
+  cf_mock "/zones?per_page"        "zones_with_agentculture.json"
+  cf_mock "/dns_records?type=TXT"  "dns_records_empty.json"
+  run bash "$WRITE_SCRIPTS/cf-dns-create.sh" agentculture.org TXT _verify.agentculture.org 'verify=abc123'
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"**proxied:** false"* ]]
+  [[ "$output" == *'"proxied": false'* ]]
+}
+
+@test "cf-dns-create.sh --ttl=3600 accepts manual TTL when not proxied" {
+  cf_mock "/zones?per_page"        "zones_with_agentculture.json"
+  cf_mock "/dns_records?type=A"    "dns_records_empty.json"
+  run bash "$WRITE_SCRIPTS/cf-dns-create.sh" agentculture.org A origin.agentculture.org 192.0.2.2 --ttl=3600
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"ttl": 3600'* ]]
+  [[ "$output" == *"**ttl:** 3600"* ]]
+  [[ "$output" != *"**ttl:** 3600 (automatic)"* ]]
+}
+
+# --- idempotency & errors ---
+
+@test "cf-dns-create.sh exits 1 when an identical record already exists" {
+  cf_mock "/zones?per_page"        "zones_with_agentculture.json"
+  cf_mock "/dns_records?type=A"    "dns_records_apex_exists.json"
+  run bash "$WRITE_SCRIPTS/cf-dns-create.sh" agentculture.org A agentculture.org 192.0.2.1 --proxied --apply
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"already exists"* ]]
+  [[ "$output" == *"existing-dns-record-id-aaaa"* ]]
+  _assert_no_post
+}
+
+@test "cf-dns-create.sh exits 1 when the zone is not in the account" {
+  cf_mock "/zones?per_page"        "zones_with_agentculture.json"
+  run bash "$WRITE_SCRIPTS/cf-dns-create.sh" nosuch.dev A nosuch.dev 192.0.2.1 --proxied --apply
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"zone nosuch.dev not found"* ]]
+}
+
+@test "cf-dns-create.sh exits 2 when positional args are missing" {
+  run bash "$WRITE_SCRIPTS/cf-dns-create.sh"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"expected 4 positional args"* ]]
+}
+
+@test "cf-dns-create.sh exits 2 when fewer than 4 positional args given" {
+  run bash "$WRITE_SCRIPTS/cf-dns-create.sh" agentculture.org A agentculture.org
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"expected 4 positional args"* ]]
+}
+
+@test "cf-dns-create.sh exits 2 on unknown flag" {
+  run bash "$WRITE_SCRIPTS/cf-dns-create.sh" agentculture.org A agentculture.org 192.0.2.1 --bogus
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"unknown flag"* ]]
+}
+
+@test "cf-dns-create.sh exits 2 on unsupported record type" {
+  run bash "$WRITE_SCRIPTS/cf-dns-create.sh" agentculture.org WEIRD foo.agentculture.org bar
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"unsupported record type"* ]]
+}
+
+@test "cf-dns-create.sh exits 2 when --ttl is out of range" {
+  run bash "$WRITE_SCRIPTS/cf-dns-create.sh" agentculture.org A origin.agentculture.org 192.0.2.2 --ttl=30
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"--ttl must be 1"* ]]
+}
+
+@test "cf-dns-create.sh exits 2 when --proxied is combined with a manual --ttl" {
+  run bash "$WRITE_SCRIPTS/cf-dns-create.sh" agentculture.org A agentculture.org 192.0.2.1 --proxied --ttl=3600
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"--proxied records must use --ttl=1"* ]]
+}
+
+# --- URL encoding of record name + content ---
+
+@test "cf-dns-create.sh URL-encodes record name and content in the existence check" {
+  cf_mock "/zones?per_page"        "zones_with_agentculture.json"
+  cf_mock "/dns_records?type=TXT"  "dns_records_empty.json"
+  run bash "$WRITE_SCRIPTS/cf-dns-create.sh" agentculture.org TXT '_dmarc.agentculture.org' 'v=DMARC1; p=none;'
+  [ "$status" -eq 0 ]
+  # `;`, `=`, and space must all be percent-encoded in the existence-check URL.
+  grep -qF 'v%3DDMARC1%3B%20p%3Dnone%3B' "$BATS_TEST_TMPDIR/curl.log"
+}

--- a/tests/fixtures/dns_record_create_ok.json
+++ b/tests/fixtures/dns_record_create_ok.json
@@ -1,0 +1,18 @@
+{
+  "success": true,
+  "errors": [],
+  "messages": [],
+  "result": {
+    "id": "new-dns-record-id-bbbb1234",
+    "type": "A",
+    "name": "agentculture.org",
+    "content": "192.0.2.1",
+    "proxied": true,
+    "ttl": 1,
+    "zone_id": "zone-id-agentculture-org-aaaaaaaaaaaaaaaa",
+    "zone_name": "agentculture.org",
+    "created_on": "2026-04-21T23:30:00.000000Z",
+    "modified_on": "2026-04-21T23:30:00.000000Z",
+    "comment": "Managed by cf-dns-create.sh in agentculture/cloudflare"
+  }
+}

--- a/tests/fixtures/dns_records_apex_exists.json
+++ b/tests/fixtures/dns_records_apex_exists.json
@@ -1,0 +1,21 @@
+{
+  "success": true,
+  "errors": [],
+  "messages": [],
+  "result": [
+    {
+      "id": "existing-dns-record-id-aaaa",
+      "type": "A",
+      "name": "agentculture.org",
+      "content": "192.0.2.1",
+      "proxied": true,
+      "ttl": 1,
+      "zone_id": "zone-id-agentculture-org-aaaaaaaaaaaaaaaa",
+      "zone_name": "agentculture.org",
+      "created_on": "2026-04-20T10:00:00.000000Z",
+      "modified_on": "2026-04-20T10:00:00.000000Z",
+      "comment": "manually created earlier"
+    }
+  ],
+  "result_info": {"page": 1, "per_page": 20, "total_pages": 1, "count": 1, "total_count": 1}
+}

--- a/tests/fixtures/dns_records_empty.json
+++ b/tests/fixtures/dns_records_empty.json
@@ -1,0 +1,7 @@
+{
+  "success": true,
+  "errors": [],
+  "messages": [],
+  "result": [],
+  "result_info": {"page": 1, "per_page": 20, "total_pages": 1, "count": 0, "total_count": 0}
+}


### PR DESCRIPTION
## Summary

Adds `cf-dns-create.sh` to the `cloudflare-write` skill. This is the second write script, following the same dry-run-by-default / `--apply`-to-commit safety pattern as `cf-redirect-create.sh`.

Immediate motivation: PR #10 landed the redirect script, but `agentculture.org` has no HTTP records today (only MX + SPF/DKIM TXT), so `curl -I https://agentculture.org` returns NXDOMAIN, not a 301 — the redirect ruleset has nothing to fire on. This script is what adds the proxied apex + `www` A records so a subsequent `cf-redirect-create.sh --apply` actually takes effect for real traffic.

## Interface

```sh
cf-dns-create.sh ZONE TYPE NAME CONTENT [--proxied] [--ttl=N] [--comment=STR] [--apply] [--json]
```

Concrete unblock of issue #2, once merged:

```sh
bash .claude/skills/cloudflare-write/scripts/cf-dns-create.sh \
  agentculture.org A agentculture.org 192.0.2.1 --proxied --apply
bash .claude/skills/cloudflare-write/scripts/cf-dns-create.sh \
  agentculture.org A www.agentculture.org 192.0.2.1 --proxied --apply
bash .claude/skills/cloudflare-write/scripts/cf-redirect-create.sh \
  agentculture.org culture.dev --www --apply
curl -I https://agentculture.org   # expect 301 → https://culture.dev
```

## Design notes

- **Idempotency key = type + name + content.** Duplicate records are refused; different-content records at the same type+name (round-robin A, multi-MX) are allowed — CF itself supports that shape.
- **TTL validation** matches CF's own rules: `1` (automatic) or `60..86400`. Combining `--proxied` with `--ttl=N` (N≠1) is rejected up-front because CF silently forces proxied records to TTL=1 and a silent override is confusing.
- **Record-type allowlist** covers A, AAAA, CNAME, TXT, MX, NS, SRV, CAA. Extend the case statement if you need PTR / URI / TLSA / etc.
- **URL-encoding** of record name + content in the existence-check query string — names can contain `_` (e.g. `_dmarc`, `_dkim`) and values can contain `=`, `;`, spaces (e.g. `"v=DMARC1; p=none;"`).

## Token scope

Needs **Zone · DNS · Edit** added to the write-ops token (on top of the Dynamic Redirect Edit scope `cf-redirect-create.sh` already requires). SETUP.md §1.5 has the updated scope table.

## Live dry-run against the AgentCulture account

```text
$ bash .claude/skills/cloudflare-write/scripts/cf-dns-create.sh \
    agentculture.org A agentculture.org 192.0.2.1 --proxied
**Dry-run — no changes applied**

- **zone:** agentculture.org (id=02969f1ac3da7107eb54a0b12a992cbc)
- **type:** A
- **name:** agentculture.org
- **content:** 192.0.2.1
- **ttl:** 1 (automatic)
- **proxied:** true

**would POST** `/zones/02969f1ac3da7107eb54a0b12a992cbc/dns_records`:

{ "type": "A", "name": "agentculture.org", "content": "192.0.2.1",
  "ttl": 1, "proxied": true, "comment": "Managed by cf-dns-create.sh …" }
```

Dry-run works with just the read token — the existence check is a GET. `--apply` is what needs the Edit scope.

## Test plan

- [x] `bats tests/bats/` — 106/106 (+16 new cases: dry-run, apply, --json, --proxied, --ttl=3600, without --proxied, idempotency, zone-not-found, missing args, unknown flag, unsupported record type, TTL out of range, --proxied+--ttl conflict, URL-encoding)
- [x] `bash tests/shellcheck.sh` — clean across 17 shell scripts
- [x] `bash tests/markdownlint.sh` — clean across 7 markdown files
- [x] Live dry-run against `agentculture.org` shows the expected proxied-apex A record body
- [ ] Qodo + Copilot review
- [ ] SonarCloud
- [ ] Post-merge: apply DNS + redirect, `curl -I` smoke

🤖 Generated with [Claude Code](https://claude.com/claude-code)