### PR TITLE
Pages deployments cleanup — signed-manifest bulk-purge (closes #1)

### DIFF
--- a/.claude/skills/cloudflare-write/SKILL.md
+++ b/.claude/skills/cloudflare-write/SKILL.md
@@ -78,6 +78,8 @@ Every write script in this skill follows the same shape:
 |---|---|
 | Create a Single Redirect for a zone | `bash .claude/skills/cloudflare-write/scripts/cf-redirect-create.sh FROM_HOST TO_HOST [--www] [--status=301] [--apply] [--json]` |
 | Create a DNS record in a zone | `bash .claude/skills/cloudflare-write/scripts/cf-dns-create.sh ZONE TYPE NAME CONTENT [--proxied] [--ttl=N] [--comment=STR] [--apply] [--json]` |
+| Delete one Pages deployment | `bash .claude/skills/cloudflare-write/scripts/cf-pages-deployment-delete.sh PROJECT SHORT_ID_OR_ID [--force-canonical] [--apply] [--json]` |
+| Bulk-delete all deployments in a Pages project | `bash .claude/skills/cloudflare-write/scripts/cf-pages-deployments-purge.sh PROJECT [...]` (two-phase, see §3.3) |
 
 ### cf-redirect-create.sh
 
@@ -166,6 +168,112 @@ same name with different IPs are allowed (CF supports round-robin);
 two records with identical type+name+content are refused as
 duplicates.
 
+### 3.3 cf-pages-deployment-delete.sh
+
+Deletes a single Pages deployment by `SHORT_ID` (8-char prefix) or
+full UUID. Dry-run by default; `--apply` to commit.
+
+```sh
+# Inventory first (read skill) to pick a short_id:
+bash .claude/skills/cloudflare/scripts/cf-pages.sh agentirc-dev
+
+# Dry-run:
+bash .claude/skills/cloudflare-write/scripts/cf-pages-deployment-delete.sh \
+  agentirc-dev 66aaccee
+
+# Apply for real:
+bash .claude/skills/cloudflare-write/scripts/cf-pages-deployment-delete.sh \
+  agentirc-dev 66aaccee --apply
+```
+
+The **canonical (aliased) deployment is protected by default** — it
+is whatever `<project>.pages.dev` currently serves, so deleting it
+without replacement breaks the site. If the target is canonical, the
+script exits `1` with a refusal message. Override with
+`--force-canonical`, which maps to `?force=true` on the CF DELETE
+endpoint.
+
+### 3.4 cf-pages-deployments-purge.sh (signed-manifest workflow)
+
+Bulk-deletes every non-canonical deployment in a Pages project. This
+is the script to reach for when a project has accumulated hundreds of
+historical deployments (issue #1: `agentirc-dev` had 138).
+
+Because "delete all of them" is one typo away from an outage, this
+script has a **three-phase signed-manifest workflow** that no other
+write script in this skill uses:
+
+1. **Plan** — the default invocation with no `--apply` writes a
+   manifest file to `./.cf-purge-manifests/<ts>-<project>.md` listing
+   every deployment it would delete, plus a SHA-256 of the id list.
+   No API mutations happen. The manifest directory is gitignored at
+   the repo root.
+
+   ```sh
+   bash .claude/skills/cloudflare-write/scripts/cf-pages-deployments-purge.sh agentirc-dev
+   ```
+
+2. **Sign** — a human or peer agent opens the manifest, **reads the
+   deployment table**, and appends exactly one line at the bottom:
+
+   ```text
+   SIGNED: <your-name-or-agent-id> <ISO-8601-UTC-timestamp>
+   ```
+
+   Example: `SIGNED: ori 2026-04-22T14:10:00Z`. The signature must be
+   within `CF_PURGE_SIG_TTL` seconds (default 3600) of apply-time.
+
+3. **Apply** — re-run the script with `--manifest <path> --apply`.
+   Before any DELETE fires, the script:
+   - validates the v1 header, `ids_sha256`, project + account match,
+   - validates the `SIGNED:` line (exactly one, well-formed, fresh),
+   - **re-fetches live state** and rejects on drift (any new
+     non-canonical deployment added since signing), and
+   - skips any ids that are already gone (idempotent re-runs).
+
+   ```sh
+   bash .claude/skills/cloudflare-write/scripts/cf-pages-deployments-purge.sh \
+     agentirc-dev --manifest ./.cf-purge-manifests/20260422T140700Z-agentirc-dev.md --apply
+   ```
+
+An `<manifest>.applied.log` is written next to the manifest with
+per-id outcomes and final counts — permanent audit trail rather than
+stdout-only.
+
+Flags:
+
+- `--include-canonical` — (plan only) include the canonical
+  deployment in the manifest. Canonical is aliased to
+  `<project>.pages.dev`, so its DELETE uses `?force=true`. The flag
+  is recorded in the manifest header so the operator signs the
+  canonical-inclusion decision explicitly.
+- `--manifest PATH` — (apply only) path to the signed manifest.
+- `--manifest-dir DIR` — (plan only) override the default output
+  directory (`./.cf-purge-manifests`).
+- `--apply` — actually DELETE. Requires `--manifest`.
+- `--continue-on-error` — on a failed DELETE, keep going instead of
+  halting. The exit code is still non-zero if any DELETE failed.
+- `--json` — structured envelope for both plan and apply phases.
+- `CF_PURGE_SIG_TTL` / `CF_PURGE_SLEEP` — env knobs for signature
+  TTL and inter-delete pacing. `CF_PURGE_SLEEP=0` disables the
+  default 250ms pacing (used by the test suite).
+
+Exit codes: `0` plan wrote manifest (or "nothing to delete") / apply
+completed with zero failures; `1` API error / manifest validation
+failure / signature invalid / drift detected / any failed DELETE;
+`2` usage error.
+
+**Why a manifest instead of a `--yes` flag?** Four reasons:
+
+1. Forces the operator to **read the concrete list** of ids before
+   approving, rather than acknowledging a count.
+2. **Time-boxed** — a 60-minute-old manifest is rejected, so a stale
+   signature can't be replayed days later.
+3. **Drift-aware** — catches new deployments that appeared between
+   planning and applying (e.g., a CI build mid-signature).
+4. **Reviewable artifact** — pairs nicely with a peer-review model
+   where one agent plans and a different agent signs.
+
 ## 4. Output modes
 
 Default markdown (`cf_output_kv` for the result block):
@@ -192,9 +300,15 @@ downstream jq pipelines.
 
 - **Updates (PUT).** No `cf-*-update.sh` scripts — resources either
   exist (keep them) or don't (create new).
-- **Deletes (DELETE).** Phase 2 territory: `agentirc.dev` Pages /
-  Workers / DNS cleanup will land as `cf-*-delete.sh` scripts in
-  this skill.
+- **Deleting the Pages project itself.** `cf-pages-deployments-purge.sh`
+  deletes every deployment but leaves the zero-deployment project
+  behind. A future `cf-pages-project-delete.sh` will land as a
+  separate, smaller PR.
+- **Workers / DNS / zone deletion.** Still Phase 3 territory; new
+  `cf-*-delete.sh` scripts can follow the same dry-run-by-default
+  pattern. Whether to re-use the manifest gate depends on blast
+  radius — a single DNS record rarely warrants it; bulk route
+  deletion probably does.
 - **Account-wide rulesets.** This skill only creates zone-level
   rulesets. Account-level rulesets (applied across many zones) are
   out of scope.

--- a/.claude/skills/cloudflare-write/scripts/cf-pages-deployment-delete.sh
+++ b/.claude/skills/cloudflare-write/scripts/cf-pages-deployment-delete.sh
@@ -81,10 +81,16 @@ project_encoded=$(jq -rn --arg v "$project" '$v|@uri')
 
 # Fetch project metadata for canonical_deployment.id. The project-detail
 # endpoint is a single-object GET, so use cf_api directly, not _paginated.
-project_json=$(cf_api "/accounts/$CLOUDFLARE_ACCOUNT_ID/pages/projects/$project_encoded" 2>/dev/null) || {
-  echo "ERROR: Pages project not found: $project" >&2
+# Don't silence cf_api's stderr — it distinguishes "project missing"
+# from "token lacks scope" / "transport failure" with structured
+# .errors, and hiding that turns every failure into the same
+# misleading "not found" message. cf_api already prints its own
+# diagnostic; we just add a final hint that the project arg was the
+# resolution target.
+if ! project_json=$(cf_api "/accounts/$CLOUDFLARE_ACCOUNT_ID/pages/projects/$project_encoded"); then
+  echo "HINT: could not resolve Pages project '$project'. Check the project name with cf-pages.sh." >&2
   exit 1
-}
+fi
 canonical_id=$(printf '%s' "$project_json" | jq -r '.result.canonical_deployment.id // ""')
 
 # Resolve target to a full deployment id. If the user passed a full
@@ -151,6 +157,7 @@ render_summary_kv() {
   printf -- '- **status:** %s\n' "$status"
   printf -- '- **created:** %s\n' "$created_on"
   printf -- '- **canonical:** %s\n' "$([[ $is_canonical -eq 1 ]] && echo 'yes (force=true)' || echo 'no')"
+  return 0
 }
 
 if (( apply == 0 )); then

--- a/.claude/skills/cloudflare-write/scripts/cf-pages-deployment-delete.sh
+++ b/.claude/skills/cloudflare-write/scripts/cf-pages-deployment-delete.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+# Delete a single CloudFlare Pages deployment.
+#
+# Usage:
+#   cf-pages-deployment-delete.sh PROJECT SHORT_ID_OR_ID [--force-canonical] [--apply] [--json]
+#
+# Default is DRY-RUN: resolves the project + deployment, refuses if the
+# target is the aliased (canonical) deployment unless --force-canonical
+# is set, prints the DELETE URL it would hit, and exits 0 WITHOUT
+# mutating anything. Pass --apply to actually DELETE.
+#
+# SHORT_ID_OR_ID accepts either the 8-char short_id (first segment of
+# the UUID) or the full deployment UUID. Short IDs are unique within a
+# project; ambiguous matches are refused.
+#
+# Flags:
+#   --force-canonical   allow deleting the currently-aliased deployment.
+#                       Maps to ?force=true on the CF DELETE endpoint.
+#                       Without this flag, the canonical deployment is
+#                       protected — the redirect-only zone that still
+#                       serves agentirc-dev.pages.dev would break.
+#   --apply             actually DELETE (without it, this is a dry-run)
+#   --json              raw CloudFlare response envelope (or simulated body in dry-run)
+#
+# Exits 1 on: project not found, deployment not found, canonical guard,
+#   API error. Exits 2 on usage error.
+
+set -euo pipefail
+shopt -s inherit_errexit
+
+mode=md
+apply=0
+force_canonical=0
+positional=()
+
+for arg in "$@"; do
+  case "$arg" in
+    --json)             mode=json ;;
+    --apply)            apply=1 ;;
+    --force-canonical)  force_canonical=1 ;;
+    -h|--help)
+      awk 'NR==1{next} /^#/{sub(/^# ?/, ""); print; next} {exit}' "$0"
+      exit 0
+      ;;
+    -*)
+      echo "ERROR: unknown flag: $arg" >&2
+      exit 2
+      ;;
+    *)
+      positional+=("$arg")
+      ;;
+  esac
+done
+
+if (( ${#positional[@]} != 2 )); then
+  echo "ERROR: expected PROJECT and SHORT_ID_OR_ID positional args, got ${#positional[@]}" >&2
+  echo "usage: cf-pages-deployment-delete.sh PROJECT SHORT_ID_OR_ID [--force-canonical] [--apply] [--json]" >&2
+  exit 2
+fi
+project="${positional[0]}"
+target="${positional[1]}"
+
+# Hand-wavy validation: project name is CF-restricted (lowercase,
+# digits, dashes), and short_id / id are hex + dashes. Reject anything
+# that could escape the URL path. Tighter than strictly necessary, but
+# matches the "encode + validate at the boundary" convention.
+if [[ ! "$project" =~ ^[a-zA-Z0-9][a-zA-Z0-9._-]*$ ]]; then
+  echo "ERROR: invalid project name: $project" >&2
+  exit 2
+fi
+if [[ ! "$target" =~ ^[a-fA-F0-9-]+$ ]]; then
+  echo "ERROR: invalid deployment id: $target (expected hex + dashes)" >&2
+  exit 2
+fi
+
+# shellcheck source=../../cloudflare/scripts/_lib.sh
+source "$(dirname "${BASH_SOURCE[0]}")/_lib.sh"
+cf_require_account_id
+
+project_encoded=$(jq -rn --arg v "$project" '$v|@uri')
+
+# Fetch project metadata for canonical_deployment.id. The project-detail
+# endpoint is a single-object GET, so use cf_api directly, not _paginated.
+project_json=$(cf_api "/accounts/$CLOUDFLARE_ACCOUNT_ID/pages/projects/$project_encoded" 2>/dev/null) || {
+  echo "ERROR: Pages project not found: $project" >&2
+  exit 1
+}
+canonical_id=$(printf '%s' "$project_json" | jq -r '.result.canonical_deployment.id // ""')
+
+# Resolve target to a full deployment id. If the user passed a full
+# UUID, we still validate it exists in the listing so "does it exist"
+# and "is it canonical" both get answered with one lookup.
+#
+# Pages list endpoints cap per_page at 10 (CF error code 8000024 on
+# per_page >= 11) — same quirk that cf-pages.sh documents. Scope the
+# override to this call via a subshell so we don't surprise other
+# callers of cf_api_paginated sourced from the same shell.
+deployments_json=$(CF_PAGE_SIZE=10 cf_api_paginated "/accounts/$CLOUDFLARE_ACCOUNT_ID/pages/projects/$project_encoded/deployments")
+
+# shellcheck disable=SC2016  # single-quoted jq filter
+matches_json=$(printf '%s' "$deployments_json" | jq --arg t "$target" '
+  [
+    .result[]
+    | select(.id == $t or .short_id == $t or ((.id | startswith($t)) and ($t | length) == 8))
+    | {id, short_id, environment, created_on,
+       status: (.latest_stage.status // "unknown")}
+  ]
+')
+match_count=$(printf '%s' "$matches_json" | jq 'length')
+
+if (( match_count == 0 )); then
+  echo "ERROR: deployment not found in project $project: $target" >&2
+  exit 1
+fi
+if (( match_count > 1 )); then
+  echo "ERROR: ambiguous match in project $project: $target matches $match_count deployments" >&2
+  printf '%s\n' "$matches_json" | jq -r '.[] | "  - \(.id) (\(.short_id))"' >&2
+  exit 1
+fi
+
+deployment_id=$(printf '%s' "$matches_json" | jq -r '.[0].id')
+short_id=$(printf '%s' "$matches_json" | jq -r '.[0].short_id')
+environment=$(printf '%s' "$matches_json" | jq -r '.[0].environment')
+status=$(printf '%s' "$matches_json" | jq -r '.[0].status')
+created_on=$(printf '%s' "$matches_json" | jq -r '.[0].created_on')
+
+is_canonical=0
+if [[ -n "$canonical_id" && "$deployment_id" == "$canonical_id" ]]; then
+  is_canonical=1
+fi
+
+# Canonical guard: refuse unless explicitly overridden.
+if (( is_canonical && force_canonical == 0 )); then
+  echo "ERROR: deployment $short_id ($deployment_id) is the canonical (aliased) deployment for project $project" >&2
+  echo "       deleting it would take $project.pages.dev offline." >&2
+  echo "       re-run with --force-canonical to override (maps to ?force=true)." >&2
+  exit 1
+fi
+
+# Build the DELETE URL. force=true required to delete an aliased
+# deployment — CF returns "this deployment is currently active" otherwise.
+delete_path="/accounts/$CLOUDFLARE_ACCOUNT_ID/pages/projects/$project_encoded/deployments/$deployment_id"
+if (( is_canonical )); then
+  delete_path="${delete_path}?force=true"
+fi
+
+render_summary_kv() {
+  printf -- '- **project:** %s\n' "$project"
+  printf -- '- **deployment:** %s (id=%s)\n' "$short_id" "$deployment_id"
+  printf -- '- **environment:** %s\n' "$environment"
+  printf -- '- **status:** %s\n' "$status"
+  printf -- '- **created:** %s\n' "$created_on"
+  printf -- '- **canonical:** %s\n' "$([[ $is_canonical -eq 1 ]] && echo 'yes (force=true)' || echo 'no')"
+}
+
+if (( apply == 0 )); then
+  if [[ "$mode" == "json" ]]; then
+    # shellcheck disable=SC2016  # single-quoted jq filter
+    jq -n \
+      --arg project "$project" \
+      --arg deployment_id "$deployment_id" \
+      --arg short_id "$short_id" \
+      --arg delete_path "$delete_path" \
+      --argjson is_canonical "$is_canonical" \
+      '{success: true, errors: [], messages: ["dry-run: no changes applied"],
+        result: {dry_run: true, project: $project,
+                 deployment_id: $deployment_id, short_id: $short_id,
+                 canonical: ($is_canonical == 1),
+                 would_delete: $delete_path}}'
+    exit 0
+  fi
+  printf '**Dry-run — no changes applied**\n\n'
+  render_summary_kv
+  # shellcheck disable=SC2016  # literal backticks wrap markdown inline code
+  printf '\n**would DELETE** `%s`\n' "$delete_path"
+  exit 0
+fi
+
+# Apply path.
+response=$(cf_api "$delete_path" -X DELETE)
+
+if [[ "$mode" == "json" ]]; then
+  printf '%s\n' "$response"
+  exit 0
+fi
+
+printf '**Deployment deleted**\n\n'
+render_summary_kv

--- a/.claude/skills/cloudflare-write/scripts/cf-pages-deployments-purge.sh
+++ b/.claude/skills/cloudflare-write/scripts/cf-pages-deployments-purge.sh
@@ -154,6 +154,14 @@ ids_sha256() {
   return 0
 }
 
+# Length of a JSON array passed as the first argument. Centralizes
+# the `jq 'length'` idiom used for every count in this script so the
+# literal isn't duplicated four times.
+json_array_length() {
+  printf '%s' "$1" | jq 'length'
+  return 0
+}
+
 # -----------------------------------------------------------------------------
 # PLAN PHASE
 # -----------------------------------------------------------------------------
@@ -179,7 +187,7 @@ if (( apply == 0 )); then
          is_canonical: (.id == $canonical)}
     ] | sort_by(.created_on)
   ')
-  purge_count=$(printf '%s' "$purge_json" | jq 'length')
+  purge_count=$(json_array_length "$purge_json")
 
   if (( purge_count == 0 )); then
     if [[ "$mode" == "json" ]]; then
@@ -454,7 +462,7 @@ drift_json=$(jq -n \
   --argjson manifest "$manifest_ids_json" \
   --arg canonical "$live_canonical" \
   '($live - $manifest) - [$canonical] | map(select(length > 0))')
-drift_count=$(printf '%s' "$drift_json" | jq 'length')
+drift_count=$(json_array_length "$drift_json")
 if (( drift_count > 0 )); then
   echo "ERROR: live project has $drift_count new non-canonical deployment(s) since the manifest was signed:" >&2
   printf '%s\n' "$drift_json" | jq -r '.[] | "  - " + .' >&2
@@ -492,8 +500,8 @@ plan_json=$(printf '%s' "$live_deployments_json" | jq \
        is_canonical: (.id == $canonical)}
   ] | sort_by(.created_on)
 ')
-plan_count=$(printf '%s' "$plan_json" | jq 'length')
-skipped_count=$(printf '%s' "$skipped_json" | jq 'length')
+plan_count=$(json_array_length "$plan_json")
+skipped_count=$(json_array_length "$skipped_json")
 
 # -----------------------------------------------------------------------------
 # Apply-log setup + deletion loop

--- a/.claude/skills/cloudflare-write/scripts/cf-pages-deployments-purge.sh
+++ b/.claude/skills/cloudflare-write/scripts/cf-pages-deployments-purge.sh
@@ -158,7 +158,8 @@ ids_sha256() {
 # the `jq 'length'` idiom used for every count in this script so the
 # literal isn't duplicated four times.
 json_array_length() {
-  printf '%s' "$1" | jq 'length'
+  local json="$1"
+  printf '%s' "$json" | jq 'length'
   return 0
 }
 

--- a/.claude/skills/cloudflare-write/scripts/cf-pages-deployments-purge.sh
+++ b/.claude/skills/cloudflare-write/scripts/cf-pages-deployments-purge.sh
@@ -137,11 +137,13 @@ fetch_canonical_id() {
   local pj
   pj=$(cf_api "/accounts/$CLOUDFLARE_ACCOUNT_ID/pages/projects/$project_encoded") || return 1
   printf '%s' "$pj" | jq -r '.result.canonical_deployment.id // ""'
+  return 0
 }
 
 # Fetch the full deployment list for the project (Pages per_page cap = 10).
 fetch_deployments_json() {
   CF_PAGE_SIZE=10 cf_api_paginated "/accounts/$CLOUDFLARE_ACCOUNT_ID/pages/projects/$project_encoded/deployments"
+  return 0
 }
 
 # Compute a stable SHA-256 over a JSON array of ids (sorted, newline-
@@ -149,6 +151,7 @@ fetch_deployments_json() {
 ids_sha256() {
   local ids_json="$1"
   printf '%s' "$ids_json" | jq -r 'sort | .[]' | sha256sum | awk '{print $1}'
+  return 0
 }
 
 # -----------------------------------------------------------------------------
@@ -300,6 +303,7 @@ manifest_read_kv() {
     exit 1
   fi
   grep -E "^- \*\*${key}:\*\* " "$manifest_path" | sed -E "s/^- \*\*${key}:\*\* //"
+  return 0
 }
 
 m_project=$(manifest_read_kv project)
@@ -378,16 +382,34 @@ if (( ${#signer} > 64 )); then
   exit 1
 fi
 
-# Parse signature timestamp into epoch. `date -d` handles ISO-8601
-# with trailing Z on GNU coreutils. Reject anything that doesn't
-# parse — we treat that as tampering.
-sig_epoch=$(date -u -d "$sig_ts" +%s 2>/dev/null || echo "")
-if [[ -z "$sig_epoch" ]]; then
+# Parse signature timestamp into epoch. GNU `date -d` and BSD
+# `date -j -f` have incompatible syntaxes — try the GNU form first
+# (CI + most Linux agents) and fall back to BSD (macOS operators
+# running the skill locally). Reject anything that doesn't parse
+# either way — we treat that as tampering.
+iso8601_to_epoch() {
+  local ts="$1" out=""
+  if out=$(date -u -d "$ts" +%s 2>/dev/null); then
+    printf '%s' "$out"; return 0
+  fi
+  # BSD date: strip a trailing Z, then parse as "%Y-%m-%dT%H:%M:%S".
+  local bsd_ts="${ts%Z}"
+  if out=$(date -u -j -f '%Y-%m-%dT%H:%M:%S' "$bsd_ts" +%s 2>/dev/null); then
+    printf '%s' "$out"; return 0
+  fi
+  return 1
+}
+
+if ! sig_epoch=$(iso8601_to_epoch "$sig_ts"); then
   echo "ERROR: SIGNED timestamp not parseable: $sig_ts" >&2
   exit 1
 fi
 now_epoch=$(date -u +%s)
 ttl="${CF_PURGE_SIG_TTL:-3600}"
+if [[ ! "$ttl" =~ ^[0-9]+$ ]]; then
+  echo "ERROR: CF_PURGE_SIG_TTL must be an integer number of seconds; got: $ttl" >&2
+  exit 1
+fi
 age=$(( now_epoch - sig_epoch ))
 if (( age > ttl )); then
   echo "ERROR: SIGNED timestamp expired (age ${age}s > TTL ${ttl}s): $sig_ts" >&2
@@ -502,7 +524,12 @@ while IFS=$'\t' read -r d_id d_short d_env d_canonical; do
     delete_path="${delete_path}?force=true"
   fi
 
-  if err=$(cf_api "$delete_path" -X DELETE 2>&1 >/dev/null); then
+  # Brace group order matters: cmd >/dev/null first, then 2>&1 around
+  # the group. Writing it the other way ('2>&1 >/dev/null') dup's
+  # stderr to the *original* stdout before stdout gets sent to
+  # /dev/null, so cf_api's .errors payload ends up on the terminal
+  # instead of in `err` — exactly what audit logging needs to avoid.
+  if err=$({ cf_api "$delete_path" -X DELETE >/dev/null; } 2>&1); then
     deleted=$((deleted + 1))
     printf '%s\tdeleted\t%s\t%s\t%s\n' \
       "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$d_short" "$d_id" "$d_env" >> "$log_path"

--- a/.claude/skills/cloudflare-write/scripts/cf-pages-deployments-purge.sh
+++ b/.claude/skills/cloudflare-write/scripts/cf-pages-deployments-purge.sh
@@ -1,0 +1,587 @@
+#!/usr/bin/env bash
+# Bulk-delete CloudFlare Pages deployments for a project, gated by a
+# signed manifest.
+#
+# Two-phase workflow (see the Signed-manifest safety gate section in
+# SKILL.md for why):
+#
+#   Phase A — PLAN (default, no --apply):
+#     cf-pages-deployments-purge.sh PROJECT [--include-canonical]
+#                                           [--manifest-dir DIR]
+#                                           [--json]
+#
+#   Phase B — SIGN: human/agent opens the manifest file, inspects the
+#   table, and appends exactly one line of the form:
+#     SIGNED: <signer-name> <ISO-8601-UTC-timestamp>
+#   Example: SIGNED: ori 2026-04-22T14:10:00Z
+#
+#   Phase C — APPLY:
+#     cf-pages-deployments-purge.sh PROJECT --manifest PATH --apply
+#                                           [--continue-on-error] [--json]
+#
+# The apply path refuses to run unless the manifest exists, passes
+# tamper / signature / drift checks, and still matches the live
+# project state. New non-canonical deployments created between plan
+# and apply cause a hard drift rejection (re-plan required). Ids
+# already gone are skipped (idempotent re-runs).
+#
+# Flags:
+#   --include-canonical   include the canonical (aliased) deployment
+#                         in the manifest. The final DELETE for that
+#                         id uses ?force=true. Recorded in the
+#                         manifest header, signed explicitly.
+#   --manifest-dir DIR    directory for the plan's manifest file
+#                         (default: ./.cf-purge-manifests)
+#   --manifest PATH       (apply only) path to a signed manifest
+#   --apply               actually DELETE. Requires --manifest.
+#   --continue-on-error   keep deleting when a single DELETE fails.
+#                         Default halts on first failure so the rest
+#                         of the list can be re-signed and retried.
+#   --json                JSON envelope output instead of markdown
+#
+# Env:
+#   CF_PURGE_SIG_TTL   signature TTL in seconds (default 3600)
+#   CF_PURGE_SLEEP     inter-delete sleep in seconds (default 0.25);
+#                      set to 0 to disable pacing (tests).
+#
+# Exits 1 on: API error / manifest invalid / signature invalid /
+#   drift / any failed DELETE. Exits 2 on usage error.
+
+set -euo pipefail
+shopt -s inherit_errexit
+
+mode=md
+apply=0
+include_canonical=0
+continue_on_error=0
+manifest_path=""
+manifest_dir="./.cf-purge-manifests"
+positional=()
+
+i=0
+args=("$@")
+while (( i < ${#args[@]} )); do
+  arg="${args[i]}"
+  case "$arg" in
+    --json)               mode=json ;;
+    --apply)              apply=1 ;;
+    --include-canonical)  include_canonical=1 ;;
+    --continue-on-error)  continue_on_error=1 ;;
+    --manifest)
+      i=$((i+1))
+      if (( i >= ${#args[@]} )); then
+        echo "ERROR: --manifest requires a path argument" >&2
+        exit 2
+      fi
+      manifest_path="${args[i]}"
+      ;;
+    --manifest=*)         manifest_path="${arg#*=}" ;;
+    --manifest-dir)
+      i=$((i+1))
+      if (( i >= ${#args[@]} )); then
+        echo "ERROR: --manifest-dir requires a path argument" >&2
+        exit 2
+      fi
+      manifest_dir="${args[i]}"
+      ;;
+    --manifest-dir=*)     manifest_dir="${arg#*=}" ;;
+    -h|--help)
+      awk 'NR==1{next} /^#/{sub(/^# ?/, ""); print; next} {exit}' "$0"
+      exit 0
+      ;;
+    -*)
+      echo "ERROR: unknown flag: $arg" >&2
+      exit 2
+      ;;
+    *)
+      positional+=("$arg")
+      ;;
+  esac
+  i=$((i+1))
+done
+
+if (( ${#positional[@]} != 1 )); then
+  echo "ERROR: expected PROJECT positional arg, got ${#positional[@]}" >&2
+  echo "usage (plan):  cf-pages-deployments-purge.sh PROJECT [--include-canonical] [--manifest-dir DIR] [--json]" >&2
+  echo "usage (apply): cf-pages-deployments-purge.sh PROJECT --manifest PATH --apply [--continue-on-error] [--json]" >&2
+  exit 2
+fi
+project="${positional[0]}"
+
+if [[ ! "$project" =~ ^[a-zA-Z0-9][a-zA-Z0-9._-]*$ ]]; then
+  echo "ERROR: invalid project name: $project" >&2
+  exit 2
+fi
+
+if (( apply == 1 )) && [[ -z "$manifest_path" ]]; then
+  echo "ERROR: --apply requires --manifest PATH" >&2
+  exit 2
+fi
+if (( apply == 0 )) && [[ -n "$manifest_path" ]]; then
+  echo "ERROR: --manifest is only valid with --apply" >&2
+  exit 2
+fi
+
+# shellcheck source=../../cloudflare/scripts/_lib.sh
+source "$(dirname "${BASH_SOURCE[0]}")/_lib.sh"
+cf_require_account_id
+
+project_encoded=$(jq -rn --arg v "$project" '$v|@uri')
+
+# -----------------------------------------------------------------------------
+# Shared helpers used by both phases
+# -----------------------------------------------------------------------------
+
+# Emit the project's current canonical_deployment.id (may be empty).
+fetch_canonical_id() {
+  local pj
+  pj=$(cf_api "/accounts/$CLOUDFLARE_ACCOUNT_ID/pages/projects/$project_encoded") || return 1
+  printf '%s' "$pj" | jq -r '.result.canonical_deployment.id // ""'
+}
+
+# Fetch the full deployment list for the project (Pages per_page cap = 10).
+fetch_deployments_json() {
+  CF_PAGE_SIZE=10 cf_api_paginated "/accounts/$CLOUDFLARE_ACCOUNT_ID/pages/projects/$project_encoded/deployments"
+}
+
+# Compute a stable SHA-256 over a JSON array of ids (sorted, newline-
+# separated). Used as the manifest tamper-check.
+ids_sha256() {
+  local ids_json="$1"
+  printf '%s' "$ids_json" | jq -r 'sort | .[]' | sha256sum | awk '{print $1}'
+}
+
+# -----------------------------------------------------------------------------
+# PLAN PHASE
+# -----------------------------------------------------------------------------
+
+if (( apply == 0 )); then
+  canonical_id=$(fetch_canonical_id) || {
+    echo "ERROR: Pages project not found: $project" >&2
+    exit 1
+  }
+  deployments_json=$(fetch_deployments_json)
+
+  # Build the purge set. Exclude canonical unless --include-canonical.
+  # shellcheck disable=SC2016  # single-quoted jq filter
+  purge_json=$(printf '%s' "$deployments_json" | jq \
+    --arg canonical "$canonical_id" \
+    --argjson include_canonical "$include_canonical" '
+    [.result[]
+      | select($include_canonical == 1 or .id != $canonical)
+      | {id, short_id,
+         environment: (.environment // "—"),
+         status: (.latest_stage.status // "unknown"),
+         created_on,
+         is_canonical: (.id == $canonical)}
+    ] | sort_by(.created_on)
+  ')
+  purge_count=$(printf '%s' "$purge_json" | jq 'length')
+
+  if (( purge_count == 0 )); then
+    if [[ "$mode" == "json" ]]; then
+      # shellcheck disable=SC2016
+      jq -n --arg project "$project" \
+        '{success: true, errors: [], messages: ["nothing to delete"],
+          result: {project: $project, purge_count: 0}}'
+    else
+      printf '**Nothing to delete** — project %s has no deployments matching the purge criteria.\n' "$project"
+    fi
+    exit 0
+  fi
+
+  ids_json=$(printf '%s' "$purge_json" | jq '[.[].id]')
+  hash=$(ids_sha256 "$ids_json")
+
+  # Generate an ISO-8601 UTC timestamp without colons — filenames on
+  # some filesystems (especially Windows-shared mounts) don't tolerate
+  # colons, so use YYYYMMDDTHHMMSSZ.
+  ts_file=$(date -u +%Y%m%dT%H%M%SZ)
+  ts_human=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+  mkdir -p "$manifest_dir"
+  out_path="$manifest_dir/${ts_file}-${project}.md"
+
+  {
+    printf '# cf-purge-manifest v1\n\n'
+    printf -- '- **project:** %s\n' "$project"
+    printf -- '- **account_id:** %s\n' "$CLOUDFLARE_ACCOUNT_ID"
+    printf -- '- **generated_at:** %s\n' "$ts_human"
+    printf -- '- **canonical_deployment_id:** %s\n' "${canonical_id:-—}"
+    printf -- '- **include_canonical:** %s\n' "$([[ $include_canonical -eq 1 ]] && echo true || echo false)"
+    printf -- '- **count:** %s\n' "$purge_count"
+    printf -- '- **ids_sha256:** %s\n' "$hash"
+    printf '\n'
+    printf '## Deployments to delete (%s)\n\n' "$purge_count"
+    printf '| SHORT_ID | ID | ENV | STATUS | CREATED | CANONICAL |\n'
+    printf '| --- | --- | --- | --- | --- | --- |\n'
+    printf '%s' "$purge_json" | jq -r '.[]
+      | [.short_id, .id, .environment, .status, .created_on,
+         (if .is_canonical then "yes" else "no" end)]
+      | @tsv' \
+      | sed 's/|/\\|/g; s/\t/ | /g; s/^/| /; s/$/ |/'
+    printf '\n\n'
+    printf '## Signature\n\n'
+    printf 'To approve this purge, append a single line below exactly like:\n\n'
+    printf '    SIGNED: <your-name-or-agent-id> <ISO-8601-UTC-timestamp>\n\n'
+    # shellcheck disable=SC2016  # literal backticks below wrap markdown inline code
+    printf 'Example: `SIGNED: ori %s`\n\n' "$ts_human"
+    printf 'Rules:\n\n'
+    # shellcheck disable=SC2016  # literal backticks below wrap markdown inline code
+    printf -- '- **Exactly one** `SIGNED:` line; multiples are rejected as ambiguous.\n'
+    printf -- '- Timestamp must be within the last %s seconds at apply-time (clock-skew future cap: 5 min).\n' "${CF_PURGE_SIG_TTL:-3600}"
+    # shellcheck disable=SC2016  # literal backticks below wrap markdown inline code
+    printf -- '- The `ids_sha256` above must still match both the table below and the live deployment set.\n'
+    printf -- '- No new non-canonical deployments may have been added since signing.\n\n'
+    printf '<!-- sign on the line below -->\n'
+  } > "$out_path"
+
+  if [[ "$mode" == "json" ]]; then
+    # shellcheck disable=SC2016
+    jq -n \
+      --arg project "$project" \
+      --arg manifest "$out_path" \
+      --arg hash "$hash" \
+      --arg canonical_id "$canonical_id" \
+      --argjson include_canonical "$include_canonical" \
+      --argjson count "$purge_count" \
+      '{success: true, errors: [], messages: ["dry-run: manifest written, sign to apply"],
+        result: {dry_run: true, project: $project, manifest: $manifest,
+                 count: $count, ids_sha256: $hash,
+                 canonical_deployment_id: $canonical_id,
+                 include_canonical: ($include_canonical == 1)}}'
+    exit 0
+  fi
+
+  printf '**Manifest written — sign to apply**\n\n'
+  printf -- '- **project:** %s\n' "$project"
+  printf -- '- **canonical_deployment_id:** %s\n' "${canonical_id:-—}"
+  printf -- '- **include_canonical:** %s\n' "$([[ $include_canonical -eq 1 ]] && echo true || echo false)"
+  printf -- '- **count:** %s\n' "$purge_count"
+  printf -- '- **manifest:** %s\n' "$out_path"
+  printf -- '- **ids_sha256:** %s\n' "$hash"
+  printf '\n'
+  printf 'Next steps:\n\n'
+  # shellcheck disable=SC2016  # literal backticks below wrap markdown inline code
+  printf '1. Open `%s` and inspect the deployment list.\n' "$out_path"
+  # shellcheck disable=SC2016  # literal backticks below wrap markdown inline code
+  printf '2. Append a single line: `SIGNED: <name> <ISO-UTC-timestamp>`.\n'
+  # shellcheck disable=SC2016  # literal backticks below wrap markdown inline code
+  printf '3. Run: `%s %s --manifest %s --apply`.\n' "$(basename "$0")" "$project" "$out_path"
+  exit 0
+fi
+
+# -----------------------------------------------------------------------------
+# APPLY PHASE
+# -----------------------------------------------------------------------------
+
+if [[ ! -f "$manifest_path" ]]; then
+  echo "ERROR: manifest not found: $manifest_path" >&2
+  exit 1
+fi
+if [[ ! -s "$manifest_path" ]]; then
+  echo "ERROR: manifest is empty: $manifest_path" >&2
+  exit 1
+fi
+
+# Header sanity.
+if ! grep -q '^# cf-purge-manifest v1$' "$manifest_path"; then
+  echo "ERROR: manifest missing v1 header: $manifest_path" >&2
+  exit 1
+fi
+
+manifest_read_kv() {
+  # $1 = key name (e.g. "project"). Extracts the value from a
+  # `- **key:** value` line. Single match required; error otherwise.
+  local key="$1" matches
+  matches=$(grep -cE "^- \*\*${key}:\*\* " "$manifest_path" || true)
+  if [[ "$matches" != "1" ]]; then
+    echo "ERROR: manifest has $matches '$key' header lines (expected 1): $manifest_path" >&2
+    exit 1
+  fi
+  grep -E "^- \*\*${key}:\*\* " "$manifest_path" | sed -E "s/^- \*\*${key}:\*\* //"
+}
+
+m_project=$(manifest_read_kv project)
+m_account=$(manifest_read_kv account_id)
+m_canonical=$(manifest_read_kv canonical_deployment_id)
+# include_canonical is captured here as a parsed header field but not
+# referenced again: whether canonical is in the purge set is already
+# decided by its membership in the id table, and the ?force=true flag
+# is driven by per-id `is_canonical` built from the *live* project
+# state below. Keep parsing it so a malformed header still fails fast.
+_=$(manifest_read_kv include_canonical)
+m_count=$(manifest_read_kv count)
+m_hash=$(manifest_read_kv ids_sha256)
+
+if [[ "$m_project" != "$project" ]]; then
+  echo "ERROR: manifest project ($m_project) does not match positional arg ($project)" >&2
+  exit 1
+fi
+if [[ "$m_account" != "$CLOUDFLARE_ACCOUNT_ID" ]]; then
+  echo "ERROR: manifest account_id ($m_account) does not match current CLOUDFLARE_ACCOUNT_ID" >&2
+  exit 1
+fi
+if [[ ! "$m_count" =~ ^[0-9]+$ ]]; then
+  echo "ERROR: manifest count is not an integer: $m_count" >&2
+  exit 1
+fi
+if [[ ! "$m_hash" =~ ^[a-f0-9]{64}$ ]]; then
+  echo "ERROR: manifest ids_sha256 is not a valid SHA-256 hex digest: $m_hash" >&2
+  exit 1
+fi
+
+# Parse the id column out of the table. Rows look like:
+#   | short | full-uuid | env | status | created | canonical |
+# Grab column 3 (1-indexed including the leading empty column from `|`).
+manifest_ids_sorted=$(awk -F' *\\| *' '
+  /^\| [a-f0-9]{8,} \| [a-f0-9-]{36} \|/ { print $3 }
+' "$manifest_path" | sort)
+manifest_ids_count=$(printf '%s\n' "$manifest_ids_sorted" | grep -c . || true)
+
+if [[ "$manifest_ids_count" != "$m_count" ]]; then
+  echo "ERROR: manifest header count ($m_count) does not match parsed table rows ($manifest_ids_count)" >&2
+  exit 1
+fi
+
+# shellcheck disable=SC2016
+manifest_ids_json=$(printf '%s\n' "$manifest_ids_sorted" \
+  | jq -R . | jq -s 'map(select(length > 0))')
+computed_hash=$(ids_sha256 "$manifest_ids_json")
+if [[ "$computed_hash" != "$m_hash" ]]; then
+  echo "ERROR: manifest ids_sha256 mismatch — header says $m_hash but table hashes to $computed_hash" >&2
+  echo "       the manifest has been edited after generation; regenerate it." >&2
+  exit 1
+fi
+
+# Signature validation.
+sig_count=$(grep -cE '^SIGNED: ' "$manifest_path" || true)
+if [[ "$sig_count" == "0" ]]; then
+  echo "ERROR: manifest is unsigned (no 'SIGNED:' line): $manifest_path" >&2
+  exit 1
+fi
+if [[ "$sig_count" != "1" ]]; then
+  echo "ERROR: manifest has $sig_count SIGNED lines (expected 1, ambiguous)" >&2
+  exit 1
+fi
+
+sig_line=$(grep -E '^SIGNED: ' "$manifest_path")
+if [[ ! "$sig_line" =~ ^SIGNED:\ ([^[:space:]]+)\ ([0-9T:Z.+-]+)$ ]]; then
+  echo "ERROR: SIGNED line malformed; expected 'SIGNED: <name> <ISO-UTC-timestamp>'" >&2
+  echo "  got: $sig_line" >&2
+  exit 1
+fi
+signer="${BASH_REMATCH[1]}"
+sig_ts="${BASH_REMATCH[2]}"
+if (( ${#signer} > 64 )); then
+  echo "ERROR: SIGNED signer name too long (${#signer} > 64)" >&2
+  exit 1
+fi
+
+# Parse signature timestamp into epoch. `date -d` handles ISO-8601
+# with trailing Z on GNU coreutils. Reject anything that doesn't
+# parse — we treat that as tampering.
+sig_epoch=$(date -u -d "$sig_ts" +%s 2>/dev/null || echo "")
+if [[ -z "$sig_epoch" ]]; then
+  echo "ERROR: SIGNED timestamp not parseable: $sig_ts" >&2
+  exit 1
+fi
+now_epoch=$(date -u +%s)
+ttl="${CF_PURGE_SIG_TTL:-3600}"
+age=$(( now_epoch - sig_epoch ))
+if (( age > ttl )); then
+  echo "ERROR: SIGNED timestamp expired (age ${age}s > TTL ${ttl}s): $sig_ts" >&2
+  echo "       re-sign the manifest with a fresh timestamp." >&2
+  exit 1
+fi
+# Clock-skew sanity: allow up to 5 min of future drift.
+if (( age < -300 )); then
+  echo "ERROR: SIGNED timestamp is more than 5 min in the future: $sig_ts (age ${age}s)" >&2
+  exit 1
+fi
+
+# -----------------------------------------------------------------------------
+# Live drift check
+# -----------------------------------------------------------------------------
+
+live_canonical=$(fetch_canonical_id) || {
+  echo "ERROR: Pages project no longer exists: $project" >&2
+  exit 1
+}
+live_deployments_json=$(fetch_deployments_json)
+
+# If the manifest said the canonical was X and it's now Y, reject.
+# Treat "manifest had no canonical" as matching "live has no canonical".
+if [[ "$m_canonical" == "—" ]]; then m_canonical=""; fi
+if [[ "$live_canonical" != "$m_canonical" ]]; then
+  echo "ERROR: canonical deployment rotated since signing" >&2
+  echo "       manifest: ${m_canonical:-<none>}" >&2
+  echo "       live:     ${live_canonical:-<none>}" >&2
+  echo "       regenerate the manifest to cover the new canonical." >&2
+  exit 1
+fi
+
+# Build the live id set (full deployment ids).
+live_ids_json=$(printf '%s' "$live_deployments_json" | jq '[.result[].id]')
+
+# Drift detection: any live non-canonical id NOT in the manifest is
+# unsigned state and must cause a hard reject.
+# shellcheck disable=SC2016
+drift_json=$(jq -n \
+  --argjson live "$live_ids_json" \
+  --argjson manifest "$manifest_ids_json" \
+  --arg canonical "$live_canonical" \
+  '($live - $manifest) - [$canonical] | map(select(length > 0))')
+drift_count=$(printf '%s' "$drift_json" | jq 'length')
+if (( drift_count > 0 )); then
+  echo "ERROR: live project has $drift_count new non-canonical deployment(s) since the manifest was signed:" >&2
+  printf '%s\n' "$drift_json" | jq -r '.[] | "  - " + .' >&2
+  echo "       regenerate the manifest so the new deployment(s) can be reviewed." >&2
+  exit 1
+fi
+
+# Intersection set: ids in both manifest and live. These are what we
+# actually delete. Manifest ids missing from live get skipped (already
+# gone — happens on idempotent re-runs).
+# shellcheck disable=SC2016
+intersect_json=$(jq -n \
+  --argjson live "$live_ids_json" \
+  --argjson manifest "$manifest_ids_json" \
+  '$manifest - ($manifest - $live)')
+# shellcheck disable=SC2016
+skipped_json=$(jq -n \
+  --argjson live "$live_ids_json" \
+  --argjson manifest "$manifest_ids_json" \
+  '$manifest - $live')
+
+# Enrich intersection with per-id metadata (short_id, canonical flag)
+# from live; sort oldest-first so a halt-on-error leaves recent
+# deployments intact. We need environment + created_on from live; do
+# that with an index-hash lookup.
+# shellcheck disable=SC2016
+plan_json=$(printf '%s' "$live_deployments_json" | jq \
+  --argjson ids "$intersect_json" \
+  --arg canonical "$live_canonical" '
+  [.result[]
+    | select(.id as $x | $ids | index($x))
+    | {id, short_id,
+       environment: (.environment // "—"),
+       created_on,
+       is_canonical: (.id == $canonical)}
+  ] | sort_by(.created_on)
+')
+plan_count=$(printf '%s' "$plan_json" | jq 'length')
+skipped_count=$(printf '%s' "$skipped_json" | jq 'length')
+
+# -----------------------------------------------------------------------------
+# Apply-log setup + deletion loop
+# -----------------------------------------------------------------------------
+
+log_path="${manifest_path}.applied.log"
+{
+  printf '# cf-purge applied-log\n'
+  printf '# manifest: %s\n' "$manifest_path"
+  printf '# signer:   %s\n' "$signer"
+  printf '# sig_ts:   %s\n' "$sig_ts"
+  printf '# started:  %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  printf '# plan:     %s (skipped-already-gone: %s)\n' "$plan_count" "$skipped_count"
+  printf '# ---\n'
+} >> "$log_path"
+
+deleted=0
+failed=0
+failures_json='[]'
+
+sleep_s="${CF_PURGE_SLEEP:-0.25}"
+
+# Iterate the plan oldest-first.
+while IFS=$'\t' read -r d_id d_short d_env d_canonical; do
+  [[ -z "$d_id" ]] && continue
+  delete_path="/accounts/$CLOUDFLARE_ACCOUNT_ID/pages/projects/$project_encoded/deployments/$d_id"
+  if [[ "$d_canonical" == "true" ]]; then
+    delete_path="${delete_path}?force=true"
+  fi
+
+  if err=$(cf_api "$delete_path" -X DELETE 2>&1 >/dev/null); then
+    deleted=$((deleted + 1))
+    printf '%s\tdeleted\t%s\t%s\t%s\n' \
+      "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$d_short" "$d_id" "$d_env" >> "$log_path"
+    # Sleep only between successes to stay under CF rate limits.
+    if [[ "$sleep_s" != "0" ]]; then
+      sleep "$sleep_s" || true
+    fi
+  else
+    failed=$((failed + 1))
+    # shellcheck disable=SC2016
+    failures_json=$(jq -n --argjson prev "$failures_json" \
+      --arg id "$d_id" --arg short "$d_short" --arg err "$err" \
+      '$prev + [{id: $id, short_id: $short, error: $err}]')
+    printf '%s\tFAILED\t%s\t%s\t%s\t%s\n' \
+      "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$d_short" "$d_id" "$d_env" "${err//$'\n'/ }" >> "$log_path"
+    if (( continue_on_error == 0 )); then
+      echo "ERROR: DELETE failed on $d_short ($d_id); halting. Re-run with --continue-on-error to skip past failures." >&2
+      break
+    fi
+  fi
+done < <(printf '%s' "$plan_json" | jq -r '.[] | [.id, .short_id, .environment, (.is_canonical|tostring)] | @tsv')
+
+{
+  printf '# ---\n'
+  printf '# finished: %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  printf '# deleted:  %s\n' "$deleted"
+  printf '# skipped:  %s\n' "$skipped_count"
+  printf '# failed:   %s\n' "$failed"
+} >> "$log_path"
+
+# Exit code: zero only if zero failures AND we attempted the whole plan.
+attempted=$(( deleted + failed ))
+status=0
+if (( failed > 0 )); then
+  status=1
+fi
+
+if [[ "$mode" == "json" ]]; then
+  # shellcheck disable=SC2016
+  jq -n \
+    --arg project "$project" \
+    --arg manifest "$manifest_path" \
+    --arg log "$log_path" \
+    --argjson deleted "$deleted" \
+    --argjson skipped "$skipped_count" \
+    --argjson failed "$failed" \
+    --argjson attempted "$attempted" \
+    --argjson plan "$plan_count" \
+    --argjson failures "$failures_json" \
+    '{success: ($failed == 0),
+      errors: (if $failed > 0 then [{code: 1, message: "one or more DELETEs failed"}] else [] end),
+      messages: [],
+      result: {project: $project, manifest: $manifest, log: $log,
+               summary: {plan: $plan, attempted: $attempted,
+                          deleted: $deleted,
+                          skipped_already_gone: $skipped,
+                          failed: $failed},
+               failures: $failures}}'
+  exit $status
+fi
+
+if (( failed == 0 )); then
+  printf '**Purge complete**\n\n'
+else
+  printf '**Purge finished with errors**\n\n'
+fi
+printf -- '- **project:** %s\n' "$project"
+printf -- '- **manifest:** %s\n' "$manifest_path"
+printf -- '- **log:** %s\n' "$log_path"
+printf -- '- **plan:** %s\n' "$plan_count"
+printf -- '- **attempted:** %s\n' "$attempted"
+printf -- '- **deleted:** %s\n' "$deleted"
+printf -- '- **skipped_already_gone:** %s\n' "$skipped_count"
+printf -- '- **failed:** %s\n' "$failed"
+if (( failed > 0 )); then
+  printf '\n## Failures\n\n'
+  printf '| SHORT_ID | ID | ERROR |\n'
+  printf '| --- | --- | --- |\n'
+  printf '%s' "$failures_json" | jq -r '.[] | [.short_id, .id, (.error | gsub("\n"; " "))] | @tsv' \
+    | sed 's/|/\\|/g; s/\t/ | /g; s/^/| /; s/$/ |/'
+fi
+exit $status

--- a/.claude/skills/cloudflare/scripts/_lib.sh
+++ b/.claude/skills/cloudflare/scripts/_lib.sh
@@ -178,8 +178,11 @@ cf_api_paginated() {
   local separator="?"
   [[ "$path" == *"?"* ]] && separator="&"
 
+  # Bare `mktemp` (no template) works on GNU coreutils but BSD / macOS
+  # `mktemp` requires either a template argument or `-t`. Pass an
+  # explicit template so this stays portable.
   local tmp
-  tmp=$(mktemp)
+  tmp=$(mktemp "${TMPDIR:-/tmp}/cf_api_paginated.XXXXXX")
   # shellcheck disable=SC2064  # $tmp expanded at trap-set time (intentional)
   trap "rm -f '$tmp' '$tmp.next'" RETURN
   printf '[]' > "$tmp"

--- a/.claude/skills/cloudflare/scripts/_lib.sh
+++ b/.claude/skills/cloudflare/scripts/_lib.sh
@@ -166,20 +166,33 @@ cf_require_account_id() {
 #   { result: [...], result_info: {page, per_page, total_pages, ...} }.
 # Do NOT call it on single-object endpoints (e.g. /user/tokens/verify) —
 # use cf_api directly there.
+#
+# Accumulates page results into a temp file so that neither argv nor
+# a bash variable ever holds the full (potentially multi-MB) combined
+# array — on the agentirc-dev Pages project (138 deployments @ ~2 KB
+# each) the old `jq -s 'add' <(printf …)` pattern blew past ARG_MAX
+# around page 10 with "Argument list too long".
 cf_api_paginated() {
   local path="$1"
   local per_page="${CF_PAGE_SIZE:-50}"
   local separator="?"
   [[ "$path" == *"?"* ]] && separator="&"
 
-  local page=1
-  local all_results='[]'
-  local response page_results total_pages last_info='{}'
+  local tmp
+  tmp=$(mktemp)
+  # shellcheck disable=SC2064  # $tmp expanded at trap-set time (intentional)
+  trap "rm -f '$tmp' '$tmp.next'" RETURN
+  printf '[]' > "$tmp"
 
+  local page=1 response page_results total_pages last_info='{}'
   while :; do
     response=$(cf_api "${path}${separator}per_page=${per_page}&page=${page}")
     page_results=$(printf '%s' "$response" | jq '.result // []')
-    all_results=$(jq -s 'add' <(printf '%s' "$all_results") <(printf '%s' "$page_results"))
+    # Accumulated set comes in via file (bounded by disk); single page
+    # comes in via process substitution (bounded by CF_PAGE_SIZE, so
+    # well under ARG_MAX even at per_page=50).
+    jq -s 'add' "$tmp" <(printf '%s' "$page_results") > "$tmp.next"
+    mv "$tmp.next" "$tmp"
     total_pages=$(printf '%s' "$response" | jq -r '.result_info.total_pages // 1')
     last_info=$(printf '%s' "$response" | jq '.result_info // {}')
     if (( page >= total_pages )); then
@@ -188,10 +201,16 @@ cf_api_paginated() {
     ((page++))
   done
 
+  # --slurpfile keeps the final build memory-bounded — the combined
+  # array stays on disk until jq streams it into the synthetic envelope.
   # shellcheck disable=SC2016  # single-quoted jq filter
   jq -n \
-    --argjson results "$all_results" \
+    --slurpfile results "$tmp" \
     --argjson info "$last_info" \
-    '{success: true, errors: [], messages: [], result: $results, result_info: ($info + {page: 1, total_pages: 1, count: ($results | length), total_count: ($results | length)})}'
+    '{success: true, errors: [], messages: [],
+      result: ($results[0] // []),
+      result_info: ($info + {page: 1, total_pages: 1,
+                              count: ($results[0] // [] | length),
+                              total_count: ($results[0] // [] | length)})}'
   return 0
 }

--- a/.gitignore
+++ b/.gitignore
@@ -168,6 +168,9 @@ dmypy.json
 # Claude Code scheduled-task state
 .claude/scheduled_tasks.lock
 
+# cf-pages-deployments-purge manifests (operational scratch, per-run)
+.cf-purge-manifests/
+
 # Cython debug symbols
 cython_debug/
 

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -67,10 +67,11 @@ scope from the Read table above (so `cf-whoami.sh` / `cf-zones.sh`
 still work) **plus** the Edit scopes below. Scope to the AgentCulture
 account and "All zones from an account" exactly like the read token.
 
-| Scope (CloudFlare dashboard label)       | Level | Access | Powers                                                                   |
-|------------------------------------------|-------|--------|--------------------------------------------------------------------------|
-| **Zone · Single Redirect** (All zones)  | Zone  | Edit   | `cf-redirect-create.sh` — creates the zone-level Single Redirect ruleset |
-| **Zone · DNS** (All zones)               | Zone  | Edit   | `cf-dns-create.sh` — creates a DNS record (A / AAAA / CNAME / TXT / MX / …) |
+| Scope (CloudFlare dashboard label)       | Level   | Access | Powers                                                                   |
+|------------------------------------------|---------|--------|--------------------------------------------------------------------------|
+| **Zone · Single Redirect** (All zones)  | Zone    | Edit   | `cf-redirect-create.sh` — creates the zone-level Single Redirect ruleset |
+| **Zone · DNS** (All zones)               | Zone    | Edit   | `cf-dns-create.sh` — creates a DNS record (A / AAAA / CNAME / TXT / MX / …) |
+| **Account · Cloudflare Pages**           | Account | Edit   | `cf-pages-deployment-delete.sh`, `cf-pages-deployments-purge.sh` — delete Pages deployments |
 
 Swap tokens by editing `.env`'s `CLOUDFLARE_API_TOKEN` when you're
 about to run a write script, then swap back. `.env` only stores one

--- a/tests/bats/cf-pages-deployment-delete.bats
+++ b/tests/bats/cf-pages-deployment-delete.bats
@@ -48,7 +48,6 @@ _assert_no_delete() {
 # --- dry-run, non-canonical ---
 
 @test "cf-pages-deployment-delete dry-run on non-canonical short_id prints would-DELETE, no DELETE call" {
-  cf_mock "/pages/projects/agentirc-dev?per_page" "pages_deployments_agentirc.json"
   cf_mock "/pages/projects/agentirc-dev/deployments?per_page" "pages_deployments_agentirc.json"
   cf_mock "/pages/projects/agentirc-dev" "pages_project_agentirc_detail.json"
   run bash "$WRITE_SCRIPTS/cf-pages-deployment-delete.sh" agentirc-dev bbbbbbbb
@@ -142,11 +141,14 @@ _assert_no_delete() {
 
 # --- resolution errors ---
 
-@test "cf-pages-deployment-delete exits 1 when project does not exist" {
+@test "cf-pages-deployment-delete exits 1 when project does not exist and surfaces the underlying CF error" {
   cf_mock "/pages/projects/nosuch" "pages_project_not_found.json"
   run bash "$WRITE_SCRIPTS/cf-pages-deployment-delete.sh" nosuch bbbbbbbb
   [ "$status" -eq 1 ]
-  [[ "$output" == *"Pages project not found"* ]]
+  # cf_api's own error output is preserved (not swallowed with 2>/dev/null),
+  # so both the CF-side message and our locally-added hint are visible.
+  [[ "$output" == *"Project not found"* ]]
+  [[ "$output" == *"could not resolve Pages project"* ]]
   _assert_no_delete
 }
 

--- a/tests/bats/cf-pages-deployment-delete.bats
+++ b/tests/bats/cf-pages-deployment-delete.bats
@@ -1,0 +1,160 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+setup() {
+  cf_bats_setup
+  WRITE_SCRIPTS="$SKILL_DIR/../cloudflare-write/scripts"
+  # Project-detail GET, deployments list, and DELETE all go through the
+  # same /accounts/.../pages/projects/agentirc-dev/... prefix. The stub's
+  # longest-substring-wins policy disambiguates by URL suffix.
+}
+
+_assert_no_delete() {
+  if grep -qF -- '-X	DELETE' "$BATS_TEST_TMPDIR/curl.log" 2>/dev/null; then
+    echo "expected no DELETE, but curl.log contains one:" >&2
+    cat "$BATS_TEST_TMPDIR/curl.log" >&2
+    return 1
+  fi
+  return 0
+}
+
+# --- usage errors ---
+
+@test "cf-pages-deployment-delete exits 2 when positional args missing" {
+  run bash "$WRITE_SCRIPTS/cf-pages-deployment-delete.sh"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"expected PROJECT and SHORT_ID_OR_ID"* ]]
+}
+
+@test "cf-pages-deployment-delete exits 2 on unknown flag" {
+  run bash "$WRITE_SCRIPTS/cf-pages-deployment-delete.sh" agentirc-dev bbbbbbbb --bogus
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"unknown flag"* ]]
+}
+
+@test "cf-pages-deployment-delete exits 2 on invalid project name" {
+  run bash "$WRITE_SCRIPTS/cf-pages-deployment-delete.sh" 'bad name!' bbbbbbbb
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"invalid project name"* ]]
+}
+
+@test "cf-pages-deployment-delete exits 2 on invalid deployment id (non-hex)" {
+  run bash "$WRITE_SCRIPTS/cf-pages-deployment-delete.sh" agentirc-dev 'not a real id!'
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"invalid deployment id"* ]]
+}
+
+# --- dry-run, non-canonical ---
+
+@test "cf-pages-deployment-delete dry-run on non-canonical short_id prints would-DELETE, no DELETE call" {
+  cf_mock "/pages/projects/agentirc-dev?per_page" "pages_deployments_agentirc.json"
+  cf_mock "/pages/projects/agentirc-dev/deployments?per_page" "pages_deployments_agentirc.json"
+  cf_mock "/pages/projects/agentirc-dev" "pages_project_agentirc_detail.json"
+  run bash "$WRITE_SCRIPTS/cf-pages-deployment-delete.sh" agentirc-dev bbbbbbbb
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"**Dry-run — no changes applied**"* ]]
+  [[ "$output" == *"bbbbbbbb"* ]]
+  [[ "$output" == *"**canonical:** no"* ]]
+  [[ "$output" == *"would DELETE"* ]]
+  [[ "$output" == *"/deployments/bbbbbbbb-bbbb-4bbb-bbbb-bbbbbbbbbbbb"* ]]
+  [[ "$output" != *"?force=true"* ]]
+  _assert_no_delete
+}
+
+@test "cf-pages-deployment-delete --json dry-run emits synthetic envelope" {
+  cf_mock "/pages/projects/agentirc-dev/deployments?per_page" "pages_deployments_agentirc.json"
+  cf_mock "/pages/projects/agentirc-dev" "pages_project_agentirc_detail.json"
+  run bash "$WRITE_SCRIPTS/cf-pages-deployment-delete.sh" agentirc-dev bbbbbbbb --json
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.success == true'
+  echo "$output" | jq -e '.result.dry_run == true'
+  echo "$output" | jq -e '.result.short_id == "bbbbbbbb"'
+  echo "$output" | jq -e '.result.canonical == false'
+  _assert_no_delete
+}
+
+# --- apply path, non-canonical ---
+
+@test "cf-pages-deployment-delete --apply on non-canonical DELETEs without force=true" {
+  cf_mock "/pages/projects/agentirc-dev/deployments?per_page" "pages_deployments_agentirc.json"
+  cf_mock "/pages/projects/agentirc-dev/deployments/bbbbbbbb" "pages_deployment_delete_ok.json"
+  cf_mock "/pages/projects/agentirc-dev" "pages_project_agentirc_detail.json"
+  run bash "$WRITE_SCRIPTS/cf-pages-deployment-delete.sh" agentirc-dev bbbbbbbb --apply
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"**Deployment deleted**"* ]]
+  cf_assert_called "-X	DELETE"
+  cf_assert_called "/deployments/bbbbbbbb-bbbb-4bbb-bbbb-bbbbbbbbbbbb"
+  run grep -F "?force=true" "$BATS_TEST_TMPDIR/curl.log"
+  [ "$status" -ne 0 ]
+}
+
+@test "cf-pages-deployment-delete --apply accepts full UUID too" {
+  cf_mock "/pages/projects/agentirc-dev/deployments?per_page" "pages_deployments_agentirc.json"
+  cf_mock "/pages/projects/agentirc-dev/deployments/bbbbbbbb" "pages_deployment_delete_ok.json"
+  cf_mock "/pages/projects/agentirc-dev" "pages_project_agentirc_detail.json"
+  run bash "$WRITE_SCRIPTS/cf-pages-deployment-delete.sh" agentirc-dev bbbbbbbb-bbbb-4bbb-bbbb-bbbbbbbbbbbb --apply
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"**Deployment deleted**"* ]]
+}
+
+# --- canonical guard ---
+
+@test "cf-pages-deployment-delete refuses canonical without --force-canonical (dry-run)" {
+  cf_mock "/pages/projects/agentirc-dev/deployments?per_page" "pages_deployments_agentirc.json"
+  cf_mock "/pages/projects/agentirc-dev" "pages_project_agentirc_detail.json"
+  run bash "$WRITE_SCRIPTS/cf-pages-deployment-delete.sh" agentirc-dev aaaaaaaa
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"canonical (aliased) deployment"* ]]
+  [[ "$output" == *"--force-canonical"* ]]
+  _assert_no_delete
+}
+
+@test "cf-pages-deployment-delete refuses canonical --apply without --force-canonical" {
+  cf_mock "/pages/projects/agentirc-dev/deployments?per_page" "pages_deployments_agentirc.json"
+  cf_mock "/pages/projects/agentirc-dev" "pages_project_agentirc_detail.json"
+  run bash "$WRITE_SCRIPTS/cf-pages-deployment-delete.sh" agentirc-dev aaaaaaaa --apply
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"canonical (aliased) deployment"* ]]
+  _assert_no_delete
+}
+
+@test "cf-pages-deployment-delete --force-canonical dry-run shows force=true in would-DELETE" {
+  cf_mock "/pages/projects/agentirc-dev/deployments?per_page" "pages_deployments_agentirc.json"
+  cf_mock "/pages/projects/agentirc-dev" "pages_project_agentirc_detail.json"
+  run bash "$WRITE_SCRIPTS/cf-pages-deployment-delete.sh" agentirc-dev aaaaaaaa --force-canonical
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"**canonical:** yes (force=true)"* ]]
+  [[ "$output" == *"?force=true"* ]]
+  _assert_no_delete
+}
+
+@test "cf-pages-deployment-delete --force-canonical --apply DELETEs with ?force=true" {
+  cf_mock "/pages/projects/agentirc-dev/deployments?per_page" "pages_deployments_agentirc.json"
+  cf_mock "/pages/projects/agentirc-dev/deployments/aaaaaaaa" "pages_deployment_delete_ok.json"
+  cf_mock "/pages/projects/agentirc-dev" "pages_project_agentirc_detail.json"
+  run bash "$WRITE_SCRIPTS/cf-pages-deployment-delete.sh" agentirc-dev aaaaaaaa --force-canonical --apply
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"**Deployment deleted**"* ]]
+  cf_assert_called "-X	DELETE"
+  cf_assert_called "?force=true"
+}
+
+# --- resolution errors ---
+
+@test "cf-pages-deployment-delete exits 1 when project does not exist" {
+  cf_mock "/pages/projects/nosuch" "pages_project_not_found.json"
+  run bash "$WRITE_SCRIPTS/cf-pages-deployment-delete.sh" nosuch bbbbbbbb
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"Pages project not found"* ]]
+  _assert_no_delete
+}
+
+@test "cf-pages-deployment-delete exits 1 when short_id does not match" {
+  cf_mock "/pages/projects/agentirc-dev/deployments?per_page" "pages_deployments_agentirc.json"
+  cf_mock "/pages/projects/agentirc-dev" "pages_project_agentirc_detail.json"
+  run bash "$WRITE_SCRIPTS/cf-pages-deployment-delete.sh" agentirc-dev 99999999
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"deployment not found"* ]]
+  _assert_no_delete
+}

--- a/tests/bats/cf-pages-deployments-purge.bats
+++ b/tests/bats/cf-pages-deployments-purge.bats
@@ -1,0 +1,338 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+setup() {
+  cf_bats_setup
+  WRITE_SCRIPTS="$SKILL_DIR/../cloudflare-write/scripts"
+  PURGE_SCRIPT="$WRITE_SCRIPTS/cf-pages-deployments-purge.sh"
+  # Dedicated per-test manifest dir so runs don't stomp on each other.
+  MANIFEST_DIR="$BATS_TEST_TMPDIR/manifests"
+  # Disable inter-delete sleep so apply tests don't take 10× longer than
+  # the CF mock round-trip.
+  export CF_PURGE_SLEEP=0
+}
+
+_assert_no_delete() {
+  if grep -qF -- '-X	DELETE' "$BATS_TEST_TMPDIR/curl.log" 2>/dev/null; then
+    echo "expected no DELETE, but curl.log contains one:" >&2
+    cat "$BATS_TEST_TMPDIR/curl.log" >&2
+    return 1
+  fi
+  return 0
+}
+
+# Build a signed manifest by running the plan phase against canned
+# mocks, then appending a SIGNED: line with the current UTC timestamp.
+# Emits the manifest path on stdout so callers can `manifest=$(_plan_and_sign …)`.
+_plan_and_sign() {
+  local project="${1:-agentirc-dev}"
+  shift || true
+  bash "$PURGE_SCRIPT" "$project" --manifest-dir "$MANIFEST_DIR" "$@" >/dev/null
+  local manifest
+  manifest=$(ls -1 "$MANIFEST_DIR"/*.md | head -n 1)
+  printf 'SIGNED: bats %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$manifest"
+  printf '%s' "$manifest"
+}
+
+# --- usage errors ---
+
+@test "cf-pages-deployments-purge exits 2 when PROJECT is missing" {
+  run bash "$PURGE_SCRIPT"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"expected PROJECT"* ]]
+}
+
+@test "cf-pages-deployments-purge exits 2 on unknown flag" {
+  run bash "$PURGE_SCRIPT" agentirc-dev --bogus
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"unknown flag"* ]]
+}
+
+@test "cf-pages-deployments-purge exits 2 when --apply is used without --manifest" {
+  run bash "$PURGE_SCRIPT" agentirc-dev --apply
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"--apply requires --manifest"* ]]
+}
+
+@test "cf-pages-deployments-purge exits 2 when --manifest is used without --apply" {
+  run bash "$PURGE_SCRIPT" agentirc-dev --manifest /tmp/nowhere.md
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"--manifest is only valid with --apply"* ]]
+}
+
+@test "cf-pages-deployments-purge exits 2 when --manifest path is missing its value" {
+  run bash "$PURGE_SCRIPT" agentirc-dev --manifest --apply
+  [ "$status" -eq 2 ]
+}
+
+# --- PLAN phase ---
+
+@test "purge plan writes a manifest with the non-canonical deployments" {
+  cf_mock "/pages/projects/agentirc-dev/deployments?per_page" "pages_deployments_agentirc.json"
+  cf_mock "/pages/projects/agentirc-dev" "pages_project_agentirc_detail.json"
+  run bash "$PURGE_SCRIPT" agentirc-dev --manifest-dir "$MANIFEST_DIR"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"**Manifest written — sign to apply**"* ]]
+  [[ "$output" == *"**count:** 2"* ]]
+  [[ "$output" == *"**canonical_deployment_id:** aaaaaaaa"* ]]
+  _assert_no_delete
+  # Manifest file exists and has the expected shape.
+  run ls -1 "$MANIFEST_DIR"
+  [ "$status" -eq 0 ]
+  [ -n "$output" ]
+  local manifest
+  manifest="$MANIFEST_DIR/$output"
+  run grep -c "^- \*\*project:\*\* agentirc-dev$" "$manifest"
+  [ "$status" -eq 0 ]
+  [ "$output" = "1" ]
+  run grep -c "^| bbbbbbbb | bbbbbbbb-bbbb-4bbb-bbbb-bbbbbbbbbbbb " "$manifest"
+  [ "$status" -eq 0 ]
+  [ "$output" = "1" ]
+}
+
+@test "purge plan --include-canonical records it in header and includes canonical row" {
+  cf_mock "/pages/projects/agentirc-dev/deployments?per_page" "pages_deployments_agentirc.json"
+  cf_mock "/pages/projects/agentirc-dev" "pages_project_agentirc_detail.json"
+  run bash "$PURGE_SCRIPT" agentirc-dev --manifest-dir "$MANIFEST_DIR" --include-canonical
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"**include_canonical:** true"* ]]
+  [[ "$output" == *"**count:** 3"* ]]
+  local manifest
+  manifest=$(ls -1 "$MANIFEST_DIR"/*.md | head -n 1)
+  run grep -c "^- \*\*include_canonical:\*\* true$" "$manifest"
+  [ "$status" -eq 0 ]
+  [ "$output" = "1" ]
+  # Canonical row flagged in table
+  run grep -c "^| aaaaaaaa | aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaaa .* | yes |$" "$manifest"
+  [ "$status" -eq 0 ]
+  [ "$output" = "1" ]
+}
+
+@test "purge plan --json emits structured envelope" {
+  cf_mock "/pages/projects/agentirc-dev/deployments?per_page" "pages_deployments_agentirc.json"
+  cf_mock "/pages/projects/agentirc-dev" "pages_project_agentirc_detail.json"
+  run bash "$PURGE_SCRIPT" agentirc-dev --manifest-dir "$MANIFEST_DIR" --json
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.success == true'
+  echo "$output" | jq -e '.result.dry_run == true'
+  echo "$output" | jq -e '.result.count == 2'
+  echo "$output" | jq -e '.result.manifest | test("\\.md$")'
+}
+
+@test "purge plan exits 0 with 'nothing to delete' when only canonical exists" {
+  cf_mock "/pages/projects/agentirc-dev/deployments?per_page" "pages_deployments_only_canonical.json"
+  cf_mock "/pages/projects/agentirc-dev" "pages_project_agentirc_detail.json"
+  # Fixture that lists only the canonical deployment.
+  cat > "$CF_FIXTURES_DIR/pages_deployments_only_canonical.json" <<'JSON'
+{"success":true,"errors":[],"messages":[],"result":[
+  {"id":"aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaaa","short_id":"aaaaaaaa",
+   "project_name":"agentirc-dev","environment":"production",
+   "created_on":"2025-09-01T08:00:00.000000Z",
+   "latest_stage":{"name":"deploy","status":"success"}}
+],"result_info":{"page":1,"per_page":10,"total_pages":1,"count":1,"total_count":1}}
+JSON
+  run bash "$PURGE_SCRIPT" agentirc-dev --manifest-dir "$MANIFEST_DIR"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Nothing to delete"* ]]
+  # No manifest written.
+  run ls -1 "$MANIFEST_DIR"
+  [ "$status" -ne 0 ] || [ -z "$output" ]
+  rm -f "$CF_FIXTURES_DIR/pages_deployments_only_canonical.json"
+}
+
+# --- APPLY phase: manifest validation errors ---
+
+@test "purge apply exits 1 when manifest file does not exist" {
+  run bash "$PURGE_SCRIPT" agentirc-dev --manifest /tmp/does-not-exist-$$.md --apply
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"manifest not found"* ]]
+  _assert_no_delete
+}
+
+@test "purge apply exits 1 when manifest is missing v1 header" {
+  local bad="$BATS_TEST_TMPDIR/bad.md"
+  printf 'not a manifest\n' > "$bad"
+  run bash "$PURGE_SCRIPT" agentirc-dev --manifest "$bad" --apply
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"missing v1 header"* ]]
+  _assert_no_delete
+}
+
+@test "purge apply exits 1 when manifest is unsigned" {
+  cf_mock "/pages/projects/agentirc-dev/deployments?per_page" "pages_deployments_agentirc.json"
+  cf_mock "/pages/projects/agentirc-dev" "pages_project_agentirc_detail.json"
+  # Plan, but don't sign.
+  bash "$PURGE_SCRIPT" agentirc-dev --manifest-dir "$MANIFEST_DIR" >/dev/null
+  local manifest
+  manifest=$(ls -1 "$MANIFEST_DIR"/*.md | head -n 1)
+  run bash "$PURGE_SCRIPT" agentirc-dev --manifest "$manifest" --apply
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"unsigned"* ]]
+  _assert_no_delete
+}
+
+@test "purge apply exits 1 on ambiguous (multiple SIGNED) lines" {
+  cf_mock "/pages/projects/agentirc-dev/deployments?per_page" "pages_deployments_agentirc.json"
+  cf_mock "/pages/projects/agentirc-dev" "pages_project_agentirc_detail.json"
+  local manifest
+  manifest=$(_plan_and_sign)
+  printf 'SIGNED: someone-else 2026-04-22T14:00:00Z\n' >> "$manifest"
+  run bash "$PURGE_SCRIPT" agentirc-dev --manifest "$manifest" --apply
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"ambiguous"* ]] || [[ "$output" == *"expected 1"* ]]
+  _assert_no_delete
+}
+
+@test "purge apply exits 1 when SIGNED timestamp is too old" {
+  cf_mock "/pages/projects/agentirc-dev/deployments?per_page" "pages_deployments_agentirc.json"
+  cf_mock "/pages/projects/agentirc-dev" "pages_project_agentirc_detail.json"
+  bash "$PURGE_SCRIPT" agentirc-dev --manifest-dir "$MANIFEST_DIR" >/dev/null
+  local manifest
+  manifest=$(ls -1 "$MANIFEST_DIR"/*.md | head -n 1)
+  # Sign with a very stale timestamp.
+  printf 'SIGNED: bats 2020-01-01T00:00:00Z\n' >> "$manifest"
+  run bash "$PURGE_SCRIPT" agentirc-dev --manifest "$manifest" --apply
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"expired"* ]]
+  _assert_no_delete
+}
+
+@test "purge apply exits 1 when SIGNED timestamp is far in the future" {
+  cf_mock "/pages/projects/agentirc-dev/deployments?per_page" "pages_deployments_agentirc.json"
+  cf_mock "/pages/projects/agentirc-dev" "pages_project_agentirc_detail.json"
+  bash "$PURGE_SCRIPT" agentirc-dev --manifest-dir "$MANIFEST_DIR" >/dev/null
+  local manifest
+  manifest=$(ls -1 "$MANIFEST_DIR"/*.md | head -n 1)
+  printf 'SIGNED: bats 2099-01-01T00:00:00Z\n' >> "$manifest"
+  run bash "$PURGE_SCRIPT" agentirc-dev --manifest "$manifest" --apply
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"future"* ]]
+  _assert_no_delete
+}
+
+@test "purge apply exits 1 when manifest project name differs from positional arg" {
+  cf_mock "/pages/projects/agentirc-dev/deployments?per_page" "pages_deployments_agentirc.json"
+  cf_mock "/pages/projects/agentirc-dev" "pages_project_agentirc_detail.json"
+  local manifest
+  manifest=$(_plan_and_sign)
+  run bash "$PURGE_SCRIPT" some-other-project --manifest "$manifest" --apply
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"project"* ]]
+  [[ "$output" == *"does not match"* ]]
+  _assert_no_delete
+}
+
+@test "purge apply exits 1 when ids_sha256 no longer matches the table (tampered)" {
+  cf_mock "/pages/projects/agentirc-dev/deployments?per_page" "pages_deployments_agentirc.json"
+  cf_mock "/pages/projects/agentirc-dev" "pages_project_agentirc_detail.json"
+  local manifest
+  manifest=$(_plan_and_sign)
+  # Delete one deployment row — tamper, breaks the SHA.
+  sed -i '/| bbbbbbbb | bbbbbbbb-bbbb/d' "$manifest"
+  run bash "$PURGE_SCRIPT" agentirc-dev --manifest "$manifest" --apply
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"ids_sha256 mismatch"* ]] || [[ "$output" == *"count"* ]]
+  _assert_no_delete
+}
+
+# --- APPLY phase: drift detection ---
+
+@test "purge apply detects a new non-canonical deployment and rejects" {
+  cf_mock "/pages/projects/agentirc-dev/deployments?per_page" "pages_deployments_agentirc.json"
+  cf_mock "/pages/projects/agentirc-dev" "pages_project_agentirc_detail.json"
+  local manifest
+  manifest=$(_plan_and_sign)
+  # Re-mock with the drift fixture for the apply-side re-fetch.
+  : > "$BATS_TEST_TMPDIR/mocks.txt"
+  cf_mock "/pages/projects/agentirc-dev/deployments?per_page" "pages_deployments_agentirc_drift.json"
+  cf_mock "/pages/projects/agentirc-dev" "pages_project_agentirc_detail.json"
+  run bash "$PURGE_SCRIPT" agentirc-dev --manifest "$manifest" --apply
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"new non-canonical deployment"* ]] || [[ "$output" == *"drift"* ]]
+  [[ "$output" == *"cccccccc"* ]]
+  _assert_no_delete
+}
+
+# --- APPLY phase: happy path and variants ---
+
+@test "purge apply deletes every non-canonical deployment and writes applied-log" {
+  cf_mock "/pages/projects/agentirc-dev/deployments?per_page" "pages_deployments_agentirc.json"
+  cf_mock "/pages/projects/agentirc-dev" "pages_project_agentirc_detail.json"
+  local manifest
+  manifest=$(_plan_and_sign)
+  cf_mock "/pages/projects/agentirc-dev/deployments/bbbbbbbb" "pages_deployment_delete_ok.json"
+  cf_mock "/pages/projects/agentirc-dev/deployments/ffffffff" "pages_deployment_delete_ok.json"
+  run bash "$PURGE_SCRIPT" agentirc-dev --manifest "$manifest" --apply
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"**Purge complete**"* ]]
+  [[ "$output" == *"**deleted:** 2"* ]]
+  [[ "$output" == *"**failed:** 0"* ]]
+  # Two DELETE calls to the right paths.
+  cf_assert_called "-X	DELETE"
+  cf_assert_called "/deployments/bbbbbbbb-bbbb-4bbb-bbbb-bbbbbbbbbbbb"
+  cf_assert_called "/deployments/ffffffff-ffff-4fff-ffff-ffffffffffff"
+  # applied.log exists next to the manifest and records the deletes.
+  [ -f "${manifest}.applied.log" ]
+  run grep -c $'\tdeleted\t' "${manifest}.applied.log"
+  [ "$output" = "2" ]
+}
+
+@test "purge apply --include-canonical passes ?force=true on the canonical DELETE" {
+  cf_mock "/pages/projects/agentirc-dev/deployments?per_page" "pages_deployments_agentirc.json"
+  cf_mock "/pages/projects/agentirc-dev" "pages_project_agentirc_detail.json"
+  local manifest
+  manifest=$(_plan_and_sign agentirc-dev --include-canonical)
+  cf_mock "/pages/projects/agentirc-dev/deployments/aaaaaaaa" "pages_deployment_delete_ok.json"
+  cf_mock "/pages/projects/agentirc-dev/deployments/bbbbbbbb" "pages_deployment_delete_ok.json"
+  cf_mock "/pages/projects/agentirc-dev/deployments/ffffffff" "pages_deployment_delete_ok.json"
+  run bash "$PURGE_SCRIPT" agentirc-dev --manifest "$manifest" --apply
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"**deleted:** 3"* ]]
+  cf_assert_called "?force=true"
+  cf_assert_called "/deployments/aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaaa"
+}
+
+@test "purge apply halts on first DELETE failure by default" {
+  cf_mock "/pages/projects/agentirc-dev/deployments?per_page" "pages_deployments_agentirc.json"
+  cf_mock "/pages/projects/agentirc-dev" "pages_project_agentirc_detail.json"
+  local manifest
+  manifest=$(_plan_and_sign)
+  # Let the first (older, bbbbbbbb) succeed and the second (ffffffff) fail.
+  cf_mock "/pages/projects/agentirc-dev/deployments/bbbbbbbb" "pages_deployment_delete_ok.json"
+  cf_mock "/pages/projects/agentirc-dev/deployments/ffffffff" "pages_deployment_delete_err.json"
+  run bash "$PURGE_SCRIPT" agentirc-dev --manifest "$manifest" --apply
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"**deleted:** 1"* ]]
+  [[ "$output" == *"**failed:** 1"* ]]
+}
+
+@test "purge apply --continue-on-error attempts all deletes even after a failure" {
+  cf_mock "/pages/projects/agentirc-dev/deployments?per_page" "pages_deployments_agentirc.json"
+  cf_mock "/pages/projects/agentirc-dev" "pages_project_agentirc_detail.json"
+  local manifest
+  manifest=$(_plan_and_sign)
+  # bbbbbbbb fails first; ffffffff should still be attempted.
+  cf_mock "/pages/projects/agentirc-dev/deployments/bbbbbbbb" "pages_deployment_delete_err.json"
+  cf_mock "/pages/projects/agentirc-dev/deployments/ffffffff" "pages_deployment_delete_ok.json"
+  run bash "$PURGE_SCRIPT" agentirc-dev --manifest "$manifest" --apply --continue-on-error
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"**deleted:** 1"* ]]
+  [[ "$output" == *"**failed:** 1"* ]]
+  cf_assert_called "/deployments/ffffffff-ffff-4fff-ffff-ffffffffffff"
+}
+
+@test "purge apply --json emits a structured summary with failures array" {
+  cf_mock "/pages/projects/agentirc-dev/deployments?per_page" "pages_deployments_agentirc.json"
+  cf_mock "/pages/projects/agentirc-dev" "pages_project_agentirc_detail.json"
+  local manifest
+  manifest=$(_plan_and_sign)
+  cf_mock "/pages/projects/agentirc-dev/deployments/bbbbbbbb" "pages_deployment_delete_ok.json"
+  cf_mock "/pages/projects/agentirc-dev/deployments/ffffffff" "pages_deployment_delete_ok.json"
+  run bash "$PURGE_SCRIPT" agentirc-dev --manifest "$manifest" --apply --json
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.success == true'
+  echo "$output" | jq -e '.result.summary.deleted == 2'
+  echo "$output" | jq -e '.result.summary.failed == 0'
+  echo "$output" | jq -e '.result.failures | length == 0'
+}

--- a/tests/fixtures/pages_deployment_delete_err.json
+++ b/tests/fixtures/pages_deployment_delete_err.json
@@ -1,0 +1,8 @@
+{
+  "success": false,
+  "errors": [
+    {"code": 8000030, "message": "This deployment is currently active and cannot be deleted without force=true."}
+  ],
+  "messages": [],
+  "result": null
+}

--- a/tests/fixtures/pages_deployment_delete_ok.json
+++ b/tests/fixtures/pages_deployment_delete_ok.json
@@ -1,0 +1,6 @@
+{
+  "success": true,
+  "errors": [],
+  "messages": [],
+  "result": null
+}

--- a/tests/fixtures/pages_deployments_agentirc.json
+++ b/tests/fixtures/pages_deployments_agentirc.json
@@ -1,0 +1,41 @@
+{
+  "success": true,
+  "errors": [],
+  "messages": [],
+  "result": [
+    {
+      "id": "ffffffff-ffff-4fff-ffff-ffffffffffff",
+      "short_id": "ffffffff",
+      "project_id": "proj-id-agentirc-dev",
+      "project_name": "agentirc-dev",
+      "environment": "production",
+      "url": "https://ffffffff.agentirc-dev.pages.dev",
+      "created_on": "2026-04-21T12:18:20.879820Z",
+      "modified_on": "2026-04-21T12:19:17.974582Z",
+      "latest_stage": {"name": "build", "status": "failure"}
+    },
+    {
+      "id": "bbbbbbbb-bbbb-4bbb-bbbb-bbbbbbbbbbbb",
+      "short_id": "bbbbbbbb",
+      "project_id": "proj-id-agentirc-dev",
+      "project_name": "agentirc-dev",
+      "environment": "preview",
+      "url": "https://bbbbbbbb.agentirc-dev.pages.dev",
+      "created_on": "2026-03-10T09:00:00.000000Z",
+      "modified_on": "2026-03-10T09:05:00.000000Z",
+      "latest_stage": {"name": "deploy", "status": "success"}
+    },
+    {
+      "id": "aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaaa",
+      "short_id": "aaaaaaaa",
+      "project_id": "proj-id-agentirc-dev",
+      "project_name": "agentirc-dev",
+      "environment": "production",
+      "url": "https://aaaaaaaa.agentirc-dev.pages.dev",
+      "created_on": "2025-09-01T08:00:00.000000Z",
+      "modified_on": "2025-09-01T08:10:00.000000Z",
+      "latest_stage": {"name": "deploy", "status": "success"}
+    }
+  ],
+  "result_info": {"page": 1, "per_page": 10, "total_pages": 1, "count": 3, "total_count": 3}
+}

--- a/tests/fixtures/pages_deployments_agentirc_drift.json
+++ b/tests/fixtures/pages_deployments_agentirc_drift.json
@@ -1,0 +1,52 @@
+{
+  "success": true,
+  "errors": [],
+  "messages": [],
+  "result": [
+    {
+      "id": "cccccccc-cccc-4ccc-cccc-cccccccccccc",
+      "short_id": "cccccccc",
+      "project_id": "proj-id-agentirc-dev",
+      "project_name": "agentirc-dev",
+      "environment": "preview",
+      "url": "https://cccccccc.agentirc-dev.pages.dev",
+      "created_on": "2026-04-22T00:00:00.000000Z",
+      "modified_on": "2026-04-22T00:05:00.000000Z",
+      "latest_stage": {"name": "deploy", "status": "success"}
+    },
+    {
+      "id": "ffffffff-ffff-4fff-ffff-ffffffffffff",
+      "short_id": "ffffffff",
+      "project_id": "proj-id-agentirc-dev",
+      "project_name": "agentirc-dev",
+      "environment": "production",
+      "url": "https://ffffffff.agentirc-dev.pages.dev",
+      "created_on": "2026-04-21T12:18:20.879820Z",
+      "modified_on": "2026-04-21T12:19:17.974582Z",
+      "latest_stage": {"name": "build", "status": "failure"}
+    },
+    {
+      "id": "bbbbbbbb-bbbb-4bbb-bbbb-bbbbbbbbbbbb",
+      "short_id": "bbbbbbbb",
+      "project_id": "proj-id-agentirc-dev",
+      "project_name": "agentirc-dev",
+      "environment": "preview",
+      "url": "https://bbbbbbbb.agentirc-dev.pages.dev",
+      "created_on": "2026-03-10T09:00:00.000000Z",
+      "modified_on": "2026-03-10T09:05:00.000000Z",
+      "latest_stage": {"name": "deploy", "status": "success"}
+    },
+    {
+      "id": "aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaaa",
+      "short_id": "aaaaaaaa",
+      "project_id": "proj-id-agentirc-dev",
+      "project_name": "agentirc-dev",
+      "environment": "production",
+      "url": "https://aaaaaaaa.agentirc-dev.pages.dev",
+      "created_on": "2025-09-01T08:00:00.000000Z",
+      "modified_on": "2025-09-01T08:10:00.000000Z",
+      "latest_stage": {"name": "deploy", "status": "success"}
+    }
+  ],
+  "result_info": {"page": 1, "per_page": 10, "total_pages": 1, "count": 4, "total_count": 4}
+}

--- a/tests/fixtures/pages_project_agentirc_detail.json
+++ b/tests/fixtures/pages_project_agentirc_detail.json
@@ -1,0 +1,26 @@
+{
+  "success": true,
+  "errors": [],
+  "messages": [],
+  "result": {
+    "name": "agentirc-dev",
+    "id": "proj-id-agentirc-dev",
+    "subdomain": "agentirc-dev.pages.dev",
+    "domains": ["agentirc-dev.pages.dev"],
+    "production_branch": "main",
+    "canonical_deployment": {
+      "id": "aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaaa",
+      "short_id": "aaaaaaaa",
+      "environment": "production",
+      "url": "https://aaaaaaaa.agentirc-dev.pages.dev",
+      "created_on": "2025-09-01T08:00:00.000000Z"
+    },
+    "latest_deployment": {
+      "id": "ffffffff-ffff-4fff-ffff-ffffffffffff",
+      "short_id": "ffffffff",
+      "environment": "production",
+      "url": "https://ffffffff.agentirc-dev.pages.dev",
+      "created_on": "2026-04-21T12:18:20.879820Z"
+    }
+  }
+}

--- a/tests/fixtures/pages_project_not_found.json
+++ b/tests/fixtures/pages_project_not_found.json
@@ -1,0 +1,6 @@
+{
+  "success": false,
+  "errors": [{"code": 8000007, "message": "Project not found"}],
+  "messages": [],
+  "result": null
+}


### PR DESCRIPTION
## Summary

- Add `cf-pages-deployment-delete.sh` — single-deployment primitive, dry-run by default, canonical deployment protected behind `--force-canonical`.
- Add `cf-pages-deployments-purge.sh` — bulk driver gated by a signed-manifest workflow (plan → sign → apply), with drift detection, SHA-256 tamper check, 60-min signature TTL, and a persistent `.applied.log` audit trail.
- Fix `cf_api_paginated` argv blow-up: temp-file accumulator + `--slurpfile`, so listing 138-deployment projects works.

## Why a signed manifest instead of `--yes`?

"Delete all of them" is one typo from an outage. The manifest gate forces the operator to **read the concrete id list** before approving (not just acknowledge a count), creates a **reviewable artifact** (nice fit for the peer-agent model), is **time-boxed** (stale signatures can't be replayed), and is **drift-aware** (new non-canonical deployments added between plan and apply cause a hard rejection).

## Workflow

```sh
# 1. Plan — writes ./.cf-purge-manifests/<ts>-<project>.md, no API mutations
bash .claude/skills/cloudflare-write/scripts/cf-pages-deployments-purge.sh agentirc-dev

# 2. Sign — human/agent opens the manifest, reads the table, appends:
#      SIGNED: ori 2026-04-22T14:10:00Z

# 3. Apply — validates signature + drift, iterates DELETEs, writes applied.log
bash .claude/skills/cloudflare-write/scripts/cf-pages-deployments-purge.sh \
  agentirc-dev --manifest ./.cf-purge-manifests/<ts>-agentirc-dev.md --apply
```

## Test plan

- [x] `bash tests/shellcheck.sh` — 0 warnings
- [x] `bash tests/markdownlint.sh` — 0 errors
- [x] `bats tests/bats/` — 147 tests pass (37 new)
- [x] Live read-side smoke test: `cf-pages.sh agentirc-dev` now lists all 138 deployments (previously crashed with "Argument list too long")
- [x] Live plan-phase smoke test: wrote a 137-row manifest for agentirc-dev, `ids_sha256` validates
- [ ] Live apply-phase smoke test: deferred to post-merge run with the write-ops token (requires adding `Account · Cloudflare Pages · Edit` scope per SETUP.md §1.5)

## Out of scope for this PR

- **Deleting the Pages project itself** — follow-up PR (`cf-pages-project-delete.sh`). Leaving a zero-deployment project behind is safe.
- **`agentirc.dev` zone DNS cleanup** — independent decision; the zone still serves the `→ culture.dev` redirect correctly after the deployments are gone.

Closes #1.

- Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)