### PR TITLE
Checkbox + canary approval gate for Pages deployments purge

### DIFF
--- a/.claude/skills/cloudflare-write/SKILL.md
+++ b/.claude/skills/cloudflare-write/SKILL.md
@@ -193,28 +193,32 @@ script exits `1` with a refusal message. Override with
 `--force-canonical`, which maps to `?force=true` on the CF DELETE
 endpoint.
 
-### 3.4 cf-pages-deployments-purge.sh (signed-manifest workflow)
+### 3.4 cf-pages-deployments-purge.sh (tick + sign manifest workflow)
 
-Bulk-deletes every non-canonical deployment in a Pages project. This
-is the script to reach for when a project has accumulated hundreds of
-historical deployments (issue #1: `agentirc-dev` had 138).
+Bulk-deletes Pages deployments in a project. Reach for this when a
+project has accumulated hundreds of historical deployments
+(issue #1: `agentirc-dev` had 138).
 
-Because "delete all of them" is one typo away from an outage, this
-script has a **three-phase signed-manifest workflow** that no other
-write script in this skill uses:
+"Delete all of them" is one typo from an outage, so the apply path is
+gated by a **three-phase manifest workflow** nothing else in this
+skill uses:
 
-1. **Plan** — the default invocation with no `--apply` writes a
-   manifest file to `./.cf-purge-manifests/<ts>-<project>.md` listing
-   every deployment it would delete, plus a SHA-256 of the id list.
-   No API mutations happen. The manifest directory is gitignored at
-   the repo root.
+1. **Plan** — the default invocation (no `--apply`) writes a manifest
+   file to `./.cf-purge-manifests/<ts>-<project>.md` listing every
+   deployment it *could* delete. Each row is a GFM task-list item
+   starting `- [ ]`; at the bottom sits a **canary** row whose random
+   22-char alnum string also lives in the `canary:` header. No API
+   mutations happen. The manifest directory is gitignored at the repo
+   root.
 
    ```sh
    bash .claude/skills/cloudflare-write/scripts/cf-pages-deployments-purge.sh agentirc-dev
    ```
 
-2. **Sign** — a human or peer agent opens the manifest, **reads the
-   deployment table**, and appends exactly one line at the bottom:
+2. **Tick + sign** — open the manifest, read each row, and change
+   `- [ ]` to `- [x]` for every deployment you actually want deleted.
+   **Leave the canary row under `## Canary` untouched.** Then append
+   exactly one signature line at the bottom:
 
    ```text
    SIGNED: <your-name-or-agent-id> <ISO-8601-UTC-timestamp>
@@ -225,11 +229,18 @@ write script in this skill uses:
 
 3. **Apply** — re-run the script with `--manifest <path> --apply`.
    Before any DELETE fires, the script:
-   - validates the v1 header, `ids_sha256`, project + account match,
+   - validates the v2 header, `canary:` field, `ids_sha256`, and
+     project + account match,
    - validates the `SIGNED:` line (exactly one, well-formed, fresh),
+   - verifies the canary row is present exactly once, its string
+     matches the header, and its checkbox is untouched (the
+     "sed-replace all `[ ]` with `[x]`" shortcut ticks the canary too
+     and aborts the whole apply),
+   - refuses if **no deployment boxes are ticked** — that implies the
+     operator forgot step 2, not that they want a no-op,
    - **re-fetches live state** and rejects on drift (any new
      non-canonical deployment added since signing), and
-   - skips any ids that are already gone (idempotent re-runs).
+   - skips any ticked ids that are already gone (idempotent re-runs).
 
    ```sh
    bash .claude/skills/cloudflare-write/scripts/cf-pages-deployments-purge.sh \
@@ -263,16 +274,30 @@ completed with zero failures; `1` API error / manifest validation
 failure / signature invalid / drift detected / any failed DELETE;
 `2` usage error.
 
-**Why a manifest instead of a `--yes` flag?** Four reasons:
+**Why tick + canary on top of signing?** The signed-manifest layer
+answers "is this approval fresh and matching live state?"; the
+tick + canary layer answers "which items did the operator *actually*
+pick, and did they review each one?"
 
-1. Forces the operator to **read the concrete list** of ids before
-   approving, rather than acknowledging a count.
-2. **Time-boxed** — a 60-minute-old manifest is rejected, so a stale
-   signature can't be replayed days later.
-3. **Drift-aware** — catches new deployments that appeared between
-   planning and applying (e.g., a CI build mid-signature).
-4. **Reviewable artifact** — pairs nicely with a peer-review model
-   where one agent plans and a different agent signs.
+1. Forces the operator to **mark each deployment individually** —
+   the approval granularity is per row, not per manifest.
+2. The canary is **randomly generated at plan time** and its string
+   must match both the header and the list row, so a "tick the
+   entire manifest" shortcut (regex-replace or a distracted
+   `sed -i`) also ticks the canary, which aborts apply with zero
+   DELETEs. Per-line review is enforced, not just expected.
+3. **Reviewable artifact** — the manifest is a concrete diff a peer
+   can read and challenge before signing; pairs with
+   one-agent-plans-another-agent-signs.
+4. **Time-boxed** — a 60-minute-old signature is rejected, so stale
+   approvals can't be replayed days later.
+5. **Drift-aware** — a new non-canonical deployment appearing
+   between plan and apply causes a hard reject, not a silent skip.
+
+This pattern (per-line tick + canary) is the **repo-wide convention
+for any future bulk-destructive script**, not just this one. New
+`cf-*-delete.sh` / `cf-*-purge.sh` scripts should follow the same
+manifest shape.
 
 ## 4. Output modes
 

--- a/.claude/skills/cloudflare-write/scripts/cf-pages-deployments-purge.sh
+++ b/.claude/skills/cloudflare-write/scripts/cf-pages-deployments-purge.sh
@@ -205,6 +205,23 @@ if (( apply == 0 )); then
   ids_json=$(printf '%s' "$purge_json" | jq '[.[].id]')
   hash=$(ids_sha256 "$ids_json")
 
+  # Canary: a random 22-char alnum string that appears in BOTH the
+  # header and the canary list row. The apply path cross-checks the
+  # two and refuses to proceed if the canary list row is ticked.
+  # That defeats the lazy "sed -i 's/[ ]/[x]/g'" shortcut — ticking
+  # everything also ticks the canary, which aborts the apply.
+  #
+  # Read a fixed-size block first and slice in bash instead of piping
+  # `tr | head -c 22`. With `set -o pipefail` the second head closing
+  # the pipe SIGPIPEs tr, and the whole script exits 141.
+  _canary_alnum=$(head -c 128 /dev/urandom | LC_ALL=C tr -dc 'A-Za-z0-9')
+  canary="${_canary_alnum:0:22}"
+  if (( ${#canary} != 22 )); then
+    echo "ERROR: failed to generate a 22-char canary (entropy source starved?)" >&2
+    exit 1
+  fi
+  unset _canary_alnum
+
   # Generate an ISO-8601 UTC timestamp without colons — filenames on
   # some filesystems (especially Windows-shared mounts) don't tolerate
   # colons, so use YYYYMMDDTHHMMSSZ.
@@ -215,7 +232,7 @@ if (( apply == 0 )); then
   out_path="$manifest_dir/${ts_file}-${project}.md"
 
   {
-    printf '# cf-purge-manifest v1\n\n'
+    printf '# cf-purge-manifest v2\n\n'
     printf -- '- **project:** %s\n' "$project"
     printf -- '- **account_id:** %s\n' "$CLOUDFLARE_ACCOUNT_ID"
     printf -- '- **generated_at:** %s\n' "$ts_human"
@@ -223,16 +240,34 @@ if (( apply == 0 )); then
     printf -- '- **include_canonical:** %s\n' "$([[ $include_canonical -eq 1 ]] && echo true || echo false)"
     printf -- '- **count:** %s\n' "$purge_count"
     printf -- '- **ids_sha256:** %s\n' "$hash"
+    printf -- '- **canary:** %s\n' "$canary"
     printf '\n'
     printf '## Deployments to delete (%s)\n\n' "$purge_count"
-    printf '| SHORT_ID | ID | ENV | STATUS | CREATED | CANONICAL |\n'
-    printf '| --- | --- | --- | --- | --- | --- |\n'
-    printf '%s' "$purge_json" | jq -r '.[]
-      | [.short_id, .id, .environment, .status, .created_on,
-         (if .is_canonical then "yes" else "no" end)]
-      | @tsv' \
-      | sed 's/|/\\|/g; s/\t/ | /g; s/^/| /; s/$/ |/'
+    # shellcheck disable=SC2016  # literal backticks below wrap markdown inline code
+    printf 'Tick `- [x]` on the lines you actually want deleted. Unticked lines\n'
+    printf 'are left alone; re-plan to include them in a future manifest. Review\n'
+    printf 'each line before ticking — the canary section below catches sloppy\n'
+    printf '"tick everything" sed-replace shortcuts.\n\n'
+    # Emit each deployment as an unticked GFM task-list row.
+    # Row shape (important — the apply parser depends on it):
+    #   - [ ] **<short8>** · `<full-uuid>` · <env> · <status> · <created> [· CANONICAL]
+    # The parser regex anchors on `- [ ]` / `- [x]` + `**<short8>**` +
+    # backtick-wrapped UUID. Changing the separator changes the parser.
+    printf '%s' "$purge_json" | jq -r '.[] |
+      "- [ ] **\(.short_id)** · `\(.id)` · \(.environment) · \(.status) · \(.created_on)" +
+      (if .is_canonical then " · CANONICAL" else "" end)'
     printf '\n\n'
+    printf '## Canary — do NOT tick\n\n'
+    # shellcheck disable=SC2016  # literal backticks below wrap markdown inline code
+    printf 'This box must stay unchecked. It exists to defeat "sed-replace all\n'
+    # shellcheck disable=SC2016  # literal backticks below wrap markdown inline code
+    printf '`[ ]` with `[x]`" shortcuts that skip per-line review. If it is\n'
+    printf 'ticked at apply-time, the purge is refused and zero deletions occur.\n'
+    # shellcheck disable=SC2016  # literal backticks wrap markdown inline code
+    printf 'The random string matches the `canary:` header value above; editing\n'
+    printf 'one without the other is detected and rejected.\n\n'
+    # shellcheck disable=SC2016  # literal backticks wrap the canary string
+    printf -- '- [ ] `%s`\n\n' "$canary"
     printf '## Signature\n\n'
     printf 'To approve this purge, append a single line below exactly like:\n\n'
     printf '    SIGNED: <your-name-or-agent-id> <ISO-8601-UTC-timestamp>\n\n'
@@ -243,7 +278,10 @@ if (( apply == 0 )); then
     printf -- '- **Exactly one** `SIGNED:` line; multiples are rejected as ambiguous.\n'
     printf -- '- Timestamp must be within the last %s seconds at apply-time (clock-skew future cap: 5 min).\n' "${CF_PURGE_SIG_TTL:-3600}"
     # shellcheck disable=SC2016  # literal backticks below wrap markdown inline code
-    printf -- '- The `ids_sha256` above must still match both the table below and the live deployment set.\n'
+    printf -- '- The `ids_sha256` above must still match both the deployment list and the live set.\n'
+    # shellcheck disable=SC2016  # literal backticks below wrap markdown inline code
+    printf -- '- The canary row must be untouched (`- [ ]`) and match the `canary:` header.\n'
+    printf -- '- At least one deployment line must be ticked.\n'
     printf -- '- No new non-canonical deployments may have been added since signing.\n\n'
     printf '<!-- sign on the line below -->\n'
   } > "$out_path"
@@ -254,32 +292,36 @@ if (( apply == 0 )); then
       --arg project "$project" \
       --arg manifest "$out_path" \
       --arg hash "$hash" \
+      --arg canary "$canary" \
       --arg canonical_id "$canonical_id" \
       --argjson include_canonical "$include_canonical" \
       --argjson count "$purge_count" \
-      '{success: true, errors: [], messages: ["dry-run: manifest written, sign to apply"],
+      '{success: true, errors: [], messages: ["dry-run: manifest written, tick + sign to apply"],
         result: {dry_run: true, project: $project, manifest: $manifest,
-                 count: $count, ids_sha256: $hash,
+                 count: $count, ids_sha256: $hash, canary: $canary,
                  canonical_deployment_id: $canonical_id,
                  include_canonical: ($include_canonical == 1)}}'
     exit 0
   fi
 
-  printf '**Manifest written — sign to apply**\n\n'
+  printf '**Manifest written — tick + sign to apply**\n\n'
   printf -- '- **project:** %s\n' "$project"
   printf -- '- **canonical_deployment_id:** %s\n' "${canonical_id:-—}"
   printf -- '- **include_canonical:** %s\n' "$([[ $include_canonical -eq 1 ]] && echo true || echo false)"
   printf -- '- **count:** %s\n' "$purge_count"
   printf -- '- **manifest:** %s\n' "$out_path"
   printf -- '- **ids_sha256:** %s\n' "$hash"
+  printf -- '- **canary:** %s\n' "$canary"
   printf '\n'
   printf 'Next steps:\n\n'
   # shellcheck disable=SC2016  # literal backticks below wrap markdown inline code
   printf '1. Open `%s` and inspect the deployment list.\n' "$out_path"
   # shellcheck disable=SC2016  # literal backticks below wrap markdown inline code
-  printf '2. Append a single line: `SIGNED: <name> <ISO-UTC-timestamp>`.\n'
+  printf '2. Tick `- [x]` on the lines you want deleted. Leave the canary row under `## Canary` untouched.\n'
   # shellcheck disable=SC2016  # literal backticks below wrap markdown inline code
-  printf '3. Run: `%s %s --manifest %s --apply`.\n' "$(basename "$0")" "$project" "$out_path"
+  printf '3. Append a single line: `SIGNED: <name> <ISO-UTC-timestamp>`.\n'
+  # shellcheck disable=SC2016  # literal backticks below wrap markdown inline code
+  printf '4. Run: `%s %s --manifest %s --apply`.\n' "$(basename "$0")" "$project" "$out_path"
   exit 0
 fi
 
@@ -296,9 +338,15 @@ if [[ ! -s "$manifest_path" ]]; then
   exit 1
 fi
 
-# Header sanity.
-if ! grep -q '^# cf-purge-manifest v1$' "$manifest_path"; then
-  echo "ERROR: manifest missing v1 header: $manifest_path" >&2
+# Header sanity. v1 manifests (old table format, no canary) are
+# incompatible with the task-list + canary parser below; they were
+# per-run throwaways anyway so there's nothing to migrate.
+if ! grep -q '^# cf-purge-manifest v2$' "$manifest_path"; then
+  if grep -q '^# cf-purge-manifest v1$' "$manifest_path"; then
+    echo "ERROR: manifest is v1; this script requires v2. Regenerate with the current plan command." >&2
+  else
+    echo "ERROR: manifest missing v2 header: $manifest_path" >&2
+  fi
   exit 1
 fi
 
@@ -326,6 +374,12 @@ m_canonical=$(manifest_read_kv canonical_deployment_id)
 _=$(manifest_read_kv include_canonical)
 m_count=$(manifest_read_kv count)
 m_hash=$(manifest_read_kv ids_sha256)
+m_canary=$(manifest_read_kv canary)
+
+if [[ ! "$m_canary" =~ ^[A-Za-z0-9]{22}$ ]]; then
+  echo "ERROR: manifest canary header is not a 22-char alnum string: $m_canary" >&2
+  exit 1
+fi
 
 if [[ "$m_project" != "$project" ]]; then
   echo "ERROR: manifest project ($m_project) does not match positional arg ($project)" >&2
@@ -344,16 +398,27 @@ if [[ ! "$m_hash" =~ ^[a-f0-9]{64}$ ]]; then
   exit 1
 fi
 
-# Parse the id column out of the table. Rows look like:
-#   | short | full-uuid | env | status | created | canonical |
-# Grab column 3 (1-indexed including the leading empty column from `|`).
-manifest_ids_sorted=$(awk -F' *\\| *' '
-  /^\| [a-f0-9]{8,} \| [a-f0-9-]{36} \|/ { print $3 }
-' "$manifest_path" | sort)
+# Parse the GFM task list. Rows look like:
+#   - [ ] **<short8>** · `<full-uuid>` · <env> · <status> · <created> [· CANONICAL]
+#   - [x] **<short8>** · `<full-uuid>` · …
+#
+# The regex anchors on the checkbox, the bold short_id, and the
+# backtick-wrapped UUID so we don't accidentally match the canary row
+# or any other task-list item.
+# shellcheck disable=SC2016  # literal regex anchors — backticks are grep pattern, not command substitution
+deploy_line_re='^- \[[ xX]\] \*\*[a-f0-9]{8}\*\* · `[a-f0-9-]{36}`'
+# shellcheck disable=SC2016
+approved_line_re='^- \[[xX]\] \*\*[a-f0-9]{8}\*\* · `[a-f0-9-]{36}`'
+# shellcheck disable=SC2016
+uuid_extract_re='s/^.*\*\*[a-f0-9]{8}\*\* · `([a-f0-9-]{36})`.*$/\1/'
+
+# Full superset (any tick state) — feeds the SHA tamper check + drift.
+manifest_ids_sorted=$(grep -E "$deploy_line_re" "$manifest_path" \
+  | sed -E "$uuid_extract_re" | sort)
 manifest_ids_count=$(printf '%s\n' "$manifest_ids_sorted" | grep -c . || true)
 
 if [[ "$manifest_ids_count" != "$m_count" ]]; then
-  echo "ERROR: manifest header count ($m_count) does not match parsed table rows ($manifest_ids_count)" >&2
+  echo "ERROR: manifest header count ($m_count) does not match parsed task-list rows ($manifest_ids_count)" >&2
   exit 1
 fi
 
@@ -362,8 +427,54 @@ manifest_ids_json=$(printf '%s\n' "$manifest_ids_sorted" \
   | jq -R . | jq -s 'map(select(length > 0))')
 computed_hash=$(ids_sha256 "$manifest_ids_json")
 if [[ "$computed_hash" != "$m_hash" ]]; then
-  echo "ERROR: manifest ids_sha256 mismatch — header says $m_hash but table hashes to $computed_hash" >&2
-  echo "       the manifest has been edited after generation; regenerate it." >&2
+  echo "ERROR: manifest ids_sha256 mismatch — header says $m_hash but task list hashes to $computed_hash" >&2
+  echo "       the manifest's deployment list has been edited after generation; regenerate it." >&2
+  exit 1
+fi
+
+# Approved subset — only lines whose checkbox is `[x]`. This is the
+# operator's explicit per-line approval; everything else is left alone.
+approved_ids_sorted=$(grep -E "$approved_line_re" "$manifest_path" \
+  | sed -E "$uuid_extract_re" | sort || true)
+# shellcheck disable=SC2016
+approved_ids_json=$(printf '%s\n' "$approved_ids_sorted" \
+  | jq -R . | jq -s 'map(select(length > 0))')
+approved_count=$(json_array_length "$approved_ids_json")
+
+# Canary validation: exactly one bare `- [ ] \`<alnum22>\`` row,
+# string equal to the `canary:` header, checkbox NOT ticked. Any
+# failure short-circuits with zero DELETEs. The whole point of the
+# canary is that a "sed replace all [ ] with [x]" shortcut ticks it
+# too; the apply path refusing is what makes per-line review
+# enforceable rather than just expected.
+# shellcheck disable=SC2016  # literal regex — backticks are grep pattern
+canary_line_re='^- \[[ xX]\] `[A-Za-z0-9]{22}`$'
+canary_line_count=$(grep -cE "$canary_line_re" "$manifest_path" || true)
+if [[ "$canary_line_count" != "1" ]]; then
+  echo "ERROR: manifest has $canary_line_count canary rows (expected exactly 1)" >&2
+  exit 1
+fi
+canary_line=$(grep -E "$canary_line_re" "$manifest_path")
+# Extract the 22-char string between the backticks.
+# shellcheck disable=SC2016  # literal sed pattern with backticks
+canary_on_line=$(printf '%s' "$canary_line" | sed -E 's/^.*`([A-Za-z0-9]{22})`$/\1/')
+if [[ "$canary_on_line" != "$m_canary" ]]; then
+  echo "ERROR: canary string on the canary row does not match the canary: header" >&2
+  echo "       header:      $m_canary" >&2
+  echo "       canary row:  $canary_on_line" >&2
+  echo "       both were random-generated at plan-time and must match." >&2
+  exit 1
+fi
+if [[ "$canary_line" =~ ^-\ \[[xX]\] ]]; then
+  echo "ERROR: Canary is ticked. Purge refused — someone ran a tick-everything" >&2
+  echo "       shortcut (e.g. sed -i 's/[ ]/[x]/g'). Regenerate the manifest" >&2
+  echo "       and tick each deployment individually." >&2
+  exit 1
+fi
+
+if (( approved_count == 0 )); then
+  echo "ERROR: No lines are ticked in the manifest. Tick the deployments you" >&2
+  echo "       want to delete (\`- [x]\`) and re-run apply. Nothing was deleted." >&2
   exit 1
 fi
 
@@ -471,19 +582,26 @@ if (( drift_count > 0 )); then
   exit 1
 fi
 
-# Intersection set: ids in both manifest and live. These are what we
-# actually delete. Manifest ids missing from live get skipped (already
-# gone — happens on idempotent re-runs).
+# Intersection set: ids that are both APPROVED (ticked) in the
+# manifest and still present in live. These are what we actually
+# delete. Approved ids missing from live get skipped (already gone —
+# happens on idempotent re-runs). Unticked ids aren't touched at all.
+#
+# Drift detection above operates on the full manifest superset;
+# actual deletes operate on the ticked subset. That separation is
+# intentional: the SHA check asks "was the deployment list tampered
+# with?", while the tick check asks "which of those did the operator
+# approve?".
 # shellcheck disable=SC2016
 intersect_json=$(jq -n \
   --argjson live "$live_ids_json" \
-  --argjson manifest "$manifest_ids_json" \
-  '$manifest - ($manifest - $live)')
+  --argjson approved "$approved_ids_json" \
+  '$approved - ($approved - $live)')
 # shellcheck disable=SC2016
 skipped_json=$(jq -n \
   --argjson live "$live_ids_json" \
-  --argjson manifest "$manifest_ids_json" \
-  '$manifest - $live')
+  --argjson approved "$approved_ids_json" \
+  '$approved - $live')
 
 # Enrich intersection with per-id metadata (short_id, canonical flag)
 # from live; sort oldest-first so a halt-on-error leaves recent

--- a/.claude/skills/cloudflare-write/scripts/cf-pages-deployments-purge.sh
+++ b/.claude/skills/cloudflare-write/scripts/cf-pages-deployments-purge.sh
@@ -213,11 +213,15 @@ if (( apply == 0 )); then
   #
   # Read a fixed-size block first and slice in bash instead of piping
   # `tr | head -c 22`. With `set -o pipefail` the second head closing
-  # the pipe SIGPIPEs tr, and the whole script exits 141.
-  _canary_alnum=$(head -c 128 /dev/urandom | LC_ALL=C tr -dc 'A-Za-z0-9')
+  # the pipe SIGPIPEs tr, and the whole script exits 141. Use a
+  # generous 256-byte sample so the alnum filter reliably yields at
+  # least 22 characters — 128 bytes flaked ~2% in practice
+  # (binomial(128, 62/256), P(X < 22) ≈ 3%), which was enough to break
+  # one CI run out of ~30.
+  _canary_alnum=$(head -c 256 /dev/urandom | LC_ALL=C tr -dc 'A-Za-z0-9')
   canary="${_canary_alnum:0:22}"
   if (( ${#canary} != 22 )); then
-    echo "ERROR: failed to generate a 22-char canary (entropy source starved?)" >&2
+    echo "ERROR: canary generation yielded fewer than 22 alphanumeric characters after filtering random input" >&2
     exit 1
   fi
   unset _canary_alnum
@@ -245,9 +249,11 @@ if (( apply == 0 )); then
     printf '## Deployments to delete (%s)\n\n' "$purge_count"
     # shellcheck disable=SC2016  # literal backticks below wrap markdown inline code
     printf 'Tick `- [x]` on the lines you actually want deleted. Unticked lines\n'
-    printf 'are left alone; re-plan to include them in a future manifest. Review\n'
-    printf 'each line before ticking — the canary section below catches sloppy\n'
-    printf '"tick everything" sed-replace shortcuts.\n\n'
+    printf 'are not deleted now and remain in this manifest — to delete them\n'
+    printf 'later, tick them and re-sign (or re-plan for a fresh manifest if\n'
+    printf 'the project has drifted). Review each line before ticking — the\n'
+    printf 'canary section below catches sloppy "tick everything" sed-replace\n'
+    printf 'shortcuts.\n\n'
     # Emit each deployment as an unticked GFM task-list row.
     # Row shape (important — the apply parser depends on it):
     #   - [ ] **<short8>** · `<full-uuid>` · <env> · <status> · <created> [· CANONICAL]
@@ -413,8 +419,11 @@ approved_line_re='^- \[[xX]\] \*\*[a-f0-9]{8}\*\* · `[a-f0-9-]{36}`'
 uuid_extract_re='s/^.*\*\*[a-f0-9]{8}\*\* · `([a-f0-9-]{36})`.*$/\1/'
 
 # Full superset (any tick state) — feeds the SHA tamper check + drift.
+# `|| true` so grep's "no match → exit 1" path doesn't tank the
+# script under `set -e`; the follow-up count-mismatch check below
+# reports the real problem (zero rows) with a specific message.
 manifest_ids_sorted=$(grep -E "$deploy_line_re" "$manifest_path" \
-  | sed -E "$uuid_extract_re" | sort)
+  | sed -E "$uuid_extract_re" | sort || true)
 manifest_ids_count=$(printf '%s\n' "$manifest_ids_sorted" | grep -c . || true)
 
 if [[ "$manifest_ids_count" != "$m_count" ]]; then

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -13,3 +13,8 @@ ignores:
   - "node_modules/**"
   - ".local/**"
   - ".git/**"
+  # cf-purge-manifests/ is operational scratch: manifests are machine-
+  # generated (GFM task-list format) and never committed. Without this
+  # ignore, a stale manifest on disk breaks local `bash tests/markdownlint.sh`
+  # runs even though CI never sees the file (it's gitignored).
+  - ".cf-purge-manifests/**"

--- a/tests/bats/cf-pages-deployments-purge.bats
+++ b/tests/bats/cf-pages-deployments-purge.bats
@@ -22,17 +22,49 @@ _assert_no_delete() {
   return 0
 }
 
-# Build a signed manifest by running the plan phase against canned
-# mocks, then appending a SIGNED: line with the current UTC timestamp.
-# Emits the manifest path on stdout so callers can `manifest=$(_plan_and_sign …)`.
+# Tick every deployment task-list row (`- [ ] **<8 hex>** ...`) in a
+# manifest. The canary row has a bare backtick-wrapped alnum string
+# instead of `**short8**`, so it's left untouched.
+_tick_all_non_canary() {
+  sed -i -E 's/^- \[ \] (\*\*[a-f0-9]{8}\*\*)/- [x] \1/' "$1"
+}
+
+# Tick one specific row by its short_id.
+_tick_short() {
+  sed -i -E "s/^- \[ \] (\*\*$2\*\*)/- [x] \1/" "$1"
+}
+
+# Tick the canary row (to exercise the "sed all" shortcut refusal).
+_tick_canary() {
+  sed -i -E 's/^- \[ \] (`[A-Za-z0-9]{22}`)$/- [x] \1/' "$1"
+}
+
+_sign() {
+  printf 'SIGNED: bats %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$1"
+}
+
+# Plan + tick all non-canary + sign. The helper callers from the v1
+# era expected "every deployment in the manifest is approved for
+# deletion" — preserve that behavior by ticking everything non-canary
+# here, so the body of each test still reads the way it did.
 _plan_and_sign() {
   local project="${1:-agentirc-dev}"
   shift || true
   bash "$PURGE_SCRIPT" "$project" --manifest-dir "$MANIFEST_DIR" "$@" >/dev/null
   local manifest
   manifest=$(ls -1 "$MANIFEST_DIR"/*.md | head -n 1)
-  printf 'SIGNED: bats %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$manifest"
+  _tick_all_non_canary "$manifest"
+  _sign "$manifest"
   printf '%s' "$manifest"
+}
+
+# Plan only (no tick, no sign). For tests that need a manifest in a
+# specific intermediate state (e.g. test the "no ticks" refusal).
+_plan_only() {
+  local project="${1:-agentirc-dev}"
+  shift || true
+  bash "$PURGE_SCRIPT" "$project" --manifest-dir "$MANIFEST_DIR" "$@" >/dev/null
+  ls -1 "$MANIFEST_DIR"/*.md | head -n 1
 }
 
 # --- usage errors ---
@@ -68,30 +100,43 @@ _plan_and_sign() {
 
 # --- PLAN phase ---
 
-@test "purge plan writes a manifest with the non-canonical deployments" {
+@test "purge plan writes a v2 manifest with a canary header and canary list row" {
   cf_mock "/pages/projects/agentirc-dev/deployments?per_page" "pages_deployments_agentirc.json"
   cf_mock "/pages/projects/agentirc-dev" "pages_project_agentirc_detail.json"
   run bash "$PURGE_SCRIPT" agentirc-dev --manifest-dir "$MANIFEST_DIR"
   [ "$status" -eq 0 ]
-  [[ "$output" == *"**Manifest written — sign to apply**"* ]]
+  [[ "$output" == *"**Manifest written — tick + sign to apply**"* ]]
   [[ "$output" == *"**count:** 2"* ]]
   [[ "$output" == *"**canonical_deployment_id:** aaaaaaaa"* ]]
+  [[ "$output" == *"**canary:**"* ]]
   _assert_no_delete
-  # Manifest file exists and has the expected shape.
-  run ls -1 "$MANIFEST_DIR"
-  [ "$status" -eq 0 ]
-  [ -n "$output" ]
+
   local manifest
-  manifest="$MANIFEST_DIR/$output"
-  run grep -c "^- \*\*project:\*\* agentirc-dev$" "$manifest"
+  manifest=$(ls -1 "$MANIFEST_DIR"/*.md | head -n 1)
+  # v2 header present
+  run grep -c '^# cf-purge-manifest v2$' "$manifest"
   [ "$status" -eq 0 ]
   [ "$output" = "1" ]
-  run grep -c "^| bbbbbbbb | bbbbbbbb-bbbb-4bbb-bbbb-bbbbbbbbbbbb " "$manifest"
+  # Header carries a 22-char alnum canary
+  run grep -cE '^- \*\*canary:\*\* [A-Za-z0-9]{22}$' "$manifest"
   [ "$status" -eq 0 ]
   [ "$output" = "1" ]
+  # Exactly one deployment line per row, all initially unticked
+  run grep -cE '^- \[ \] \*\*[a-f0-9]{8}\*\* · `[a-f0-9-]{36}`' "$manifest"
+  [ "$status" -eq 0 ]
+  [ "$output" = "2" ]
+  # Canary row present and unticked, backticks wrap a 22-char alnum
+  run grep -cE '^- \[ \] `[A-Za-z0-9]{22}`$' "$manifest"
+  [ "$status" -eq 0 ]
+  [ "$output" = "1" ]
+  # Canary header value matches canary list-row value
+  local h="" l=""
+  h=$(grep -E '^- \*\*canary:\*\* ' "$manifest" | sed -E 's/^- \*\*canary:\*\* //')
+  l=$(grep -E '^- \[ \] `[A-Za-z0-9]{22}`$' "$manifest" | sed -E 's/^.*`([A-Za-z0-9]{22})`$/\1/')
+  [ "$h" = "$l" ]
 }
 
-@test "purge plan --include-canonical records it in header and includes canonical row" {
+@test "purge plan --include-canonical records it in header and includes canonical task-list row" {
   cf_mock "/pages/projects/agentirc-dev/deployments?per_page" "pages_deployments_agentirc.json"
   cf_mock "/pages/projects/agentirc-dev" "pages_project_agentirc_detail.json"
   run bash "$PURGE_SCRIPT" agentirc-dev --manifest-dir "$MANIFEST_DIR" --include-canonical
@@ -103,13 +148,13 @@ _plan_and_sign() {
   run grep -c "^- \*\*include_canonical:\*\* true$" "$manifest"
   [ "$status" -eq 0 ]
   [ "$output" = "1" ]
-  # Canonical row flagged in table
-  run grep -c "^| aaaaaaaa | aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaaa .* | yes |$" "$manifest"
+  # Canonical row is in the task list and carries the CANONICAL marker
+  run grep -cE '^- \[ \] \*\*aaaaaaaa\*\* · `aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaaa` · .* · CANONICAL$' "$manifest"
   [ "$status" -eq 0 ]
   [ "$output" = "1" ]
 }
 
-@test "purge plan --json emits structured envelope" {
+@test "purge plan --json emits structured envelope with canary field" {
   cf_mock "/pages/projects/agentirc-dev/deployments?per_page" "pages_deployments_agentirc.json"
   cf_mock "/pages/projects/agentirc-dev" "pages_project_agentirc_detail.json"
   run bash "$PURGE_SCRIPT" agentirc-dev --manifest-dir "$MANIFEST_DIR" --json
@@ -118,6 +163,7 @@ _plan_and_sign() {
   echo "$output" | jq -e '.result.dry_run == true'
   echo "$output" | jq -e '.result.count == 2'
   echo "$output" | jq -e '.result.manifest | test("\\.md$")'
+  echo "$output" | jq -e '.result.canary | test("^[A-Za-z0-9]{22}$")'
 }
 
 @test "purge plan exits 0 with 'nothing to delete' when only canonical exists" {
@@ -150,22 +196,31 @@ JSON
   _assert_no_delete
 }
 
-@test "purge apply exits 1 when manifest is missing v1 header" {
+@test "purge apply exits 1 when manifest is missing v2 header" {
   local bad="$BATS_TEST_TMPDIR/bad.md"
   printf 'not a manifest\n' > "$bad"
   run bash "$PURGE_SCRIPT" agentirc-dev --manifest "$bad" --apply
   [ "$status" -eq 1 ]
-  [[ "$output" == *"missing v1 header"* ]]
+  [[ "$output" == *"missing v2 header"* ]]
+  _assert_no_delete
+}
+
+@test "purge apply surfaces v1→v2 hint when handed an old manifest" {
+  local old="$BATS_TEST_TMPDIR/v1.md"
+  printf '# cf-purge-manifest v1\n- **project:** agentirc-dev\n' > "$old"
+  run bash "$PURGE_SCRIPT" agentirc-dev --manifest "$old" --apply
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"v1"* ]]
+  [[ "$output" == *"v2"* ]]
   _assert_no_delete
 }
 
 @test "purge apply exits 1 when manifest is unsigned" {
   cf_mock "/pages/projects/agentirc-dev/deployments?per_page" "pages_deployments_agentirc.json"
   cf_mock "/pages/projects/agentirc-dev" "pages_project_agentirc_detail.json"
-  # Plan, but don't sign.
-  bash "$PURGE_SCRIPT" agentirc-dev --manifest-dir "$MANIFEST_DIR" >/dev/null
   local manifest
-  manifest=$(ls -1 "$MANIFEST_DIR"/*.md | head -n 1)
+  manifest=$(_plan_only)
+  _tick_all_non_canary "$manifest"
   run bash "$PURGE_SCRIPT" agentirc-dev --manifest "$manifest" --apply
   [ "$status" -eq 1 ]
   [[ "$output" == *"unsigned"* ]]
@@ -187,10 +242,9 @@ JSON
 @test "purge apply exits 1 when SIGNED timestamp is too old" {
   cf_mock "/pages/projects/agentirc-dev/deployments?per_page" "pages_deployments_agentirc.json"
   cf_mock "/pages/projects/agentirc-dev" "pages_project_agentirc_detail.json"
-  bash "$PURGE_SCRIPT" agentirc-dev --manifest-dir "$MANIFEST_DIR" >/dev/null
   local manifest
-  manifest=$(ls -1 "$MANIFEST_DIR"/*.md | head -n 1)
-  # Sign with a very stale timestamp.
+  manifest=$(_plan_only)
+  _tick_all_non_canary "$manifest"
   printf 'SIGNED: bats 2020-01-01T00:00:00Z\n' >> "$manifest"
   run bash "$PURGE_SCRIPT" agentirc-dev --manifest "$manifest" --apply
   [ "$status" -eq 1 ]
@@ -201,9 +255,9 @@ JSON
 @test "purge apply exits 1 when SIGNED timestamp is far in the future" {
   cf_mock "/pages/projects/agentirc-dev/deployments?per_page" "pages_deployments_agentirc.json"
   cf_mock "/pages/projects/agentirc-dev" "pages_project_agentirc_detail.json"
-  bash "$PURGE_SCRIPT" agentirc-dev --manifest-dir "$MANIFEST_DIR" >/dev/null
   local manifest
-  manifest=$(ls -1 "$MANIFEST_DIR"/*.md | head -n 1)
+  manifest=$(_plan_only)
+  _tick_all_non_canary "$manifest"
   printf 'SIGNED: bats 2099-01-01T00:00:00Z\n' >> "$manifest"
   run bash "$PURGE_SCRIPT" agentirc-dev --manifest "$manifest" --apply
   [ "$status" -eq 1 ]
@@ -223,16 +277,75 @@ JSON
   _assert_no_delete
 }
 
-@test "purge apply exits 1 when ids_sha256 no longer matches the table (tampered)" {
+@test "purge apply exits 1 when ids_sha256 no longer matches the task list (tampered)" {
   cf_mock "/pages/projects/agentirc-dev/deployments?per_page" "pages_deployments_agentirc.json"
   cf_mock "/pages/projects/agentirc-dev" "pages_project_agentirc_detail.json"
   local manifest
   manifest=$(_plan_and_sign)
-  # Delete one deployment row — tamper, breaks the SHA.
-  sed -i '/| bbbbbbbb | bbbbbbbb-bbbb/d' "$manifest"
+  # Remove one deployment row — breaks the SHA.
+  sed -i '/bbbbbbbb-bbbb-4bbb-bbbb-bbbbbbbbbbbb/d' "$manifest"
   run bash "$PURGE_SCRIPT" agentirc-dev --manifest "$manifest" --apply
   [ "$status" -eq 1 ]
   [[ "$output" == *"ids_sha256 mismatch"* ]] || [[ "$output" == *"count"* ]]
+  _assert_no_delete
+}
+
+# --- APPLY phase: canary validation ---
+
+@test "purge apply refuses to proceed when the canary row is ticked" {
+  cf_mock "/pages/projects/agentirc-dev/deployments?per_page" "pages_deployments_agentirc.json"
+  cf_mock "/pages/projects/agentirc-dev" "pages_project_agentirc_detail.json"
+  local manifest
+  manifest=$(_plan_only)
+  # Simulate the "sed -i 's/[ ]/[x]/g'" shortcut: tick everything,
+  # including the canary row.
+  sed -i -E 's/^- \[ \]/- [x]/' "$manifest"
+  _sign "$manifest"
+  run bash "$PURGE_SCRIPT" agentirc-dev --manifest "$manifest" --apply
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"Canary is ticked"* ]]
+  _assert_no_delete
+}
+
+@test "purge apply refuses when the canary line's random string is edited" {
+  cf_mock "/pages/projects/agentirc-dev/deployments?per_page" "pages_deployments_agentirc.json"
+  cf_mock "/pages/projects/agentirc-dev" "pages_project_agentirc_detail.json"
+  local manifest
+  manifest=$(_plan_and_sign)
+  # Replace the canary list row's string (but not the header), breaking
+  # the cross-check. The replacement has to be a valid 22-char alnum so
+  # the row regex still matches — otherwise the "canary line count"
+  # check would fire first with a less informative message.
+  sed -i -E 's/^(- \[ \] )`[A-Za-z0-9]{22}`$/\1`Zzzzzzzzzzzzzzzzzzzzzz`/' "$manifest"
+  run bash "$PURGE_SCRIPT" agentirc-dev --manifest "$manifest" --apply
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"canary string on the canary row does not match"* ]]
+  _assert_no_delete
+}
+
+@test "purge apply refuses when the canary row is missing" {
+  cf_mock "/pages/projects/agentirc-dev/deployments?per_page" "pages_deployments_agentirc.json"
+  cf_mock "/pages/projects/agentirc-dev" "pages_project_agentirc_detail.json"
+  local manifest
+  manifest=$(_plan_and_sign)
+  # Delete the canary list row.
+  sed -i -E '/^- \[ \] `[A-Za-z0-9]{22}`$/d' "$manifest"
+  run bash "$PURGE_SCRIPT" agentirc-dev --manifest "$manifest" --apply
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"canary rows"* ]] || [[ "$output" == *"expected exactly 1"* ]]
+  _assert_no_delete
+}
+
+@test "purge apply refuses when no deployment boxes are ticked" {
+  cf_mock "/pages/projects/agentirc-dev/deployments?per_page" "pages_deployments_agentirc.json"
+  cf_mock "/pages/projects/agentirc-dev" "pages_project_agentirc_detail.json"
+  local manifest
+  manifest=$(_plan_only)
+  # Sign but don't tick anything.
+  _sign "$manifest"
+  run bash "$PURGE_SCRIPT" agentirc-dev --manifest "$manifest" --apply
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"No lines are ticked"* ]]
   _assert_no_delete
 }
 
@@ -256,7 +369,7 @@ JSON
 
 # --- APPLY phase: happy path and variants ---
 
-@test "purge apply deletes every non-canonical deployment and writes applied-log" {
+@test "purge apply deletes every ticked deployment and writes applied-log" {
   cf_mock "/pages/projects/agentirc-dev/deployments?per_page" "pages_deployments_agentirc.json"
   cf_mock "/pages/projects/agentirc-dev" "pages_project_agentirc_detail.json"
   local manifest
@@ -276,6 +389,29 @@ JSON
   [ -f "${manifest}.applied.log" ]
   run grep -c $'\tdeleted\t' "${manifest}.applied.log"
   [ "$output" = "2" ]
+}
+
+@test "purge apply deletes ONLY the ticked subset, leaves others untouched" {
+  cf_mock "/pages/projects/agentirc-dev/deployments?per_page" "pages_deployments_agentirc.json"
+  cf_mock "/pages/projects/agentirc-dev" "pages_project_agentirc_detail.json"
+  local manifest
+  manifest=$(_plan_only)
+  # Tick only one of the two non-canonical lines. The "ffffffff" row
+  # stays unticked and must NOT receive a DELETE.
+  _tick_short "$manifest" bbbbbbbb
+  _sign "$manifest"
+  cf_mock "/pages/projects/agentirc-dev/deployments/bbbbbbbb" "pages_deployment_delete_ok.json"
+  # Intentionally do NOT mock ffffffff's DELETE — if the script tries to
+  # hit it, the stub returns a synthetic success:false and this test
+  # fails on a real DELETE attempt. Belt and suspenders: assert
+  # curl.log doesn't contain that id either.
+  run bash "$PURGE_SCRIPT" agentirc-dev --manifest "$manifest" --apply
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"**deleted:** 1"* ]]
+  cf_assert_called "/deployments/bbbbbbbb-bbbb-4bbb-bbbb-bbbbbbbbbbbb"
+  # No DELETE on the unticked one.
+  run grep -F "/deployments/ffffffff-ffff-4fff-ffff-ffffffffffff" "$BATS_TEST_TMPDIR/curl.log"
+  [ "$status" -ne 0 ]
 }
 
 @test "purge apply --include-canonical passes ?force=true on the canonical DELETE" {


### PR DESCRIPTION
## Summary

Adds per-line explicit approval on top of the signed-manifest workflow from #12. Bumps the manifest from v1 to v2:

- **Plan** emits each deployment as a GFM task-list row prefixed `- [ ]` (instead of a markdown table).
- A **canary** row sits at the bottom: `- [ ] \`<random-22-char-alnum>\``. The same random string lives in a new `canary:` header field.
- **Apply** deletes only `- [x]` lines. If the canary row is ticked, or its string doesn't match the header, or no lines are ticked, apply aborts with zero DELETEs.

## Why a canary?

An operator (human or agent) who runs `sed -i 's/[ ]/[x]/g'` on the manifest to "tick everything" also ticks the canary, which aborts apply. This makes per-line review *enforced* — not just *expected*. Pairs cleanly with the existing signed-manifest layer:

- signature → "is this approval fresh and matching live state?"
- ticks + canary → "which items did the operator actually pick, and did they review each one?"

The feedback memory records this as the **repo-wide convention** for any future `cf-*-delete.sh` / `cf-*-purge.sh`.

## Test plan

- [x] `bash tests/shellcheck.sh` — 0 warnings
- [x] `bash tests/markdownlint.sh` — 0 errors (ignore rule added for `.cf-purge-manifests/**`)
- [x] `bats tests/bats/` — **153 tests pass** (29 for purge, 6 new over v1):
  - v1 manifest rejected with v1→v2 hint
  - canary ticked → refused, zero DELETE
  - canary string edited (not matching header) → refused
  - canary row missing → refused
  - zero boxes ticked → refused
  - partial tick → only ticked rows DELETE'd, others untouched
  - all other v1-era cases still pass
- [x] Live plan-phase smoke test: 137-row v2 manifest generated for `agentirc-dev`, canary header + list-row agreement verified, all rows start `- [ ]`.
- [ ] Live apply-phase smoke: done post-merge when we actually clean up `agentirc-dev`.

## Files changed

- `.claude/skills/cloudflare-write/scripts/cf-pages-deployments-purge.sh` — v2 writer + parser rewrite
- `tests/bats/cf-pages-deployments-purge.bats` — +6 cases, updated helpers (`_tick_all_non_canary`, `_tick_short`, `_tick_canary`, `_sign`, `_plan_only`)
- `.claude/skills/cloudflare-write/SKILL.md` — updated §3.4 for tick + sign workflow
- `.markdownlint-cli2.yaml` — ignore `.cf-purge-manifests/**`

- Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)