### PR TITLE
Always pass ?force=true on purge DELETE (hotfix for #1 live halt)

### DIFF
--- a/.claude/skills/cloudflare-write/SKILL.md
+++ b/.claude/skills/cloudflare-write/SKILL.md
@@ -254,10 +254,12 @@ stdout-only.
 Flags:
 
 - `--include-canonical` — (plan only) include the canonical
-  deployment in the manifest. Canonical is aliased to
-  `<project>.pages.dev`, so its DELETE uses `?force=true`. The flag
-  is recorded in the manifest header so the operator signs the
-  canonical-inclusion decision explicitly.
+  deployment in the manifest. The flag is recorded in the manifest
+  header so the operator signs the canonical-inclusion decision
+  explicitly. (Apply unconditionally sends `?force=true` on every
+  DELETE since CF Pages marks canonical **and** every per-branch
+  preview as aliased; `?force=true` is a no-op on unaliased
+  deployments. The per-row tick is the real consent gate.)
 - `--manifest PATH` — (apply only) path to the signed manifest.
 - `--manifest-dir DIR` — (plan only) override the default output
   directory (`./.cf-purge-manifests`).

--- a/.claude/skills/cloudflare-write/scripts/cf-pages-deployments-purge.sh
+++ b/.claude/skills/cloudflare-write/scripts/cf-pages-deployments-purge.sh
@@ -374,9 +374,10 @@ m_account=$(manifest_read_kv account_id)
 m_canonical=$(manifest_read_kv canonical_deployment_id)
 # include_canonical is captured here as a parsed header field but not
 # referenced again: whether canonical is in the purge set is already
-# decided by its membership in the id table, and the ?force=true flag
-# is driven by per-id `is_canonical` built from the *live* project
-# state below. Keep parsing it so a malformed header still fails fast.
+# decided by its membership in the id list. Every DELETE now passes
+# `?force=true` unconditionally (see the delete loop below), so there's
+# no downstream `is_canonical` routing to do. Parse the field anyway
+# so a malformed header fails fast.
 _=$(manifest_read_kv include_canonical)
 m_count=$(manifest_read_kv count)
 m_hash=$(manifest_read_kv ids_sha256)
@@ -652,13 +653,19 @@ failures_json='[]'
 
 sleep_s="${CF_PURGE_SLEEP:-0.25}"
 
-# Iterate the plan oldest-first.
-while IFS=$'\t' read -r d_id d_short d_env d_canonical; do
+# Iterate the plan oldest-first. Every DELETE unconditionally carries
+# `?force=true` — the CF parameter is only meaningful for aliased
+# deployments (canonical AND per-branch preview aliases like
+# `<branch>.<project>.pages.dev`) and is a no-op on unaliased ones.
+# We discovered the hard way on issue #1 that `agentirc-dev`'s preview
+# builds have branch aliases, so a force-free DELETE returns CF error
+# code 8000035 ("cannot delete an aliased deployment without
+# ?force=true"). The manifest tick is the real consent gate — if the
+# operator approved a row, that's permission to drop it regardless
+# of which CF-side alias check would normally fire.
+while IFS=$'\t' read -r d_id d_short d_env; do
   [[ -z "$d_id" ]] && continue
-  delete_path="/accounts/$CLOUDFLARE_ACCOUNT_ID/pages/projects/$project_encoded/deployments/$d_id"
-  if [[ "$d_canonical" == "true" ]]; then
-    delete_path="${delete_path}?force=true"
-  fi
+  delete_path="/accounts/$CLOUDFLARE_ACCOUNT_ID/pages/projects/$project_encoded/deployments/$d_id?force=true"
 
   # Brace group order matters: cmd >/dev/null first, then 2>&1 around
   # the group. Writing it the other way ('2>&1 >/dev/null') dup's
@@ -686,7 +693,7 @@ while IFS=$'\t' read -r d_id d_short d_env d_canonical; do
       break
     fi
   fi
-done < <(printf '%s' "$plan_json" | jq -r '.[] | [.id, .short_id, .environment, (.is_canonical|tostring)] | @tsv')
+done < <(printf '%s' "$plan_json" | jq -r '.[] | [.id, .short_id, .environment] | @tsv')
 
 {
   printf '# ---\n'

--- a/.claude/skills/cloudflare-write/scripts/cf-pages-deployments-purge.sh
+++ b/.claude/skills/cloudflare-write/scripts/cf-pages-deployments-purge.sh
@@ -27,9 +27,13 @@
 #
 # Flags:
 #   --include-canonical   include the canonical (aliased) deployment
-#                         in the manifest. The final DELETE for that
-#                         id uses ?force=true. Recorded in the
-#                         manifest header, signed explicitly.
+#                         in the manifest. Recorded in the manifest
+#                         header so the operator signs the
+#                         canonical-inclusion decision explicitly.
+#                         (Every DELETE in the apply loop carries
+#                         ?force=true unconditionally — canonical
+#                         isn't special there; see the apply-loop
+#                         comment for the reasoning.)
 #   --manifest-dir DIR    directory for the plan's manifest file
 #                         (default: ./.cf-purge-manifests)
 #   --manifest PATH       (apply only) path to a signed manifest

--- a/tests/bats/cf-pages-deployments-purge.bats
+++ b/tests/bats/cf-pages-deployments-purge.bats
@@ -391,6 +391,32 @@ JSON
   [ "$output" = "2" ]
 }
 
+@test "purge apply always sends ?force=true on EVERY DELETE (guards against issue #1 follow-up)" {
+  # CF Pages marks both the canonical deployment AND every per-branch
+  # preview deployment (aliases like `<branch>.<project>.pages.dev`)
+  # as aliased. A force-free DELETE on any of them returns CF code
+  # 8000035. The manifest-tick gate is the real consent layer, so the
+  # script unconditionally forces — this test stops a regression that
+  # would silently halt a purge partway through (which happened live
+  # on `agentirc-dev` with 41 aliased deployments in the 137-row set).
+  cf_mock "/pages/projects/agentirc-dev/deployments?per_page" "pages_deployments_agentirc.json"
+  cf_mock "/pages/projects/agentirc-dev" "pages_project_agentirc_detail.json"
+  local manifest
+  manifest=$(_plan_and_sign)
+  cf_mock "/pages/projects/agentirc-dev/deployments/bbbbbbbb" "pages_deployment_delete_ok.json"
+  cf_mock "/pages/projects/agentirc-dev/deployments/ffffffff" "pages_deployment_delete_ok.json"
+  run bash "$PURGE_SCRIPT" agentirc-dev --manifest "$manifest" --apply
+  [ "$status" -eq 0 ]
+  # Every DELETE URL in the log ends with `?force=true`. grep for any
+  # DELETE that does NOT have it → expect zero.
+  run grep -F -- '-X	DELETE' "$BATS_TEST_TMPDIR/curl.log"
+  local total_deletes="$output"
+  run grep -F -- '?force=true' "$BATS_TEST_TMPDIR/curl.log"
+  local forced_deletes="$output"
+  [ -n "$total_deletes" ]
+  [ "$(echo "$total_deletes" | wc -l)" = "$(echo "$forced_deletes" | wc -l)" ]
+}
+
 @test "purge apply deletes ONLY the ticked subset, leaves others untouched" {
   cf_mock "/pages/projects/agentirc-dev/deployments?per_page" "pages_deployments_agentirc.json"
   cf_mock "/pages/projects/agentirc-dev" "pages_project_agentirc_detail.json"

--- a/tests/bats/cf-pages-deployments-purge.bats
+++ b/tests/bats/cf-pages-deployments-purge.bats
@@ -407,14 +407,22 @@ JSON
   cf_mock "/pages/projects/agentirc-dev/deployments/ffffffff" "pages_deployment_delete_ok.json"
   run bash "$PURGE_SCRIPT" agentirc-dev --manifest "$manifest" --apply
   [ "$status" -eq 0 ]
-  # Every DELETE URL in the log ends with `?force=true`. grep for any
-  # DELETE that does NOT have it → expect zero.
-  run grep -F -- '-X	DELETE' "$BATS_TEST_TMPDIR/curl.log"
+  # Use `grep -c` directly — it reports an accurate count (0 for no
+  # match, correct non-zero exit code). The earlier `echo "$var" | wc -l`
+  # pattern would double-count a trailing newline and mask the case
+  # where there are zero DELETEs but zero ?force=true either (both
+  # pipelines would report 1). (Copilot caught this on PR #14.)
+  run grep -cF -- '-X	DELETE' "$BATS_TEST_TMPDIR/curl.log"
+  [ "$status" -eq 0 ]
   local total_deletes="$output"
-  run grep -F -- '?force=true' "$BATS_TEST_TMPDIR/curl.log"
-  local forced_deletes="$output"
-  [ -n "$total_deletes" ]
-  [ "$(echo "$total_deletes" | wc -l)" = "$(echo "$forced_deletes" | wc -l)" ]
+  [ "$total_deletes" -gt 0 ]
+  # Count DELETE lines that ALSO carry ?force=true. Filter first on
+  # DELETE so we don't false-match a ?force=true that happened to
+  # appear in some other logged curl argv (defensive — there's no
+  # such path today, but belt + suspenders).
+  run bash -c "grep -F -- '-X	DELETE' \"$BATS_TEST_TMPDIR/curl.log\" | grep -cF -- '?force=true'"
+  [ "$status" -eq 0 ]
+  [ "$total_deletes" = "$output" ]
 }
 
 @test "purge apply deletes ONLY the ticked subset, leaves others untouched" {


### PR DESCRIPTION
## Summary

**Hotfix for a live apply that halted at row 3/137 on `agentirc-dev`.** CloudFlare returned code 8000035 on a non-canonical deployment because CF Pages marks **every** per-branch preview (`<branch>.<project>.pages.dev`) as aliased, not just the canonical one. The v2 script only excluded canonical from force-free DELETEs, so any of the 40 branch-aliased previews in agentirc-dev tripped the check.

## Fix

Unconditionally append `?force=true` to every DELETE in the apply loop.

- `?force=true` is a no-op on unaliased deployments (CF only honors it to bypass the alias-safety check).
- The manifest-tick gate is the real consent layer — once the operator explicitly ticked a row, that's permission to drop it regardless of which CF-side alias check would otherwise fire.
- Simplifies the delete loop by collapsing the `if d_canonical then ?force=true` branch into a single unconditional path.

## Test plan

- [x] `bash tests/shellcheck.sh` — 0 warnings
- [x] `bash tests/markdownlint.sh` — 0 errors
- [x] `bats tests/bats/` — **154 pass** (153 + 1 new regression test: `curl.log`'s DELETE count must equal its `?force=true` count; verified to fail if I temporarily revert the script change, pass after).
- [x] All existing cases still green: canonical / non-canonical ordering / halt-on-error / --continue-on-error / partial tick / drift / --json summary.

## Out of scope

`cf-pages-deployment-delete.sh` has the same canonical-only `?force=true` logic and would hit the same CF error on a branch-aliased id. That's a separate fix — single-item deletes with an explicit id and `--apply` are narrower consent than a batch manifest, so they should grow a `--force` flag rather than always-on behavior. Filing as a follow-up.

## Operational note

The currently-signed manifest at `./.cf-purge-manifests/20260422T062700Z-agentirc-dev.md` (signed by `claude 2026-04-22T06:33:04Z`, TTL expires `07:33:04Z`) is still valid after this fix: the id set and sha256 are unchanged, and the apply path verifies manifest state, not URL shape. Merging this and rerunning apply against that same manifest will pick up the 2 already-deleted ids as "skipped_already_gone" and force-DELETE the remaining 135.

- Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)