### PR TITLE
Add cf-pages-project-create.sh — create a Pages project from a GitHub repo

### DIFF
--- a/.claude/skills/cloudflare-write/SKILL.md
+++ b/.claude/skills/cloudflare-write/SKILL.md
@@ -43,6 +43,14 @@ token**) with these *additional* scopes on top of the read scopes:
   Redirect".)
 - **Zone · DNS · Edit** (All zones from AgentCulture) —
   required by `cf-dns-create.sh`
+- **Account · Cloudflare Pages · Edit** (this account) —
+  required by `cf-pages-project-create.sh`,
+  `cf-pages-deployment-delete.sh`, and
+  `cf-pages-deployments-purge.sh`. Creating a Pages project also
+  needs the **Cloudflare Pages GitHub App** to be installed on the
+  source GitHub owner (org or user) and granted access to the
+  target repo — that's a one-time dashboard / GitHub-admin step this
+  skill cannot automate.
 
 Swap the token into `.env` when you're about to run a write script,
 then swap back. One token at a time.
@@ -78,6 +86,7 @@ Every write script in this skill follows the same shape:
 |---|---|
 | Create a Single Redirect for a zone | `bash .claude/skills/cloudflare-write/scripts/cf-redirect-create.sh FROM_HOST TO_HOST [--www] [--status=301] [--apply] [--json]` |
 | Create a DNS record in a zone | `bash .claude/skills/cloudflare-write/scripts/cf-dns-create.sh ZONE TYPE NAME CONTENT [--proxied] [--ttl=N] [--comment=STR] [--apply] [--json]` |
+| Create a Pages project connected to a GitHub repo | `bash .claude/skills/cloudflare-write/scripts/cf-pages-project-create.sh NAME GITHUB_OWNER REPO_NAME [--clone-from=PROJECT] [...] [--apply] [--json]` |
 | Delete one Pages deployment | `bash .claude/skills/cloudflare-write/scripts/cf-pages-deployment-delete.sh PROJECT SHORT_ID_OR_ID [--force-canonical] [--apply] [--json]` |
 | Bulk-delete all deployments in a Pages project | `bash .claude/skills/cloudflare-write/scripts/cf-pages-deployments-purge.sh PROJECT [...]` (two-phase, see §3.3) |
 
@@ -167,6 +176,68 @@ Idempotency key: **type + name + content**. Two A records at the
 same name with different IPs are allowed (CF supports round-robin);
 two records with identical type+name+content are refused as
 duplicates.
+
+### cf-pages-project-create.sh
+
+Creates a Cloudflare Pages project connected to a GitHub repository.
+Mirrors the build + deployment settings of an existing project when
+given `--clone-from=PROJECT`, so "spin up a second project with the
+same style as culture-dev" is one flag, not a dozen.
+
+```sh
+# Dry-run — shows the full POST body we would send, including the
+# build_config / deployment_configs lifted from culture-dev:
+bash .claude/skills/cloudflare-write/scripts/cf-pages-project-create.sh \
+  culture agentculture culture --clone-from=culture-dev
+
+# Apply for real:
+bash .claude/skills/cloudflare-write/scripts/cf-pages-project-create.sh \
+  culture agentculture culture --clone-from=culture-dev --apply
+```
+
+Positional args:
+
+- `NAME` — Pages project name, becomes `NAME.pages.dev`. Must be
+  1-58 chars, lowercase alphanumeric + hyphens, no leading/trailing
+  hyphen. Enforced locally before the POST.
+- `GITHUB_OWNER` — GitHub org or user that owns the repo
+  (e.g. `agentculture`).
+- `REPO_NAME` — repository name within that owner (e.g. `culture`).
+
+Flags:
+
+- `--clone-from=PROJECT` — copy `build_config`, `deployment_configs`,
+  and `production_branch` from an existing Pages project in the
+  same account. Individual overrides (below) still win.
+- `--production-branch=BRANCH` — git branch that produces
+  production deployments. Default `main` (or the cloned value).
+- `--build-command=CMD` — shell command CF runs to build the site.
+- `--destination-dir=DIR` — path CF uploads (relative to root-dir).
+- `--root-dir=DIR` — repo subdirectory to build from. `""` (the
+  default) means the repo root.
+- `--compatibility-date=YYYY-MM-DD` — applied to both preview and
+  production deployment configs.
+- `--build-image-version=N` — `1`, `2`, or `3` (default `3` = latest).
+- `--apply` — actually POST. Without it, dry-run.
+- `--json` — raw CloudFlare response envelope (or simulated body in
+  dry-run).
+
+Idempotency: scripts refuses to proceed if `NAME` already exists in
+the account. Pick a different name or delete the existing project.
+
+**GitHub App prerequisite.** The apply path calls
+`POST /accounts/:id/pages/projects` with the GitHub `owner` and
+`repo_name`. For this to succeed the Cloudflare Pages GitHub App
+must be installed on `GITHUB_OWNER` with access to `REPO_NAME`. If
+the dashboard UI couldn't list the repo when connecting manually,
+the API call will fail for the same underlying reason — the script
+surfaces the CF error and exits 1. The fix is a one-time
+installation/authorization step in the GitHub org admin UI, not
+something this skill can automate.
+
+Custom domains (including apex mappings like `culture.dev`) are not
+created by this script; attach them in the Pages dashboard or via a
+follow-on `cf-pages-domain-add.sh` once that lands.
 
 ### 3.3 cf-pages-deployment-delete.sh
 

--- a/.claude/skills/cloudflare-write/scripts/cf-pages-project-create.sh
+++ b/.claude/skills/cloudflare-write/scripts/cf-pages-project-create.sh
@@ -1,0 +1,297 @@
+#!/usr/bin/env bash
+# Create a Cloudflare Pages project connected to a GitHub repository.
+#
+# Usage:
+#   cf-pages-project-create.sh NAME GITHUB_OWNER REPO_NAME [flags]
+#
+# Default is DRY-RUN: verifies the account id, checks no project with
+# NAME already exists, resolves --clone-from (if given), prints the
+# JSON body that would be POSTed, and exits 0 WITHOUT mutating
+# anything. Pass --apply to actually create the project.
+#
+# Prerequisites for --apply to succeed against the live API:
+#   * CLOUDFLARE_API_TOKEN has Account · Cloudflare Pages · Edit
+#   * The Cloudflare Pages GitHub App is installed on GITHUB_OWNER and
+#     granted access to REPO_NAME. If not, the POST fails with a CF
+#     error about the repo being unreachable — that's a dashboard /
+#     GitHub-org-admin action this script cannot automate.
+#
+# Flags:
+#   --clone-from=PROJECT        copy build_config, deployment_configs,
+#                               and production_branch from an existing
+#                               Pages project in the same account.
+#                               Individual --build-command / --destination-dir /
+#                               --root-dir / --production-branch /
+#                               --compatibility-date / --build-image-version
+#                               flags override the cloned values.
+#   --production-branch=BRANCH  git branch that produces production
+#                               deployments (default: main, or cloned)
+#   --build-command=CMD         shell command CF runs to build the site
+#   --destination-dir=DIR       path (relative to root-dir) of the
+#                               built output directory CF uploads
+#   --root-dir=DIR              repo subdirectory to build from
+#                               (default: "" = repo root)
+#   --compatibility-date=DATE   YYYY-MM-DD, applied to both preview and
+#                               production deployment configs
+#   --build-image-version=N     1, 2, or 3 (default: 3 = latest)
+#   --apply                     actually POST (without it, dry-run)
+#   --json                      raw CF response envelope (or simulated
+#                               body in dry-run)
+#
+# Exits 1 on: account id missing, project name already exists,
+#   --clone-from target not found, any API error.
+# Exits 2 on usage error.
+
+set -euo pipefail
+shopt -s inherit_errexit
+
+mode=md
+apply=0
+clone_from=""
+production_branch=""
+build_command=""
+destination_dir=""
+root_dir=""
+compatibility_date=""
+build_image_version=""
+# Track whether --root-dir was explicitly passed: "" is a meaningful
+# value (repo root) that's distinct from "unset" (fall back to clone
+# or default).
+root_dir_set=0
+positional=()
+
+for arg in "$@"; do
+  case "$arg" in
+    --json)   mode=json ;;
+    --apply)  apply=1 ;;
+    --clone-from=*)           clone_from="${arg#*=}" ;;
+    --production-branch=*)    production_branch="${arg#*=}" ;;
+    --build-command=*)        build_command="${arg#*=}" ;;
+    --destination-dir=*)      destination_dir="${arg#*=}" ;;
+    --root-dir=*)             root_dir="${arg#*=}"; root_dir_set=1 ;;
+    --compatibility-date=*)   compatibility_date="${arg#*=}" ;;
+    --build-image-version=*)  build_image_version="${arg#*=}" ;;
+    -h|--help)
+      awk 'NR==1{next} /^#/{sub(/^# ?/, ""); print; next} {exit}' "$0"
+      exit 0
+      ;;
+    -*)
+      echo "ERROR: unknown flag: $arg" >&2
+      exit 2
+      ;;
+    *)
+      positional+=("$arg")
+      ;;
+  esac
+done
+
+if (( ${#positional[@]} != 3 )); then
+  echo "ERROR: expected NAME, GITHUB_OWNER, and REPO_NAME positional args, got ${#positional[@]}" >&2
+  echo "usage: cf-pages-project-create.sh NAME GITHUB_OWNER REPO_NAME [flags]" >&2
+  exit 2
+fi
+name="${positional[0]}"
+owner="${positional[1]}"
+repo="${positional[2]}"
+
+# CF Pages project names: 1-58 chars, [a-z0-9-], cannot start/end with
+# hyphen. Enforce locally so errors come from us, not a cryptic CF 400.
+if [[ ! "$name" =~ ^[a-z0-9]([a-z0-9-]{0,56}[a-z0-9])?$ ]]; then
+  echo "ERROR: invalid project name: $name" >&2
+  echo "       must be 1-58 chars, lowercase a-z 0-9 and hyphens, no leading/trailing hyphen" >&2
+  exit 2
+fi
+
+# GitHub owner / repo naming: alnum, dash, underscore, dot.
+gh_re='^[A-Za-z0-9][A-Za-z0-9._-]{0,99}$'
+for v in "$owner" "$repo"; do
+  if [[ ! "$v" =~ $gh_re ]]; then
+    echo "ERROR: invalid GitHub identifier: $v" >&2
+    exit 2
+  fi
+done
+
+if [[ -n "$production_branch" ]]; then
+  branch_re='^[A-Za-z0-9._/-]{1,255}$'
+  if [[ ! "$production_branch" =~ $branch_re ]]; then
+    echo "ERROR: invalid --production-branch: $production_branch" >&2
+    exit 2
+  fi
+fi
+
+if [[ -n "$compatibility_date" ]]; then
+  if [[ ! "$compatibility_date" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
+    echo "ERROR: --compatibility-date must be YYYY-MM-DD, got: $compatibility_date" >&2
+    exit 2
+  fi
+fi
+
+if [[ -n "$build_image_version" ]]; then
+  if [[ ! "$build_image_version" =~ ^[0-9]+$ ]] || (( 10#$build_image_version < 1 || 10#$build_image_version > 3 )); then
+    echo "ERROR: --build-image-version must be 1, 2, or 3, got: $build_image_version" >&2
+    exit 2
+  fi
+  build_image_version=$((10#$build_image_version))
+fi
+
+# shellcheck source=../../cloudflare/scripts/_lib.sh
+source "$(dirname "${BASH_SOURCE[0]}")/_lib.sh"
+cf_require_account_id
+
+# CloudFlare Pages list endpoints cap per_page at 10 — requests with
+# per_page >= 11 return code 8000024 "Invalid list options provided".
+# The shared helper defaults to 50, so override here. Respect a
+# user-supplied CF_PAGE_SIZE (the bats suite uses that to test drift).
+export CF_PAGE_SIZE="${CF_PAGE_SIZE:-10}"
+
+# Pre-flight: make sure NAME isn't already taken in this account.
+# GET a single project returns 404 (8000007 "Project not found") if
+# absent — we treat that as "ok to create". Any other error path
+# propagates via cf_api's `exit 1`.
+projects_json=$(cf_api_paginated "/accounts/$CLOUDFLARE_ACCOUNT_ID/pages/projects")
+# shellcheck disable=SC2016  # single-quoted jq filter
+existing_id=$(printf '%s' "$projects_json" | jq -r --arg n "$name" \
+  '[.result[] | select(.name == $n) | .id] | .[0] // ""')
+if [[ -n "$existing_id" ]]; then
+  echo "ERROR: Pages project '$name' already exists in this account (id=$existing_id)" >&2
+  echo "       pick a different NAME or delete the existing project first" >&2
+  exit 1
+fi
+
+# --clone-from: fetch template project so we can inherit its
+# build_config / deployment_configs / production_branch.
+cloned_build_command=""
+cloned_destination_dir=""
+cloned_root_dir=""
+cloned_production_branch=""
+cloned_compat_date=""
+cloned_build_image=""
+if [[ -n "$clone_from" ]]; then
+  # shellcheck disable=SC2016  # single-quoted jq filter
+  clone_id=$(printf '%s' "$projects_json" | jq -r --arg n "$clone_from" \
+    '[.result[] | select(.name == $n) | .id] | .[0] // ""')
+  if [[ -z "$clone_id" ]]; then
+    echo "ERROR: --clone-from project '$clone_from' not found in this account" >&2
+    exit 1
+  fi
+  clone_detail=$(cf_api "/accounts/$CLOUDFLARE_ACCOUNT_ID/pages/projects/$clone_from")
+  cloned_build_command=$(printf '%s' "$clone_detail" | jq -r '.result.build_config.build_command // ""')
+  cloned_destination_dir=$(printf '%s' "$clone_detail" | jq -r '.result.build_config.destination_dir // ""')
+  cloned_root_dir=$(printf '%s' "$clone_detail" | jq -r '.result.build_config.root_dir // ""')
+  cloned_production_branch=$(printf '%s' "$clone_detail" | jq -r '.result.production_branch // ""')
+  cloned_compat_date=$(printf '%s' "$clone_detail" | jq -r '.result.deployment_configs.production.compatibility_date // ""')
+  cloned_build_image=$(printf '%s' "$clone_detail" | jq -r '.result.deployment_configs.production.build_image_major_version // ""')
+fi
+
+# Explicit flags win over clone; clone wins over built-in defaults.
+effective_production_branch="${production_branch:-${cloned_production_branch:-main}}"
+effective_build_command="${build_command:-$cloned_build_command}"
+effective_destination_dir="${destination_dir:-$cloned_destination_dir}"
+if (( root_dir_set )); then
+  effective_root_dir="$root_dir"
+else
+  effective_root_dir="$cloned_root_dir"
+fi
+effective_compat_date="${compatibility_date:-$cloned_compat_date}"
+effective_build_image="${build_image_version:-${cloned_build_image:-3}}"
+
+# Build the POST body. Unset fields are emitted as empty-string /
+# default values — CF treats an unset build_command as "no build
+# step" (direct upload style), which is a valid state.
+# shellcheck disable=SC2016  # single-quoted jq filter
+body=$(jq -n \
+  --arg name           "$name" \
+  --arg owner          "$owner" \
+  --arg repo           "$repo" \
+  --arg prod_branch    "$effective_production_branch" \
+  --arg build_command  "$effective_build_command" \
+  --arg dest_dir       "$effective_destination_dir" \
+  --arg root_dir       "$effective_root_dir" \
+  --arg compat_date    "$effective_compat_date" \
+  --argjson build_image "$effective_build_image" \
+  '{
+    name: $name,
+    production_branch: $prod_branch,
+    source: {
+      type: "github",
+      config: {
+        owner: $owner,
+        repo_name: $repo,
+        production_branch: $prod_branch,
+        pr_comments_enabled: true,
+        deployments_enabled: true,
+        production_deployments_enabled: true,
+        preview_deployment_setting: "all",
+        preview_branch_includes: ["*"],
+        preview_branch_excludes: [],
+        path_includes: ["*"],
+        path_excludes: []
+      }
+    },
+    build_config: {
+      build_command: $build_command,
+      destination_dir: $dest_dir,
+      root_dir: $root_dir
+    },
+    deployment_configs: {
+      preview: ({
+        fail_open: true,
+        always_use_latest_compatibility_date: false,
+        build_image_major_version: $build_image,
+        usage_model: "standard"
+      } + (if $compat_date == "" then {} else {compatibility_date: $compat_date} end)),
+      production: ({
+        fail_open: true,
+        always_use_latest_compatibility_date: false,
+        build_image_major_version: $build_image,
+        usage_model: "standard"
+      } + (if $compat_date == "" then {} else {compatibility_date: $compat_date} end))
+    }
+  }')
+
+_render_summary_md() {
+  local banner="$1"
+  printf '%s\n\n' "$banner"
+  printf -- '- **name:** %s\n' "$name"
+  printf -- '- **account:** %s\n' "$CLOUDFLARE_ACCOUNT_ID"
+  printf -- '- **source:** github:%s/%s\n' "$owner" "$repo"
+  printf -- '- **production_branch:** %s\n' "$effective_production_branch"
+  printf -- '- **build_command:** %s\n' "${effective_build_command:-—}"
+  printf -- '- **destination_dir:** %s\n' "${effective_destination_dir:-—}"
+  printf -- '- **root_dir:** %s\n' "${effective_root_dir:-<repo root>}"
+  printf -- '- **compatibility_date:** %s\n' "${effective_compat_date:-<cf default>}"
+  printf -- '- **build_image_major_version:** %s\n' "$effective_build_image"
+  if [[ -n "$clone_from" ]]; then
+    printf -- '- **cloned_from:** %s\n' "$clone_from"
+  fi
+}
+
+if (( apply == 0 )); then
+  if [[ "$mode" == "json" ]]; then
+    # shellcheck disable=SC2016  # single-quoted jq filter
+    jq -n --argjson body "$body" --arg account "$CLOUDFLARE_ACCOUNT_ID" \
+      '{success: true, errors: [], messages: ["dry-run: no changes applied"],
+        result: {dry_run: true, account_id: $account, would_post: $body}}'
+    exit 0
+  fi
+  _render_summary_md "**Dry-run — no changes applied**"
+  # shellcheck disable=SC2016  # single-quoted literal backticks wrap markdown inline code
+  printf '\n**would POST** `/accounts/%s/pages/projects`:\n\n' "$CLOUDFLARE_ACCOUNT_ID"
+  printf '```json\n'
+  printf '%s\n' "$body"
+  printf '```\n'
+  exit 0
+fi
+
+response=$(cf_api "/accounts/$CLOUDFLARE_ACCOUNT_ID/pages/projects" -X POST --data-binary "$body")
+
+if [[ "$mode" == "json" ]]; then
+  printf '%s\n' "$response"
+  exit 0
+fi
+
+new_id=$(printf '%s' "$response" | jq -r '.result.id // "—"')
+subdomain=$(printf '%s' "$response" | jq -r '.result.subdomain // "—"')
+_render_summary_md "**Pages project created**"
+printf -- '- **project_id:** %s\n' "$new_id"
+printf -- '- **subdomain:** https://%s\n' "$subdomain"

--- a/.claude/skills/cloudflare-write/scripts/cf-pages-project-create.sh
+++ b/.claude/skills/cloudflare-write/scripts/cf-pages-project-create.sh
@@ -54,10 +54,16 @@ destination_dir=""
 root_dir=""
 compatibility_date=""
 build_image_version=""
-# Track whether --root-dir was explicitly passed: "" is a meaningful
-# value (repo root) that's distinct from "unset" (fall back to clone
-# or default).
+# Track whether each overridable flag was explicitly passed: "" is a
+# meaningful value (e.g. clear a cloned build_command) that's distinct
+# from "unset" (fall back to clone or built-in default). Without these
+# booleans, a plain `:-` expansion silently treats "" as "fall back".
 root_dir_set=0
+build_command_set=0
+destination_dir_set=0
+compatibility_date_set=0
+production_branch_set=0
+build_image_version_set=0
 positional=()
 
 for arg in "$@"; do
@@ -65,12 +71,12 @@ for arg in "$@"; do
     --json)   mode=json ;;
     --apply)  apply=1 ;;
     --clone-from=*)           clone_from="${arg#*=}" ;;
-    --production-branch=*)    production_branch="${arg#*=}" ;;
-    --build-command=*)        build_command="${arg#*=}" ;;
-    --destination-dir=*)      destination_dir="${arg#*=}" ;;
+    --production-branch=*)    production_branch="${arg#*=}"; production_branch_set=1 ;;
+    --build-command=*)        build_command="${arg#*=}"; build_command_set=1 ;;
+    --destination-dir=*)      destination_dir="${arg#*=}"; destination_dir_set=1 ;;
     --root-dir=*)             root_dir="${arg#*=}"; root_dir_set=1 ;;
-    --compatibility-date=*)   compatibility_date="${arg#*=}" ;;
-    --build-image-version=*)  build_image_version="${arg#*=}" ;;
+    --compatibility-date=*)   compatibility_date="${arg#*=}"; compatibility_date_set=1 ;;
+    --build-image-version=*)  build_image_version="${arg#*=}"; build_image_version_set=1 ;;
     -h|--help)
       awk 'NR==1{next} /^#/{sub(/^# ?/, ""); print; next} {exit}' "$0"
       exit 0
@@ -145,9 +151,10 @@ cf_require_account_id
 export CF_PAGE_SIZE="${CF_PAGE_SIZE:-10}"
 
 # Pre-flight: make sure NAME isn't already taken in this account.
-# GET a single project returns 404 (8000007 "Project not found") if
-# absent — we treat that as "ok to create". Any other error path
-# propagates via cf_api's `exit 1`.
+# List every Pages project via the paginated endpoint, then filter by
+# name with jq. Any API/listing error propagates via cf_api_paginated's
+# `exit 1`. The same list also serves --clone-from's existence check
+# below, so we pay one round-trip for both.
 projects_json=$(cf_api_paginated "/accounts/$CLOUDFLARE_ACCOUNT_ID/pages/projects")
 # shellcheck disable=SC2016  # single-quoted jq filter
 existing_id=$(printf '%s' "$projects_json" | jq -r --arg n "$name" \
@@ -167,14 +174,22 @@ cloned_production_branch=""
 cloned_compat_date=""
 cloned_build_image=""
 if [[ -n "$clone_from" ]]; then
+  # Existence check against the list we already fetched — no second
+  # round-trip. Use `any(...)` because we don't need the id, only
+  # confirmation that the name resolves.
   # shellcheck disable=SC2016  # single-quoted jq filter
-  clone_id=$(printf '%s' "$projects_json" | jq -r --arg n "$clone_from" \
-    '[.result[] | select(.name == $n) | .id] | .[0] // ""')
-  if [[ -z "$clone_id" ]]; then
+  if ! printf '%s' "$projects_json" | jq -e --arg n "$clone_from" \
+      'any(.result[]; .name == $n)' >/dev/null; then
     echo "ERROR: --clone-from project '$clone_from' not found in this account" >&2
     exit 1
   fi
-  clone_detail=$(cf_api "/accounts/$CLOUDFLARE_ACCOUNT_ID/pages/projects/$clone_from")
+  # URL-encode --clone-from before interpolating into the path. Project
+  # names are locally validated as lowercase alnum + hyphen for *new*
+  # projects, but existing projects may have been created via the
+  # dashboard under older, looser rules — be defensive on the lookup.
+  # shellcheck disable=SC2016  # single-quoted jq filter
+  clone_from_encoded=$(printf '%s' "$clone_from" | jq -sRr @uri)
+  clone_detail=$(cf_api "/accounts/$CLOUDFLARE_ACCOUNT_ID/pages/projects/$clone_from_encoded")
   cloned_build_command=$(printf '%s' "$clone_detail" | jq -r '.result.build_config.build_command // ""')
   cloned_destination_dir=$(printf '%s' "$clone_detail" | jq -r '.result.build_config.destination_dir // ""')
   cloned_root_dir=$(printf '%s' "$clone_detail" | jq -r '.result.build_config.root_dir // ""')
@@ -184,16 +199,21 @@ if [[ -n "$clone_from" ]]; then
 fi
 
 # Explicit flags win over clone; clone wins over built-in defaults.
-effective_production_branch="${production_branch:-${cloned_production_branch:-main}}"
-effective_build_command="${build_command:-$cloned_build_command}"
-effective_destination_dir="${destination_dir:-$cloned_destination_dir}"
-if (( root_dir_set )); then
-  effective_root_dir="$root_dir"
-else
-  effective_root_dir="$cloned_root_dir"
-fi
-effective_compat_date="${compatibility_date:-$cloned_compat_date}"
-effective_build_image="${build_image_version:-${cloned_build_image:-3}}"
+# `*_set` booleans distinguish "flag passed with empty value" (which
+# must override the clone) from "flag not passed" (fall back to
+# clone / default). A plain `:-` would conflate the two.
+if (( production_branch_set ));    then effective_production_branch="$production_branch";
+else effective_production_branch="${cloned_production_branch:-main}"; fi
+if (( build_command_set ));        then effective_build_command="$build_command";
+else effective_build_command="$cloned_build_command"; fi
+if (( destination_dir_set ));      then effective_destination_dir="$destination_dir";
+else effective_destination_dir="$cloned_destination_dir"; fi
+if (( root_dir_set ));             then effective_root_dir="$root_dir";
+else effective_root_dir="$cloned_root_dir"; fi
+if (( compatibility_date_set ));   then effective_compat_date="$compatibility_date";
+else effective_compat_date="$cloned_compat_date"; fi
+if (( build_image_version_set ));  then effective_build_image="$build_image_version";
+else effective_build_image="${cloned_build_image:-3}"; fi
 
 # Build the POST body. Unset fields are emitted as empty-string /
 # default values — CF treats an unset build_command as "no build

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,7 @@ Layout:
     _lib.sh                          # symlink → ../../cloudflare/scripts/_lib.sh (DRY)
     cf-redirect-create.sh            # create a zone Single Redirect (dry-run default, --apply to commit)
     cf-dns-create.sh                 # create a DNS record in a zone (same safety pattern)
+    cf-pages-project-create.sh       # create a Pages project from a GitHub repo, --clone-from=PROJECT lifts build/deploy config
 .claude/skills/pr-review/            # vendored from ~/.claude/skills — fetch/reply/resolve PR comments
 tests/
   bats/                              # bats-core unit tests; PATH-injected curl stub for offline mocking

--- a/tests/bats/cf-pages-project-create.bats
+++ b/tests/bats/cf-pages-project-create.bats
@@ -204,6 +204,19 @@ _assert_no_post() {
   echo "$output" | jq -e '.result.would_post.deployment_configs.production | has("compatibility_date") | not'
 }
 
+@test "cf-pages-project-create.sh explicit empty --build-command clears cloned value" {
+  cf_mock "/pages/projects?per_page"    "pages_projects_with_culture_dev.json"
+  cf_mock "/pages/projects/culture-dev" "pages_project_culture_dev_detail.json"
+  run bash "$WRITE_SCRIPTS/cf-pages-project-create.sh" culture agentculture culture \
+    --clone-from=culture-dev --build-command= --json
+  [ "$status" -eq 0 ]
+  # Explicit empty flag must beat the cloned build_command — otherwise
+  # users can't unset a cloned value short of editing the clone source.
+  echo "$output" | jq -e '.result.would_post.build_config.build_command == ""'
+  # Other cloned fields still inherited.
+  echo "$output" | jq -e '.result.would_post.build_config.destination_dir == "_site_culture"'
+}
+
 @test "cf-pages-project-create.sh --production-branch overrides default" {
   cf_mock "/pages/projects?per_page" "pages_projects_with_culture_dev.json"
   run bash "$WRITE_SCRIPTS/cf-pages-project-create.sh" culture agentculture culture \

--- a/tests/bats/cf-pages-project-create.bats
+++ b/tests/bats/cf-pages-project-create.bats
@@ -1,0 +1,214 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+setup() {
+  cf_bats_setup
+  WRITE_SCRIPTS="$SKILL_DIR/../cloudflare-write/scripts"
+}
+
+# Helper — asserts curl was NEVER invoked with `-X POST`.
+_assert_no_post() {
+  if grep -qF '	-X	POST	' "$BATS_TEST_TMPDIR/curl.log" 2>/dev/null; then
+    echo "expected no POST, but curl.log contains one:" >&2
+    cat "$BATS_TEST_TMPDIR/curl.log" >&2
+    return 1
+  fi
+  return 0
+}
+
+# --- dry-run (default, no --apply) ---
+
+@test "cf-pages-project-create.sh dry-run prints banner, source summary, and would-POST body" {
+  cf_mock "/pages/projects?per_page" "pages_projects_with_culture_dev.json"
+  run bash "$WRITE_SCRIPTS/cf-pages-project-create.sh" culture agentculture culture
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"**Dry-run — no changes applied**"* ]]
+  [[ "$output" == *"**name:** culture"* ]]
+  [[ "$output" == *"**source:** github:agentculture/culture"* ]]
+  [[ "$output" == *"**production_branch:** main"* ]]
+  [[ "$output" == *"**would POST**"* ]]
+  [[ "$output" == *'"type": "github"'* ]]
+  [[ "$output" == *'"owner": "agentculture"'* ]]
+  [[ "$output" == *'"repo_name": "culture"'* ]]
+  _assert_no_post
+}
+
+@test "cf-pages-project-create.sh dry-run --json emits synthetic envelope" {
+  cf_mock "/pages/projects?per_page" "pages_projects_with_culture_dev.json"
+  run bash "$WRITE_SCRIPTS/cf-pages-project-create.sh" culture agentculture culture --json
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.success == true'
+  echo "$output" | jq -e '.result.dry_run == true'
+  echo "$output" | jq -e '.result.account_id == "test-account-id"'
+  echo "$output" | jq -e '.result.would_post.name == "culture"'
+  echo "$output" | jq -e '.result.would_post.source.config.owner == "agentculture"'
+  echo "$output" | jq -e '.result.would_post.source.config.repo_name == "culture"'
+  echo "$output" | jq -e '.result.would_post.source.config.preview_deployment_setting == "all"'
+  [[ "$output" != *"Dry-run — no changes applied"* ]]
+  _assert_no_post
+}
+
+# --- --clone-from ---
+
+@test "cf-pages-project-create.sh --clone-from lifts build_config and compatibility_date" {
+  cf_mock "/pages/projects?per_page"        "pages_projects_with_culture_dev.json"
+  cf_mock "/pages/projects/culture-dev"     "pages_project_culture_dev_detail.json"
+  run bash "$WRITE_SCRIPTS/cf-pages-project-create.sh" culture agentculture culture \
+    --clone-from=culture-dev --json
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.result.would_post.build_config.build_command | contains("jekyll build")'
+  echo "$output" | jq -e '.result.would_post.build_config.destination_dir == "_site_culture"'
+  echo "$output" | jq -e '.result.would_post.build_config.root_dir == ""'
+  echo "$output" | jq -e '.result.would_post.deployment_configs.production.compatibility_date == "2026-04-10"'
+  echo "$output" | jq -e '.result.would_post.deployment_configs.preview.compatibility_date == "2026-04-10"'
+  echo "$output" | jq -e '.result.would_post.deployment_configs.production.build_image_major_version == 3'
+}
+
+@test "cf-pages-project-create.sh explicit --build-command overrides --clone-from" {
+  cf_mock "/pages/projects?per_page"        "pages_projects_with_culture_dev.json"
+  cf_mock "/pages/projects/culture-dev"     "pages_project_culture_dev_detail.json"
+  run bash "$WRITE_SCRIPTS/cf-pages-project-create.sh" culture agentculture culture \
+    --clone-from=culture-dev --build-command="echo override" --json
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.result.would_post.build_config.build_command == "echo override"'
+  # Other cloned fields still present.
+  echo "$output" | jq -e '.result.would_post.build_config.destination_dir == "_site_culture"'
+}
+
+@test "cf-pages-project-create.sh exits 1 when --clone-from target does not exist" {
+  cf_mock "/pages/projects?per_page" "pages_projects_with_culture_dev.json"
+  run bash "$WRITE_SCRIPTS/cf-pages-project-create.sh" culture agentculture culture \
+    --clone-from=nosuch-project
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"--clone-from project 'nosuch-project' not found"* ]]
+  _assert_no_post
+}
+
+# --- apply path ---
+
+@test "cf-pages-project-create.sh --apply POSTs the project body and reports new id" {
+  cf_mock "/pages/projects?per_page"    "pages_projects_with_culture_dev.json"
+  cf_mock "/pages/projects/culture-dev" "pages_project_culture_dev_detail.json"
+  cf_mock "/pages/projects"             "pages_project_create_ok.json"
+  run bash "$WRITE_SCRIPTS/cf-pages-project-create.sh" culture agentculture culture \
+    --clone-from=culture-dev --apply
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"**Pages project created**"* ]]
+  [[ "$output" == *"proj-id-culture-new-99999999"* ]]
+  [[ "$output" == *"https://culture.pages.dev"* ]]
+  cf_assert_called "-X	POST"
+  cf_assert_called "/accounts/test-account-id/pages/projects"
+}
+
+@test "cf-pages-project-create.sh --apply --json passes CF response envelope through" {
+  cf_mock "/pages/projects?per_page"    "pages_projects_with_culture_dev.json"
+  cf_mock "/pages/projects/culture-dev" "pages_project_culture_dev_detail.json"
+  cf_mock "/pages/projects"             "pages_project_create_ok.json"
+  run bash "$WRITE_SCRIPTS/cf-pages-project-create.sh" culture agentculture culture \
+    --clone-from=culture-dev --apply --json
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.success == true'
+  echo "$output" | jq -e '.result.id == "proj-id-culture-new-99999999"'
+  echo "$output" | jq -e '.result.subdomain == "culture.pages.dev"'
+  [[ "$output" != *"Pages project created"* ]]
+}
+
+@test "cf-pages-project-create.sh --apply sends the resolved build_command in the request body" {
+  cf_mock "/pages/projects?per_page"    "pages_projects_with_culture_dev.json"
+  cf_mock "/pages/projects/culture-dev" "pages_project_culture_dev_detail.json"
+  cf_mock "/pages/projects"             "pages_project_create_ok.json"
+  run bash "$WRITE_SCRIPTS/cf-pages-project-create.sh" culture agentculture culture \
+    --clone-from=culture-dev --apply
+  [ "$status" -eq 0 ]
+  # curl.log captures the full argv tab-separated. The --data-binary
+  # argument contains the JSON body; grep for the cloned build command.
+  grep -qF 'bundle exec jekyll build --config _config.base.yml,_config.culture.yml -d _site_culture' \
+    "$BATS_TEST_TMPDIR/curl.log"
+}
+
+# --- idempotency & errors ---
+
+@test "cf-pages-project-create.sh exits 1 when a project with NAME already exists" {
+  cf_mock "/pages/projects?per_page" "pages_projects_with_culture.json"
+  run bash "$WRITE_SCRIPTS/cf-pages-project-create.sh" culture agentculture culture --apply
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"already exists in this account"* ]]
+  [[ "$output" == *"proj-id-culture-already-exists"* ]]
+  _assert_no_post
+}
+
+@test "cf-pages-project-create.sh exits 2 when positional args are missing" {
+  run bash "$WRITE_SCRIPTS/cf-pages-project-create.sh"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"expected NAME, GITHUB_OWNER, and REPO_NAME"* ]]
+}
+
+@test "cf-pages-project-create.sh exits 2 with only two positional args" {
+  run bash "$WRITE_SCRIPTS/cf-pages-project-create.sh" culture agentculture
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"expected NAME, GITHUB_OWNER, and REPO_NAME"* ]]
+}
+
+@test "cf-pages-project-create.sh exits 2 on unknown flag" {
+  run bash "$WRITE_SCRIPTS/cf-pages-project-create.sh" culture agentculture culture --bogus
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"unknown flag"* ]]
+}
+
+@test "cf-pages-project-create.sh exits 2 on invalid project name (uppercase)" {
+  run bash "$WRITE_SCRIPTS/cf-pages-project-create.sh" Culture agentculture culture
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"invalid project name"* ]]
+}
+
+@test "cf-pages-project-create.sh exits 2 on invalid project name (leading hyphen)" {
+  run bash "$WRITE_SCRIPTS/cf-pages-project-create.sh" -culture agentculture culture
+  [ "$status" -eq 2 ]
+  # Leading hyphen gets parsed as unknown flag before the name check
+  # fires — either outcome is a usage error we want to surface.
+  [[ "$output" == *"unknown flag"* || "$output" == *"invalid project name"* ]]
+}
+
+@test "cf-pages-project-create.sh exits 2 on invalid github owner" {
+  run bash "$WRITE_SCRIPTS/cf-pages-project-create.sh" culture 'bad owner' culture
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"invalid GitHub identifier"* ]]
+}
+
+@test "cf-pages-project-create.sh exits 2 on malformed --compatibility-date" {
+  run bash "$WRITE_SCRIPTS/cf-pages-project-create.sh" culture agentculture culture \
+    --compatibility-date=2026/04/22
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"YYYY-MM-DD"* ]]
+}
+
+@test "cf-pages-project-create.sh exits 2 on --build-image-version out of range" {
+  run bash "$WRITE_SCRIPTS/cf-pages-project-create.sh" culture agentculture culture \
+    --build-image-version=99
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"must be 1, 2, or 3"* ]]
+}
+
+# --- overrides without --clone-from ---
+
+@test "cf-pages-project-create.sh without --clone-from uses built-in defaults" {
+  cf_mock "/pages/projects?per_page" "pages_projects_with_culture_dev.json"
+  run bash "$WRITE_SCRIPTS/cf-pages-project-create.sh" culture agentculture culture --json
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.result.would_post.production_branch == "main"'
+  echo "$output" | jq -e '.result.would_post.build_config.build_command == ""'
+  echo "$output" | jq -e '.result.would_post.build_config.root_dir == ""'
+  echo "$output" | jq -e '.result.would_post.deployment_configs.production.build_image_major_version == 3'
+  # No compatibility_date set → field omitted entirely, not emitted as ""
+  echo "$output" | jq -e '.result.would_post.deployment_configs.production | has("compatibility_date") | not'
+}
+
+@test "cf-pages-project-create.sh --production-branch overrides default" {
+  cf_mock "/pages/projects?per_page" "pages_projects_with_culture_dev.json"
+  run bash "$WRITE_SCRIPTS/cf-pages-project-create.sh" culture agentculture culture \
+    --production-branch=develop --json
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.result.would_post.production_branch == "develop"'
+  echo "$output" | jq -e '.result.would_post.source.config.production_branch == "develop"'
+}

--- a/tests/fixtures/pages_project_create_ok.json
+++ b/tests/fixtures/pages_project_create_ok.json
@@ -1,0 +1,50 @@
+{
+  "success": true,
+  "errors": [],
+  "messages": [],
+  "result": {
+    "name": "culture",
+    "id": "proj-id-culture-new-99999999",
+    "created_on": "2026-04-22T14:30:00.000000Z",
+    "subdomain": "culture.pages.dev",
+    "domains": ["culture.pages.dev"],
+    "production_branch": "main",
+    "source": {
+      "type": "github",
+      "config": {
+        "owner": "agentculture",
+        "repo_name": "culture",
+        "production_branch": "main",
+        "pr_comments_enabled": true,
+        "deployments_enabled": true,
+        "production_deployments_enabled": true,
+        "preview_deployment_setting": "all",
+        "preview_branch_includes": ["*"],
+        "preview_branch_excludes": [],
+        "path_includes": ["*"],
+        "path_excludes": []
+      }
+    },
+    "build_config": {
+      "build_command": "bundle exec jekyll build --config _config.base.yml,_config.culture.yml -d _site_culture",
+      "destination_dir": "_site_culture",
+      "root_dir": ""
+    },
+    "deployment_configs": {
+      "preview": {
+        "fail_open": true,
+        "always_use_latest_compatibility_date": false,
+        "compatibility_date": "2026-04-10",
+        "build_image_major_version": 3,
+        "usage_model": "standard"
+      },
+      "production": {
+        "fail_open": true,
+        "always_use_latest_compatibility_date": false,
+        "compatibility_date": "2026-04-10",
+        "build_image_major_version": 3,
+        "usage_model": "standard"
+      }
+    }
+  }
+}

--- a/tests/fixtures/pages_project_culture_dev_detail.json
+++ b/tests/fixtures/pages_project_culture_dev_detail.json
@@ -1,0 +1,58 @@
+{
+  "success": true,
+  "errors": [],
+  "messages": [],
+  "result": {
+    "name": "culture-dev",
+    "id": "proj-id-culture-dev",
+    "created_on": "2026-04-10T18:30:42.751466Z",
+    "subdomain": "culture-dev.pages.dev",
+    "domains": ["culture-dev.pages.dev", "culture.dev"],
+    "production_branch": "main",
+    "source": {
+      "type": "github",
+      "config": {
+        "owner": "OriNachum",
+        "owner_id": "20955789",
+        "repo_name": "culture",
+        "repo_id": "1186470444",
+        "production_branch": "main",
+        "pr_comments_enabled": true,
+        "deployments_enabled": true,
+        "production_deployments_enabled": true,
+        "preview_deployment_setting": "all",
+        "preview_branch_includes": ["*"],
+        "preview_branch_excludes": [],
+        "path_includes": ["*"],
+        "path_excludes": []
+      }
+    },
+    "build_config": {
+      "build_command": "bundle exec jekyll build --config _config.base.yml,_config.culture.yml -d _site_culture",
+      "destination_dir": "_site_culture",
+      "root_dir": "",
+      "web_analytics_tag": null,
+      "web_analytics_token": null
+    },
+    "deployment_configs": {
+      "preview": {
+        "env_vars": null,
+        "fail_open": true,
+        "always_use_latest_compatibility_date": false,
+        "compatibility_date": "2026-04-10",
+        "compatibility_flags": [],
+        "build_image_major_version": 3,
+        "usage_model": "standard"
+      },
+      "production": {
+        "env_vars": null,
+        "fail_open": true,
+        "always_use_latest_compatibility_date": false,
+        "compatibility_date": "2026-04-10",
+        "compatibility_flags": [],
+        "build_image_major_version": 3,
+        "usage_model": "standard"
+      }
+    }
+  }
+}

--- a/tests/fixtures/pages_projects_with_culture.json
+++ b/tests/fixtures/pages_projects_with_culture.json
@@ -36,5 +36,5 @@
       }
     }
   ],
-  "result_info": {"page": 1, "per_page": 20, "total_pages": 1, "count": 2, "total_count": 2}
+  "result_info": {"page": 1, "per_page": 10, "total_pages": 1, "count": 2, "total_count": 2}
 }

--- a/tests/fixtures/pages_projects_with_culture.json
+++ b/tests/fixtures/pages_projects_with_culture.json
@@ -1,0 +1,40 @@
+{
+  "success": true,
+  "errors": [],
+  "messages": [],
+  "result": [
+    {
+      "name": "culture",
+      "id": "proj-id-culture-already-exists",
+      "created_on": "2026-04-22T10:00:00.000000Z",
+      "subdomain": "culture.pages.dev",
+      "domains": ["culture.pages.dev"],
+      "production_branch": "main",
+      "source": {
+        "type": "github",
+        "config": {
+          "owner": "agentculture",
+          "repo_name": "culture",
+          "production_branch": "main"
+        }
+      }
+    },
+    {
+      "name": "culture-dev",
+      "id": "proj-id-culture-dev",
+      "created_on": "2026-04-10T18:30:42.751466Z",
+      "subdomain": "culture-dev.pages.dev",
+      "domains": ["culture-dev.pages.dev", "culture.dev"],
+      "production_branch": "main",
+      "source": {
+        "type": "github",
+        "config": {
+          "owner": "OriNachum",
+          "repo_name": "culture",
+          "production_branch": "main"
+        }
+      }
+    }
+  ],
+  "result_info": {"page": 1, "per_page": 20, "total_pages": 1, "count": 2, "total_count": 2}
+}

--- a/tests/fixtures/pages_projects_with_culture_dev.json
+++ b/tests/fixtures/pages_projects_with_culture_dev.json
@@ -36,5 +36,5 @@
       }
     }
   ],
-  "result_info": {"page": 1, "per_page": 20, "total_pages": 1, "count": 2, "total_count": 2}
+  "result_info": {"page": 1, "per_page": 10, "total_pages": 1, "count": 2, "total_count": 2}
 }

--- a/tests/fixtures/pages_projects_with_culture_dev.json
+++ b/tests/fixtures/pages_projects_with_culture_dev.json
@@ -1,0 +1,40 @@
+{
+  "success": true,
+  "errors": [],
+  "messages": [],
+  "result": [
+    {
+      "name": "culture-dev",
+      "id": "proj-id-culture-dev",
+      "created_on": "2026-04-10T18:30:42.751466Z",
+      "subdomain": "culture-dev.pages.dev",
+      "domains": ["culture-dev.pages.dev", "culture.dev"],
+      "production_branch": "main",
+      "source": {
+        "type": "github",
+        "config": {
+          "owner": "OriNachum",
+          "repo_name": "culture",
+          "production_branch": "main"
+        }
+      }
+    },
+    {
+      "name": "agentirc-dev",
+      "id": "proj-id-agentirc-dev",
+      "created_on": "2025-09-01T08:00:00.000000Z",
+      "subdomain": "agentirc-dev.pages.dev",
+      "domains": ["agentirc.dev"],
+      "production_branch": "main",
+      "source": {
+        "type": "github",
+        "config": {
+          "owner": "agentculture",
+          "repo_name": "agentirc-site",
+          "production_branch": "main"
+        }
+      }
+    }
+  ],
+  "result_info": {"page": 1, "per_page": 20, "total_pages": 1, "count": 2, "total_count": 2}
+}


### PR DESCRIPTION
## Summary

- Adds `cf-pages-project-create.sh` to the `cloudflare-write` skill — creates a Cloudflare Pages project connected to a GitHub repo, dry-run by default, `--apply` to commit.
- `--clone-from=PROJECT` lifts `build_config` / `deployment_configs` / `production_branch` from an existing Pages project, so spinning up a sibling doesn't require re-typing every build flag. Explicit `--build-command` / `--destination-dir` / `--root-dir` / `--production-branch` / `--compatibility-date` / `--build-image-version` still override.
- 19 new bats tests + 4 fixtures; full repo suite 173/173 green; shellcheck + markdownlint clean.

## Why

Dashboard UI fails when connecting a freshly-accessible GitHub org to a new Pages project (hit today trying to point a new project at `agentculture/culture` while the old one points at `OriNachum/culture`). The REST path is deterministic and scriptable, and fits the skill's existing dry-run/`--apply` mould.

The script has already been applied once: project `culture` (id `33b5b0e0-be44-48b7-9a90-14fa2e7bdbf4`) is now live, cloned from `culture-dev`, connected to `agentculture/culture` on branch `main`. Subdomain came back as `culture-72d.pages.dev` — CF auto-suffixed because `culture.pages.dev` was already claimed platform-wide; custom domain to be attached in a follow-on.

## Notable bits

- **GitHub App prerequisite** surfaced in SKILL.md: if the Cloudflare Pages GitHub App isn't installed on the source org with access to the repo, the POST fails the same way the dashboard did — not something this skill can automate.
- Pre-flight idempotency: refuses to proceed if `NAME` already exists in the account.
- Local validation: project name `[a-z0-9-]{1,58}`, GitHub identifiers, compatibility date `YYYY-MM-DD`, build image version ∈ {1,2,3}. Errors come from us, not a cryptic CF 400.
- `export CF_PAGE_SIZE="${CF_PAGE_SIZE:-10}"` — Pages list endpoint rejects `per_page > 10` (error 8000024), same workaround the read `cf-pages.sh` uses.
- Token scope addition documented: **Account · Cloudflare Pages · Edit** joins the write-token scope list in SKILL.md §1.

## Test plan

- [x] `bats tests/bats/cf-pages-project-create.bats` — 19/19
- [x] `bats tests/bats/` — 173/173
- [x] `bash tests/shellcheck.sh`
- [x] `bash tests/markdownlint.sh`
- [x] Live dry-run against CF API — POST body matches culture-dev template exactly
- [x] Live `--apply` — project created, id + subdomain returned, verifiable in dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)
- Claude