### PR TITLE
Wire culture.dev/afi → Pages project afi (closes #16)

### DIFF
--- a/.claude/skills/cloudflare-write/SKILL.md
+++ b/.claude/skills/cloudflare-write/SKILL.md
@@ -305,8 +305,18 @@ Flags:
 - `--compatibility-date=YYYY-MM-DD` — pins the Workers runtime
   version. Defaults to today (UTC). Match existing peer Workers to
   keep behavior consistent — `agex-proxy` uses `2026-04-20`.
-- `--apply` — actually PUT. Without it, dry-run.
-- `--json` — raw CloudFlare response envelope (or simulated body in
+- `--no-workers-dev` — suppress the default post-upload
+  enable-workers.dev-subdomain step. By default (match agex-proxy /
+  citation-cli-proxy), the script does two writes: the multipart
+  PUT of the script, then a POST to
+  `/accounts/{id}/workers/scripts/{name}/subdomain` with
+  `{enabled: true, previews_enabled: false}`. The second POST is
+  necessary because CF's upload endpoint leaves the `.workers.dev`
+  subdomain disabled, unlike the dashboard. Use `--no-workers-dev`
+  for private Workers that should only run on Workers routes.
+- `--apply` — actually PUT+POST. Without it, dry-run.
+- `--json` — merged CloudFlare envelope
+  `{success, result: {upload, subdomain}}` (or simulated body in
   dry-run).
 
 Idempotency: pre-flight lists the account's Workers scripts and

--- a/.claude/skills/cloudflare-write/SKILL.md
+++ b/.claude/skills/cloudflare-write/SKILL.md
@@ -46,11 +46,20 @@ token**) with these *additional* scopes on top of the read scopes:
 - **Account · Cloudflare Pages · Edit** (this account) —
   required by `cf-pages-project-create.sh`,
   `cf-pages-deployment-delete.sh`, and
-  `cf-pages-deployments-purge.sh`. Creating a Pages project also
-  needs the **Cloudflare Pages GitHub App** to be installed on the
-  source GitHub owner (org or user) and granted access to the
-  target repo — that's a one-time dashboard / GitHub-admin step this
-  skill cannot automate.
+  `cf-pages-deployments-purge.sh`. Creating a **GitHub-connected**
+  Pages project (no `--direct-upload`) additionally needs the
+  **Cloudflare Pages GitHub App** installed on the source GitHub
+  owner (org or user) with access to the target repo — a one-time
+  dashboard / GitHub-admin step this skill cannot automate.
+  `--direct-upload` projects have no GitHub App dependency.
+- **Account · Workers Scripts · Edit** (this account) —
+  required by `cf-worker-create.sh`. Uploads a Worker script (the
+  subpath-proxy template, typically) via multipart PUT.
+- **Zone · Workers Routes · Edit** (**All zones from AgentCulture**) —
+  required by `cf-workers-route-create.sh`. Per
+  `memory/zone_ids.md`, zone-level scopes on a subset fail with code
+  10000; cover every zone or the route POST will reject even though
+  the dry-run passed.
 
 Swap the token into `.env` when you're about to run a write script,
 then swap back. One token at a time.
@@ -87,6 +96,10 @@ Every write script in this skill follows the same shape:
 | Create a Single Redirect for a zone | `bash .claude/skills/cloudflare-write/scripts/cf-redirect-create.sh FROM_HOST TO_HOST [--www] [--status=301] [--apply] [--json]` |
 | Create a DNS record in a zone | `bash .claude/skills/cloudflare-write/scripts/cf-dns-create.sh ZONE TYPE NAME CONTENT [--proxied] [--ttl=N] [--comment=STR] [--apply] [--json]` |
 | Create a Pages project connected to a GitHub repo | `bash .claude/skills/cloudflare-write/scripts/cf-pages-project-create.sh NAME GITHUB_OWNER REPO_NAME [--clone-from=PROJECT] [...] [--apply] [--json]` |
+| Create a Direct Upload Pages project (no git source) | `bash .claude/skills/cloudflare-write/scripts/cf-pages-project-create.sh NAME --direct-upload [--compatibility-date=DATE] [--apply] [--json]` |
+| Upload a Worker script | `bash .claude/skills/cloudflare-write/scripts/cf-worker-create.sh NAME --from-file=PATH [--module\|--service-worker] [--compatibility-date=DATE] [--apply] [--json]` |
+| Create a Workers route on a zone | `bash .claude/skills/cloudflare-write/scripts/cf-workers-route-create.sh ZONE PATTERN SCRIPT [--apply] [--json]` |
+| Stand up a new `culture.dev/NAME` sub-site (agex-style) | 3 scripts above + `templates/subpath-proxy.js`; see `references/subpath-site-pattern.md` |
 | Delete one Pages deployment | `bash .claude/skills/cloudflare-write/scripts/cf-pages-deployment-delete.sh PROJECT SHORT_ID_OR_ID [--force-canonical] [--apply] [--json]` |
 | Bulk-delete all deployments in a Pages project | `bash .claude/skills/cloudflare-write/scripts/cf-pages-deployments-purge.sh PROJECT [...]` (two-phase, see §3.3) |
 
@@ -179,10 +192,19 @@ duplicates.
 
 ### cf-pages-project-create.sh
 
-Creates a Cloudflare Pages project connected to a GitHub repository.
+Creates a Cloudflare Pages project in either **GitHub-connected**
+mode (default) or **Direct Upload** mode (with `--direct-upload`).
 Mirrors the build + deployment settings of an existing project when
 given `--clone-from=PROJECT`, so "spin up a second project with the
 same style as culture-dev" is one flag, not a dozen.
+
+**Direct Upload vs GitHub-connected** — with `--direct-upload` the
+project has no `source` field, no GitHub App dependency, and
+deployments come from `wrangler pages deploy` / CF's direct-upload
+API rather than auto-builds. That's the mode used by the
+`culture.dev/NAME` sub-site pattern (agex, citation-cli, afi) where
+the consumer repo's own CI builds the site and uploads the finished
+bundle. See `references/subpath-site-pattern.md`.
 
 ```sh
 # Dry-run — shows the full POST body we would send, including the
@@ -193,6 +215,10 @@ bash .claude/skills/cloudflare-write/scripts/cf-pages-project-create.sh \
 # Apply for real:
 bash .claude/skills/cloudflare-write/scripts/cf-pages-project-create.sh \
   culture agentculture culture --clone-from=culture-dev --apply
+
+# Direct Upload variant (agex / citation-cli / afi style — no source):
+bash .claude/skills/cloudflare-write/scripts/cf-pages-project-create.sh \
+  afi --direct-upload --compatibility-date=2026-04-20 --apply
 ```
 
 Positional args:
@@ -201,14 +227,21 @@ Positional args:
   1-58 chars, lowercase alphanumeric + hyphens, no leading/trailing
   hyphen. Enforced locally before the POST.
 - `GITHUB_OWNER` — GitHub org or user that owns the repo
-  (e.g. `agentculture`).
+  (e.g. `agentculture`). **Only with the default GitHub-connected
+  mode.** Omit under `--direct-upload`.
 - `REPO_NAME` — repository name within that owner (e.g. `culture`).
+  Same rule — omit under `--direct-upload`.
 
 Flags:
 
+- `--direct-upload` — create a Direct Upload project (no `source`
+  field in the POST body; deployments happen via `wrangler pages
+  deploy` or direct-upload API calls). Positional args collapse to
+  NAME only; passing OWNER / REPO alongside is an error.
 - `--clone-from=PROJECT` — copy `build_config`, `deployment_configs`,
   and `production_branch` from an existing Pages project in the
-  same account. Individual overrides (below) still win.
+  same account. Works with or without `--direct-upload`. Individual
+  overrides (below) still win.
 - `--production-branch=BRANCH` — git branch that produces
   production deployments. Default `main` (or the cloned value).
 - `--build-command=CMD` — shell command CF runs to build the site.
@@ -238,6 +271,86 @@ something this skill can automate.
 Custom domains (including apex mappings like `culture.dev`) are not
 created by this script; attach them in the Pages dashboard or via a
 follow-on `cf-pages-domain-add.sh` once that lands.
+
+### cf-worker-create.sh
+
+Uploads a Cloudflare Worker script from a local file via the
+multipart `PUT /accounts/:id/workers/scripts/:name` endpoint.
+
+```sh
+# Dry-run (no mutation; prints metadata + a 20-line source preview):
+bash .claude/skills/cloudflare-write/scripts/cf-worker-create.sh \
+  afi-proxy --from-file=/tmp/afi-proxy.js --compatibility-date=2026-04-20
+
+# Apply:
+bash .claude/skills/cloudflare-write/scripts/cf-worker-create.sh \
+  afi-proxy --from-file=/tmp/afi-proxy.js --compatibility-date=2026-04-20 --apply
+```
+
+Positional args:
+
+- `NAME` — Worker script name. 1-63 chars, lowercase alphanumeric
+  plus `_-`, no leading/trailing `_` or `-`. Enforced locally.
+
+Flags:
+
+- `--from-file=PATH` — local `.js` file to upload. Required.
+- `--module` — ES-module format (default). Metadata:
+  `{"main_module":"worker.js", "compatibility_date": ...}`.
+  Part content-type `application/javascript+module`.
+- `--service-worker` — legacy service-worker format. Metadata:
+  `{"body_part":"script", "compatibility_date": ...}`. Part
+  content-type `application/javascript`. Mutually exclusive with
+  `--module`.
+- `--compatibility-date=YYYY-MM-DD` — pins the Workers runtime
+  version. Defaults to today (UTC). Match existing peer Workers to
+  keep behavior consistent — `agex-proxy` uses `2026-04-20`.
+- `--apply` — actually PUT. Without it, dry-run.
+- `--json` — raw CloudFlare response envelope (or simulated body in
+  dry-run).
+
+Idempotency: pre-flight lists the account's Workers scripts and
+refuses with exit 1 if `NAME` already exists. Overwriting an existing
+Worker is a separate (future) `cf-worker-update.sh` responsibility.
+
+### cf-workers-route-create.sh
+
+Creates a Workers route on a zone — binds a Worker script to a URL
+pattern. The route sits at
+`POST /zones/:zone_id/workers/routes` with body
+`{pattern, script}`.
+
+```sh
+# Dry-run:
+bash .claude/skills/cloudflare-write/scripts/cf-workers-route-create.sh \
+  culture.dev 'culture.dev/afi*' afi-proxy
+
+# Apply:
+bash .claude/skills/cloudflare-write/scripts/cf-workers-route-create.sh \
+  culture.dev 'culture.dev/afi*' afi-proxy --apply
+```
+
+Positional args:
+
+- `ZONE` — zone name (e.g. `culture.dev`). Resolved to id via the
+  usual `cf_api_paginated /zones` lookup.
+- `PATTERN` — CF Workers pattern, scheme-less (`culture.dev/afi*`,
+  not `https://culture.dev/afi*`). Quote it in the shell so the
+  globbing doesn't eat the `*`. Scheme-prefixed patterns are
+  rejected up-front.
+- `SCRIPT` — name of an existing Workers script (per
+  `cf-worker-create.sh` naming rules).
+
+Flags:
+
+- `--apply` — actually POST. Without it, dry-run.
+- `--json` — raw CloudFlare response envelope.
+
+Idempotency: pre-flight lists the zone's routes and refuses with
+exit 1 if a route with the identical `{pattern, script}` pair
+already exists. Different scripts mapped to the same pattern (or the
+same script on different patterns) are allowed — only exact dupes
+are refused.
 
 ### 3.3 cf-pages-deployment-delete.sh
 
@@ -371,6 +484,32 @@ This pattern (per-line tick + canary) is the **repo-wide convention
 for any future bulk-destructive script**, not just this one. New
 `cf-*-delete.sh` / `cf-*-purge.sh` scripts should follow the same
 manifest shape.
+
+## 3.5 Sub-site pattern on `culture.dev` (agex-style)
+
+The `culture.dev/agex`, `culture.dev/citation-cli`, and
+`culture.dev/afi` sub-sites share a single three-resource pattern:
+
+1. a **Direct Upload** Pages project `NAME` (see §cf-pages-project-create.sh);
+2. a **Worker** `NAME-proxy` rendered from
+   `templates/subpath-proxy.js` (see §cf-worker-create.sh);
+3. a **Workers route** `culture.dev/NAME*` → `NAME-proxy`
+   (see §cf-workers-route-create.sh).
+
+For the render-and-deploy recipe, zehut/shushu onboarding, and the
+three-URL verification checklist, read the full reference at
+`references/subpath-site-pattern.md`.
+
+## 3.6 Templates and references
+
+- `templates/subpath-proxy.js` — subpath-proxy Worker source, two
+  placeholders (`__SUBPATH__`, `__UPSTREAM__`). Derived from the
+  live `agex-proxy` script and kept deliberately small so updates
+  stay reviewable. Render with `sed` before feeding to
+  `cf-worker-create.sh`.
+- `references/subpath-site-pattern.md` — architecture note for the
+  `culture.dev/NAME` sub-site pattern plus a step-by-step recipe for
+  standing up a new one.
 
 ## 4. Output modes
 

--- a/.claude/skills/cloudflare-write/references/subpath-site-pattern.md
+++ b/.claude/skills/cloudflare-write/references/subpath-site-pattern.md
@@ -51,20 +51,7 @@ upstream.
 Tooling: the three scripts in `cloudflare-write/scripts/` plus the
 template at `cloudflare-write/templates/subpath-proxy.js`.
 
-### 1. Render the proxy Worker source
-
-```sh
-mkdir -p /tmp/foo-provision
-sed -e 's/__SUBPATH__/foo/g' \
-    -e 's|__UPSTREAM__|https://foo.pages.dev|g' \
-    .claude/skills/cloudflare-write/templates/subpath-proxy.js \
-    > /tmp/foo-provision/foo-proxy.js
-```
-
-Two placeholders, both double-underscored to keep sed substitution
-unambiguous: `__SUBPATH__` and `__UPSTREAM__`.
-
-### 2. Create the Pages project (Direct Upload)
+### 1. Create the Pages project first (to learn the real subdomain)
 
 ```sh
 # Dry-run first — inspect the POST body:
@@ -78,6 +65,35 @@ bash .claude/skills/cloudflare-write/scripts/cf-pages-project-create.sh \
 Match the `--compatibility-date` to whatever the existing sub-sites
 use (as of 2026-04-23: `2026-04-20`, verified on `agex-proxy`). Pin
 it — don't let CF choose a default that can drift.
+
+**Gotcha — subdomain auto-suffixing.** The apply output's
+`**subdomain:**` field is the real `*.pages.dev` hostname. It is
+usually `foo.pages.dev`, but CF auto-suffixes any name that collides
+with the platform pool: `culture` got `culture-72d.pages.dev`, `afi`
+got `afi-bn9.pages.dev`. **Record whatever the apply prints** —
+don't assume `foo.pages.dev`. You'll wire that exact hostname into
+the proxy Worker in the next step.
+
+Alternative (read-only) way to recover the subdomain later:
+
+```sh
+bash .claude/skills/cloudflare/scripts/cf-pages.sh --json \
+  | jq -r '.result[] | select(.name == "foo") | .subdomain'
+```
+
+### 2. Render the proxy Worker source (using the real subdomain)
+
+```sh
+mkdir -p /tmp/foo-provision
+# Use the subdomain from step 1's apply output, NOT a guess:
+sed -e 's/__SUBPATH__/foo/g' \
+    -e 's|__UPSTREAM__|https://REAL-SUBDOMAIN|g' \
+    .claude/skills/cloudflare-write/templates/subpath-proxy.js \
+    > /tmp/foo-provision/foo-proxy.js
+```
+
+Two placeholders, both double-underscored to keep sed substitution
+unambiguous: `__SUBPATH__` and `__UPSTREAM__`.
 
 ### 3. Upload the proxy Worker
 

--- a/.claude/skills/cloudflare-write/references/subpath-site-pattern.md
+++ b/.claude/skills/cloudflare-write/references/subpath-site-pattern.md
@@ -1,0 +1,147 @@
+# Sub-path site pattern on `culture.dev`
+
+**Problem.** We want several independent sites served under the same
+apex — `culture.dev/agex`, `culture.dev/citation-cli`, `culture.dev/afi`
+— each owned by a different repo / team, deployed independently,
+with their own PR preview URLs. They can't all sit on `culture.dev`
+itself (that's the main Jekyll site), and we don't want them at the
+apex of their own sub-domains (Discord / docs sharing is cleaner
+when everything is `culture.dev/*`).
+
+**Shape we settled on.** Three resources per sub-site:
+
+1. A **Direct Upload Pages project** named `NAME` — owns the actual
+   site content, gets a per-branch preview URL
+   `https://{branch}.NAME.pages.dev` for free, and is driven by the
+   consumer repo's deploy workflow (not by CF's GitHub integration).
+2. A **Worker** named `NAME-proxy` — intercepts traffic under
+   `/NAME` and `/NAME/*`, strips the `/NAME` prefix, and fetches from
+   `https://NAME.pages.dev`. Same-origin redirect `Location` headers
+   are rewritten back under `/NAME/*` so link navigation stays within
+   the culture.dev/NAME namespace.
+3. A **Workers route** `culture.dev/NAME*` → `NAME-proxy` — binds the
+   Worker to the traffic.
+
+All three are small, independent, and owned by this repo's
+`cloudflare-write` skill. `agex`, `citation-cli`, and `afi` are all
+deployed this way; `zehut` and `shushu` will be next.
+
+## Why Direct Upload and not GitHub-connected Pages?
+
+CF's GitHub-connected Pages builds the site on CF infrastructure.
+We'd rather the consumer repo's own CI build the site, attach its
+own caching / secrets / versioning, and then upload the finished
+bundle via `wrangler pages deploy`. Direct Upload removes CF from
+the build path and keeps the GitHub ↔ CF coupling to a single
+`CLOUDFLARE_API_TOKEN` secret.
+
+## Why a proxy Worker instead of a CNAME?
+
+`NAME.pages.dev` serves at the **root** (`/`). A CNAME / DNS record
+alone can't rewrite the URL prefix — a link to `/about` on the site
+would end up at `culture.dev/about`, not `culture.dev/NAME/about`.
+The Worker does the prefix-strip on the way upstream and
+prefix-re-add on same-origin redirects coming back. Without it,
+every link on the sub-site would have to be manually prefixed with
+`/NAME` and navigation would still break on 3xx responses from
+upstream.
+
+## Render-and-deploy recipe (for a hypothetical `foo` sub-site)
+
+Tooling: the three scripts in `cloudflare-write/scripts/` plus the
+template at `cloudflare-write/templates/subpath-proxy.js`.
+
+### 1. Render the proxy Worker source
+
+```sh
+mkdir -p /tmp/foo-provision
+sed -e 's/__SUBPATH__/foo/g' \
+    -e 's|__UPSTREAM__|https://foo.pages.dev|g' \
+    .claude/skills/cloudflare-write/templates/subpath-proxy.js \
+    > /tmp/foo-provision/foo-proxy.js
+```
+
+Two placeholders, both double-underscored to keep sed substitution
+unambiguous: `__SUBPATH__` and `__UPSTREAM__`.
+
+### 2. Create the Pages project (Direct Upload)
+
+```sh
+# Dry-run first — inspect the POST body:
+bash .claude/skills/cloudflare-write/scripts/cf-pages-project-create.sh \
+  foo --direct-upload --compatibility-date=2026-04-20
+# Commit:
+bash .claude/skills/cloudflare-write/scripts/cf-pages-project-create.sh \
+  foo --direct-upload --compatibility-date=2026-04-20 --apply
+```
+
+Match the `--compatibility-date` to whatever the existing sub-sites
+use (as of 2026-04-23: `2026-04-20`, verified on `agex-proxy`). Pin
+it — don't let CF choose a default that can drift.
+
+### 3. Upload the proxy Worker
+
+```sh
+# Dry-run:
+bash .claude/skills/cloudflare-write/scripts/cf-worker-create.sh \
+  foo-proxy --from-file=/tmp/foo-provision/foo-proxy.js \
+  --compatibility-date=2026-04-20
+# Commit:
+bash .claude/skills/cloudflare-write/scripts/cf-worker-create.sh \
+  foo-proxy --from-file=/tmp/foo-provision/foo-proxy.js \
+  --compatibility-date=2026-04-20 --apply
+```
+
+### 4. Create the Workers route
+
+```sh
+bash .claude/skills/cloudflare-write/scripts/cf-workers-route-create.sh \
+  culture.dev 'culture.dev/foo*' foo-proxy                  # dry
+bash .claude/skills/cloudflare-write/scripts/cf-workers-route-create.sh \
+  culture.dev 'culture.dev/foo*' foo-proxy --apply
+```
+
+Single-quote the pattern so the shell's glob expansion doesn't eat
+the `*`.
+
+### 5. Hand the consumer repo the deploy secrets
+
+The consumer's docs workflow needs two GitHub Actions secrets on
+its repo:
+
+- `CLOUDFLARE_API_TOKEN` — an Account · Cloudflare Pages · Edit token
+- `CLOUDFLARE_ACCOUNT_ID`
+
+These are out-of-band from this skill (GH-side, not CF-side). Use
+`gh secret set CLOUDFLARE_API_TOKEN -R agentculture/<repo>` once
+the token is minted.
+
+### 6. Verify
+
+Use the read-only `cloudflare` skill:
+
+```sh
+bash .claude/skills/cloudflare/scripts/cf-pages.sh
+bash .claude/skills/cloudflare/scripts/cf-workers.sh
+bash .claude/skills/cloudflare/scripts/cf-workers-routes.sh
+```
+
+After the consumer's first deploy, probe the three URL shapes:
+
+- `https://foo.pages.dev/` → the raw Pages site
+- `https://culture.dev/foo/` → served via `foo-proxy`
+- `https://{branch}.foo.pages.dev/` → per-branch preview
+  (needed by PR-preview links in the consumer's docs workflow)
+
+## Token-scope checklist
+
+The write token (kept in `.env` under `CLOUDFLARE_API_TOKEN` during
+apply) must carry:
+
+- Account · Cloudflare Pages · Edit
+- Account · Workers Scripts · Edit
+- Zone · Workers Routes · Edit — **All zones from AgentCulture**
+  (zone-level scopes on a subset fail with code 10000; see
+  `memory/zone_ids.md`)
+
+Swap back to the read-only token when the apply is done.

--- a/.claude/skills/cloudflare-write/scripts/cf-pages-project-create.sh
+++ b/.claude/skills/cloudflare-write/scripts/cf-pages-project-create.sh
@@ -1,8 +1,13 @@
 #!/usr/bin/env bash
-# Create a Cloudflare Pages project connected to a GitHub repository.
+# Create a Cloudflare Pages project — either GitHub-connected (default)
+# or Direct Upload (with --direct-upload).
 #
 # Usage:
+#   # GitHub-connected:
 #   cf-pages-project-create.sh NAME GITHUB_OWNER REPO_NAME [flags]
+#   # Direct Upload (no git source; deployments come from wrangler /
+#   # the CF Pages deploy API — used by agex, citation-cli, afi):
+#   cf-pages-project-create.sh NAME --direct-upload [flags]
 #
 # Default is DRY-RUN: verifies the account id, checks no project with
 # NAME already exists, resolves --clone-from (if given), prints the
@@ -11,12 +16,20 @@
 #
 # Prerequisites for --apply to succeed against the live API:
 #   * CLOUDFLARE_API_TOKEN has Account · Cloudflare Pages · Edit
-#   * The Cloudflare Pages GitHub App is installed on GITHUB_OWNER and
-#     granted access to REPO_NAME. If not, the POST fails with a CF
-#     error about the repo being unreachable — that's a dashboard /
-#     GitHub-org-admin action this script cannot automate.
+#   * (GitHub-connected only) The Cloudflare Pages GitHub App is
+#     installed on GITHUB_OWNER and granted access to REPO_NAME. If
+#     not, the POST fails with a CF error about the repo being
+#     unreachable — that's a dashboard / GitHub-org-admin action this
+#     script cannot automate. Direct Upload has no GitHub App dep.
 #
 # Flags:
+#   --direct-upload             create a Direct Upload project (no
+#                               `source` field in the POST body; the
+#                               project is populated via later
+#                               `wrangler pages deploy` / direct-upload
+#                               API calls). Positional args collapse
+#                               to NAME only; passing OWNER / REPO
+#                               alongside --direct-upload is an error.
 #   --clone-from=PROJECT        copy build_config, deployment_configs,
 #                               and production_branch from an existing
 #                               Pages project in the same account.
@@ -24,6 +37,10 @@
 #                               --root-dir / --production-branch /
 #                               --compatibility-date / --build-image-version
 #                               flags override the cloned values.
+#                               --clone-from only copies build + deploy
+#                               config — the source block is always
+#                               derived fresh from OWNER / REPO (or
+#                               omitted under --direct-upload).
 #   --production-branch=BRANCH  git branch that produces production
 #                               deployments (default: main, or cloned)
 #   --build-command=CMD         shell command CF runs to build the site
@@ -47,6 +64,7 @@ shopt -s inherit_errexit
 
 mode=md
 apply=0
+direct_upload=0
 clone_from=""
 production_branch=""
 build_command=""
@@ -68,8 +86,9 @@ positional=()
 
 for arg in "$@"; do
   case "$arg" in
-    --json)   mode=json ;;
-    --apply)  apply=1 ;;
+    --json)            mode=json ;;
+    --apply)           apply=1 ;;
+    --direct-upload)   direct_upload=1 ;;
     --clone-from=*)           clone_from="${arg#*=}" ;;
     --production-branch=*)    production_branch="${arg#*=}"; production_branch_set=1 ;;
     --build-command=*)        build_command="${arg#*=}"; build_command_set=1 ;;
@@ -91,14 +110,26 @@ for arg in "$@"; do
   esac
 done
 
-if (( ${#positional[@]} != 3 )); then
-  echo "ERROR: expected NAME, GITHUB_OWNER, and REPO_NAME positional args, got ${#positional[@]}" >&2
-  echo "usage: cf-pages-project-create.sh NAME GITHUB_OWNER REPO_NAME [flags]" >&2
-  exit 2
+if (( direct_upload )); then
+  if (( ${#positional[@]} != 1 )); then
+    echo "ERROR: --direct-upload takes exactly one positional arg (NAME), got ${#positional[@]}" >&2
+    echo "usage: cf-pages-project-create.sh NAME --direct-upload [flags]" >&2
+    exit 2
+  fi
+  name="${positional[0]}"
+  owner=""
+  repo=""
+else
+  if (( ${#positional[@]} != 3 )); then
+    echo "ERROR: expected NAME, GITHUB_OWNER, and REPO_NAME positional args, got ${#positional[@]}" >&2
+    echo "usage: cf-pages-project-create.sh NAME GITHUB_OWNER REPO_NAME [flags]" >&2
+    echo "   or: cf-pages-project-create.sh NAME --direct-upload [flags]" >&2
+    exit 2
+  fi
+  name="${positional[0]}"
+  owner="${positional[1]}"
+  repo="${positional[2]}"
 fi
-name="${positional[0]}"
-owner="${positional[1]}"
-repo="${positional[2]}"
 
 # CF Pages project names: 1-58 chars, [a-z0-9-], cannot start/end with
 # hyphen. Enforce locally so errors come from us, not a cryptic CF 400.
@@ -108,14 +139,17 @@ if [[ ! "$name" =~ ^[a-z0-9]([a-z0-9-]{0,56}[a-z0-9])?$ ]]; then
   exit 2
 fi
 
-# GitHub owner / repo naming: alnum, dash, underscore, dot.
-gh_re='^[A-Za-z0-9][A-Za-z0-9._-]{0,99}$'
-for v in "$owner" "$repo"; do
-  if [[ ! "$v" =~ $gh_re ]]; then
-    echo "ERROR: invalid GitHub identifier: $v" >&2
-    exit 2
-  fi
-done
+# GitHub owner / repo naming: alnum, dash, underscore, dot. Skipped
+# under --direct-upload where there's no source repo to validate.
+if (( direct_upload == 0 )); then
+  gh_re='^[A-Za-z0-9][A-Za-z0-9._-]{0,99}$'
+  for v in "$owner" "$repo"; do
+    if [[ ! "$v" =~ $gh_re ]]; then
+      echo "ERROR: invalid GitHub identifier: $v" >&2
+      exit 2
+    fi
+  done
+fi
 
 if [[ -n "$production_branch" ]]; then
   branch_re='^[A-Za-z0-9._/-]{1,255}$'
@@ -229,25 +263,10 @@ body=$(jq -n \
   --arg root_dir       "$effective_root_dir" \
   --arg compat_date    "$effective_compat_date" \
   --argjson build_image "$effective_build_image" \
-  '{
+  --argjson direct_upload "$direct_upload" \
+  '({
     name: $name,
     production_branch: $prod_branch,
-    source: {
-      type: "github",
-      config: {
-        owner: $owner,
-        repo_name: $repo,
-        production_branch: $prod_branch,
-        pr_comments_enabled: true,
-        deployments_enabled: true,
-        production_deployments_enabled: true,
-        preview_deployment_setting: "all",
-        preview_branch_includes: ["*"],
-        preview_branch_excludes: [],
-        path_includes: ["*"],
-        path_excludes: []
-      }
-    },
     build_config: {
       build_command: $build_command,
       destination_dir: $dest_dir,
@@ -267,14 +286,35 @@ body=$(jq -n \
         usage_model: "standard"
       } + (if $compat_date == "" then {} else {compatibility_date: $compat_date} end))
     }
-  }')
+  })
+  + (if $direct_upload == 1 then {} else {
+    source: {
+      type: "github",
+      config: {
+        owner: $owner,
+        repo_name: $repo,
+        production_branch: $prod_branch,
+        pr_comments_enabled: true,
+        deployments_enabled: true,
+        production_deployments_enabled: true,
+        preview_deployment_setting: "all",
+        preview_branch_includes: ["*"],
+        preview_branch_excludes: [],
+        path_includes: ["*"],
+        path_excludes: []
+      }
+    }} end)')
 
 _render_summary_md() {
   local banner="$1"
   printf '%s\n\n' "$banner"
   printf -- '- **name:** %s\n' "$name"
   printf -- '- **account:** %s\n' "$CLOUDFLARE_ACCOUNT_ID"
-  printf -- '- **source:** github:%s/%s\n' "$owner" "$repo"
+  if (( direct_upload )); then
+    printf -- '- **source:** direct_upload\n'
+  else
+    printf -- '- **source:** github:%s/%s\n' "$owner" "$repo"
+  fi
   printf -- '- **production_branch:** %s\n' "$effective_production_branch"
   printf -- '- **build_command:** %s\n' "${effective_build_command:-—}"
   printf -- '- **destination_dir:** %s\n' "${effective_destination_dir:-—}"

--- a/.claude/skills/cloudflare-write/scripts/cf-worker-create.sh
+++ b/.claude/skills/cloudflare-write/scripts/cf-worker-create.sh
@@ -52,6 +52,11 @@ from_file=""
 fmt=module
 compat_date=""
 workers_dev=1   # default: enable .workers.dev subdomain (matches agex-proxy)
+# Track which fmt flag (if any) was explicitly passed, so we can
+# reject the mutually-exclusive `--module --service-worker` case
+# instead of silently letting the later flag win.
+fmt_module_set=0
+fmt_service_worker_set=0
 positional=()
 
 for arg in "$@"; do
@@ -59,8 +64,8 @@ for arg in "$@"; do
     --json)                   mode=json ;;
     --apply)                  apply=1 ;;
     --from-file=*)            from_file="${arg#*=}" ;;
-    --module)                 fmt=module ;;
-    --service-worker)         fmt=service-worker ;;
+    --module)                 fmt=module;         fmt_module_set=1 ;;
+    --service-worker)         fmt=service-worker; fmt_service_worker_set=1 ;;
     --compatibility-date=*)   compat_date="${arg#*=}" ;;
     --no-workers-dev)         workers_dev=0 ;;
     -h|--help)
@@ -83,6 +88,11 @@ if (( ${#positional[@]} != 1 )); then
   exit 2
 fi
 name="${positional[0]}"
+
+if (( fmt_module_set && fmt_service_worker_set )); then
+  echo "ERROR: --module and --service-worker are mutually exclusive" >&2
+  exit 2
+fi
 
 # Worker script names: 1-63 chars, [a-z0-9_-], cannot start/end with
 # hyphen or underscore. Enforce locally so errors come from us, not a
@@ -114,19 +124,25 @@ fi
 source "$(dirname "${BASH_SOURCE[0]}")/_lib.sh"
 cf_require_account_id
 
-# Build the metadata JSON part based on format.
+# Build the metadata JSON part based on format. `part_name` is the
+# multipart form-field name AND the filename= attribute — CF matches
+# the script part against metadata.main_module / metadata.body_part
+# via that string, so they have to agree. Module format points at
+# worker.js; service-worker format points at `script`.
 case "$fmt" in
   module)
     # shellcheck disable=SC2016  # single-quoted jq filter
     metadata=$(jq -n --arg date "$compat_date" \
       '{main_module: "worker.js", compatibility_date: $date}')
     part_ct="application/javascript+module"
+    part_name="worker.js"
     ;;
   service-worker)
     # shellcheck disable=SC2016  # single-quoted jq filter
     metadata=$(jq -n --arg date "$compat_date" \
       '{body_part: "script", compatibility_date: $date}')
     part_ct="application/javascript"
+    part_name="script"
     ;;
   *)
     echo "ERROR: internal: unknown format: $fmt" >&2
@@ -185,7 +201,7 @@ if (( apply == 0 )); then
   # shellcheck disable=SC2016  # literal backticks fence a markdown code block
   printf 'metadata:\n\n```json\n%s\n```\n\n' "$metadata"
   # shellcheck disable=SC2016  # literal backticks open a markdown code fence
-  printf 'worker.js preview (first 20 lines):\n\n```javascript\n'
+  printf '%s preview (first 20 lines):\n\n```javascript\n' "$part_name"
   head -20 "$from_file"
   printf '```\n'
   # shellcheck disable=SC2016  # literal backticks wrap markdown inline code
@@ -203,13 +219,16 @@ fi
 # shell re-quoting surprises.
 #
 # IMPORTANT: `-F "name=@path"` makes curl emit
-# `Content-Disposition: form-data; name="worker.js"; filename="afi-proxy.js"`
-# — the filename comes from the source path's basename. CF's module
+# `Content-Disposition: form-data; name="$part_name"; filename="afi-proxy.js"`
+# — the filename comes from the source path's basename. CF's
 # resolver then complains with code 10021 "No such module: worker.js"
-# because `main_module` points at `worker.js` but the only part CF
-# sees is `filename="afi-proxy.js"`. The fix is `;filename=worker.js`
-# which overrides the filename regardless of the source path. Keep
-# this — removing it breaks every apply against the live API.
+# (module mode) or a similar miss for service-worker mode, because
+# metadata.main_module / metadata.body_part points at "$part_name"
+# but the only part CF sees is `filename="afi-proxy.js"`. Fix:
+# `;filename=$part_name`, which overrides the filename regardless of
+# the source path. The part's form-field NAME (left of the =) must
+# also match $part_name, since some CF paths key off that too.
+# Removing either breaks every apply against the live API.
 meta_tmp=$(mktemp "${TMPDIR:-/tmp}/cf-worker-metadata.XXXXXX.json")
 trap 'rm -f "$meta_tmp"' EXIT
 printf '%s' "$metadata" > "$meta_tmp"
@@ -220,7 +239,7 @@ url_upload="$CF_API_BASE/accounts/$CLOUDFLARE_ACCOUNT_ID/workers/scripts/$name"
 response=$(curl -sS -X PUT \
   -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
   -F "metadata=@$meta_tmp;type=application/json;filename=metadata.json" \
-  -F "worker.js=@$from_file;type=$part_ct;filename=worker.js" \
+  -F "$part_name=@$from_file;type=$part_ct;filename=$part_name" \
   "$url_upload")
 
 if ! printf '%s' "$response" | jq -e '.success == true' >/dev/null 2>&1; then

--- a/.claude/skills/cloudflare-write/scripts/cf-worker-create.sh
+++ b/.claude/skills/cloudflare-write/scripts/cf-worker-create.sh
@@ -184,6 +184,15 @@ fi
 # Content-Type + boundary automatically. We write metadata to a
 # temp file so curl's @-reference reads it byte-for-byte without
 # shell re-quoting surprises.
+#
+# IMPORTANT: `-F "name=@path"` makes curl emit
+# `Content-Disposition: form-data; name="worker.js"; filename="afi-proxy.js"`
+# — the filename comes from the source path's basename. CF's module
+# resolver then complains with code 10021 "No such module: worker.js"
+# because `main_module` points at `worker.js` but the only part CF
+# sees is `filename="afi-proxy.js"`. The fix is `;filename=worker.js`
+# which overrides the filename regardless of the source path. Keep
+# this — removing it breaks every apply against the live API.
 meta_tmp=$(mktemp "${TMPDIR:-/tmp}/cf-worker-metadata.XXXXXX.json")
 trap 'rm -f "$meta_tmp"' EXIT
 printf '%s' "$metadata" > "$meta_tmp"
@@ -193,8 +202,8 @@ url_upload="$CF_API_BASE/accounts/$CLOUDFLARE_ACCOUNT_ID/workers/scripts/$name"
 # which would conflict with the multipart boundary curl computes.
 response=$(curl -sS -X PUT \
   -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
-  -F "metadata=@$meta_tmp;type=application/json" \
-  -F "worker.js=@$from_file;type=$part_ct" \
+  -F "metadata=@$meta_tmp;type=application/json;filename=metadata.json" \
+  -F "worker.js=@$from_file;type=$part_ct;filename=worker.js" \
   "$url_upload")
 
 if ! printf '%s' "$response" | jq -e '.success == true' >/dev/null 2>&1; then

--- a/.claude/skills/cloudflare-write/scripts/cf-worker-create.sh
+++ b/.claude/skills/cloudflare-write/scripts/cf-worker-create.sh
@@ -148,6 +148,7 @@ _render_summary_md() {
   printf -- '- **compatibility_date:** %s\n' "$compat_date"
   printf -- '- **from_file:** %s\n' "$from_file"
   printf -- '- **source_bytes:** %s\n' "$(wc -c < "$from_file" | tr -d ' ')"
+  return 0
 }
 
 if (( apply == 0 )); then

--- a/.claude/skills/cloudflare-write/scripts/cf-worker-create.sh
+++ b/.claude/skills/cloudflare-write/scripts/cf-worker-create.sh
@@ -26,6 +26,15 @@
 #   --compatibility-date=DATE   YYYY-MM-DD (default: today). Pins the
 #                               Workers runtime behavior — upgrade by
 #                               bumping this, never silently.
+#   --no-workers-dev            do NOT enable the Worker's
+#                               NAME.<account>.workers.dev subdomain.
+#                               By default the subdomain is enabled
+#                               after a successful upload, matching
+#                               the live agex-proxy / citation-cli-proxy
+#                               state. Pass this to opt out (e.g. for
+#                               internal Workers that should only run
+#                               on their Workers routes, never at a
+#                               public .workers.dev URL).
 #   --apply                     actually PUT (without it, dry-run)
 #   --json                      raw CF response envelope (or simulated
 #                               body in dry-run)
@@ -42,6 +51,7 @@ apply=0
 from_file=""
 fmt=module
 compat_date=""
+workers_dev=1   # default: enable .workers.dev subdomain (matches agex-proxy)
 positional=()
 
 for arg in "$@"; do
@@ -52,6 +62,7 @@ for arg in "$@"; do
     --module)                 fmt=module ;;
     --service-worker)         fmt=service-worker ;;
     --compatibility-date=*)   compat_date="${arg#*=}" ;;
+    --no-workers-dev)         workers_dev=0 ;;
     -h|--help)
       awk 'NR==1{next} /^#/{sub(/^# ?/, ""); print; next} {exit}' "$0"
       exit 0
@@ -148,6 +159,7 @@ _render_summary_md() {
   printf -- '- **compatibility_date:** %s\n' "$compat_date"
   printf -- '- **from_file:** %s\n' "$from_file"
   printf -- '- **source_bytes:** %s\n' "$(wc -c < "$from_file" | tr -d ' ')"
+  printf -- '- **workers_dev_subdomain:** %s\n' "$([[ $workers_dev -eq 1 ]] && echo enabled || echo disabled)"
   return 0
 }
 
@@ -159,9 +171,11 @@ if (( apply == 0 )); then
           --arg name "$name" \
           --arg from_file "$from_file" \
           --arg fmt "$fmt" \
+          --argjson workers_dev "$workers_dev" \
       '{success: true, errors: [], messages: ["dry-run: no changes applied"],
         result: {dry_run: true, account_id: $account, name: $name,
                  from_file: $from_file, format: $fmt,
+                 workers_dev_subdomain: (if $workers_dev == 1 then "enabled" else "disabled" end),
                  would_put: {metadata: $metadata}}}'
     exit 0
   fi
@@ -174,6 +188,9 @@ if (( apply == 0 )); then
   printf 'worker.js preview (first 20 lines):\n\n```javascript\n'
   head -20 "$from_file"
   printf '```\n'
+  # shellcheck disable=SC2016  # literal backticks wrap markdown inline code
+  printf '\n**would POST** `/accounts/%s/workers/scripts/%s/subdomain` with `{"enabled": %s, "previews_enabled": false}`\n' \
+    "$CLOUDFLARE_ACCOUNT_ID" "$name" "$([[ $workers_dev -eq 1 ]] && echo true || echo false)"
   exit 0
 fi
 
@@ -212,8 +229,30 @@ if ! printf '%s' "$response" | jq -e '.success == true' >/dev/null 2>&1; then
   exit 1
 fi
 
+# Second write: set the `.workers.dev` subdomain state. Required
+# because CF's PUT /workers/scripts/{name} endpoint defaults the
+# subdomain to DISABLED, while the dashboard / wrangler default it
+# to ENABLED. Without this the new Worker isn't reachable at its
+# NAME.<account>.workers.dev URL, which is a silent divergence from
+# agex-proxy / citation-cli-proxy (both `enabled: true`). Same
+# Account · Workers Scripts · Edit scope — no extra permission.
+#
+# NOTE: CF's subdomain endpoint is POST, not PUT. Sending PUT here
+# returns code 10405 "Method not allowed for this authentication
+# scheme" (misleading — the auth is fine, the method is wrong).
+# Keep -X POST.
+subdomain_body=$(jq -n --argjson enabled "$workers_dev" \
+  '{enabled: ($enabled == 1), previews_enabled: false}')
+subdomain_response=$(cf_api \
+  "/accounts/$CLOUDFLARE_ACCOUNT_ID/workers/scripts/$name/subdomain" \
+  -X POST --data-binary "$subdomain_body")
+
 if [[ "$mode" == "json" ]]; then
-  printf '%s\n' "$response"
+  # Merge the upload response and the subdomain response into one
+  # envelope so downstream jq pipelines see both outcomes.
+  jq -n --argjson upload "$response" --argjson subdomain "$subdomain_response" \
+    '{success: true, errors: [], messages: [],
+      result: {upload: $upload.result, subdomain: $subdomain.result}}'
   exit 0
 fi
 
@@ -222,3 +261,5 @@ etag=$(printf '%s' "$response" | jq -r '.result.etag // "—"')
 modified=$(printf '%s' "$response" | jq -r '.result.modified_on // "—"')
 printf -- '- **etag:** %s\n' "$etag"
 printf -- '- **modified_on:** %s\n' "$modified"
+printf -- '- **workers_dev_enabled:** %s\n' \
+  "$(printf '%s' "$subdomain_response" | jq -r '.result.enabled')"

--- a/.claude/skills/cloudflare-write/scripts/cf-worker-create.sh
+++ b/.claude/skills/cloudflare-write/scripts/cf-worker-create.sh
@@ -1,0 +1,214 @@
+#!/usr/bin/env bash
+# Create (upload) a Cloudflare Worker script.
+#
+# Usage:
+#   cf-worker-create.sh NAME --from-file=PATH [flags]
+#
+# Default is DRY-RUN: verifies the account id, checks that no Worker
+# with NAME already exists, prints the metadata JSON that would be sent
+# and a preview of the script source, then exits 0 WITHOUT mutating
+# anything. Pass --apply to actually upload.
+#
+# Prerequisites for --apply to succeed against the live API:
+#   * CLOUDFLARE_API_TOKEN has Account · Workers Scripts · Edit
+#
+# Flags:
+#   --from-file=PATH            local worker.js file to upload (required)
+#   --module                    ES-module format (default). Sets
+#                               metadata.main_module = "worker.js" and
+#                               the worker part Content-Type to
+#                               application/javascript+module.
+#   --service-worker            legacy service-worker format. Sets
+#                               metadata.body_part = "script" and the
+#                               worker part Content-Type to
+#                               application/javascript. Mutually
+#                               exclusive with --module.
+#   --compatibility-date=DATE   YYYY-MM-DD (default: today). Pins the
+#                               Workers runtime behavior — upgrade by
+#                               bumping this, never silently.
+#   --apply                     actually PUT (without it, dry-run)
+#   --json                      raw CF response envelope (or simulated
+#                               body in dry-run)
+#
+# Exits 1 on: account id missing, file not found, Worker already exists,
+#   any API error.
+# Exits 2 on usage error.
+
+set -euo pipefail
+shopt -s inherit_errexit
+
+mode=md
+apply=0
+from_file=""
+fmt=module
+compat_date=""
+positional=()
+
+for arg in "$@"; do
+  case "$arg" in
+    --json)                   mode=json ;;
+    --apply)                  apply=1 ;;
+    --from-file=*)            from_file="${arg#*=}" ;;
+    --module)                 fmt=module ;;
+    --service-worker)         fmt=service-worker ;;
+    --compatibility-date=*)   compat_date="${arg#*=}" ;;
+    -h|--help)
+      awk 'NR==1{next} /^#/{sub(/^# ?/, ""); print; next} {exit}' "$0"
+      exit 0
+      ;;
+    -*)
+      echo "ERROR: unknown flag: $arg" >&2
+      exit 2
+      ;;
+    *)
+      positional+=("$arg")
+      ;;
+  esac
+done
+
+if (( ${#positional[@]} != 1 )); then
+  echo "ERROR: expected NAME positional arg, got ${#positional[@]}" >&2
+  echo "usage: cf-worker-create.sh NAME --from-file=PATH [flags]" >&2
+  exit 2
+fi
+name="${positional[0]}"
+
+# Worker script names: 1-63 chars, [a-z0-9_-], cannot start/end with
+# hyphen or underscore. Enforce locally so errors come from us, not a
+# cryptic CF 400.
+if [[ ! "$name" =~ ^[a-z0-9]([a-z0-9_-]{0,61}[a-z0-9])?$ ]]; then
+  echo "ERROR: invalid worker name: $name" >&2
+  echo "       must be 1-63 chars, lowercase a-z 0-9 _ -, no leading/trailing _ or -" >&2
+  exit 2
+fi
+
+if [[ -z "$from_file" ]]; then
+  echo "ERROR: --from-file=PATH is required" >&2
+  exit 2
+fi
+if [[ ! -f "$from_file" ]]; then
+  echo "ERROR: --from-file not found or not a regular file: $from_file" >&2
+  exit 1
+fi
+
+if [[ -z "$compat_date" ]]; then
+  compat_date=$(date -u +%Y-%m-%d)
+fi
+if [[ ! "$compat_date" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
+  echo "ERROR: --compatibility-date must be YYYY-MM-DD, got: $compat_date" >&2
+  exit 2
+fi
+
+# shellcheck source=../../cloudflare/scripts/_lib.sh
+source "$(dirname "${BASH_SOURCE[0]}")/_lib.sh"
+cf_require_account_id
+
+# Build the metadata JSON part based on format.
+case "$fmt" in
+  module)
+    # shellcheck disable=SC2016  # single-quoted jq filter
+    metadata=$(jq -n --arg date "$compat_date" \
+      '{main_module: "worker.js", compatibility_date: $date}')
+    part_ct="application/javascript+module"
+    ;;
+  service-worker)
+    # shellcheck disable=SC2016  # single-quoted jq filter
+    metadata=$(jq -n --arg date "$compat_date" \
+      '{body_part: "script", compatibility_date: $date}')
+    part_ct="application/javascript"
+    ;;
+  *)
+    echo "ERROR: internal: unknown format: $fmt" >&2
+    exit 2
+    ;;
+esac
+
+# Pre-flight: fail loudly if a Worker with this NAME is already
+# deployed. Idempotency is explicit — no silent overwrites. We query
+# the list endpoint (`/accounts/{id}/workers/scripts`) and filter by
+# name client-side. This keeps the pre-flight URL distinct from the
+# per-script upload URL (`/accounts/.../workers/scripts/{name}`),
+# which is important for the bats curl stub — it can't discriminate
+# GET vs PUT on the same URL.
+scripts_json=$(cf_api_paginated "/accounts/$CLOUDFLARE_ACCOUNT_ID/workers/scripts")
+# shellcheck disable=SC2016  # single-quoted jq filter
+if printf '%s' "$scripts_json" | jq -e --arg n "$name" \
+    'any(.result[]; .id == $n)' >/dev/null; then
+  echo "ERROR: Worker '$name' already exists in account $CLOUDFLARE_ACCOUNT_ID" >&2
+  echo "       refusing to overwrite; delete it first or use a future cf-worker-update script" >&2
+  exit 1
+fi
+
+_render_summary_md() {
+  local banner="$1"
+  printf '%s\n\n' "$banner"
+  printf -- '- **name:** %s\n' "$name"
+  printf -- '- **account:** %s\n' "$CLOUDFLARE_ACCOUNT_ID"
+  printf -- '- **format:** %s\n' "$fmt"
+  printf -- '- **compatibility_date:** %s\n' "$compat_date"
+  printf -- '- **from_file:** %s\n' "$from_file"
+  printf -- '- **source_bytes:** %s\n' "$(wc -c < "$from_file" | tr -d ' ')"
+}
+
+if (( apply == 0 )); then
+  if [[ "$mode" == "json" ]]; then
+    # shellcheck disable=SC2016  # single-quoted jq filter
+    jq -n --argjson metadata "$metadata" \
+          --arg account "$CLOUDFLARE_ACCOUNT_ID" \
+          --arg name "$name" \
+          --arg from_file "$from_file" \
+          --arg fmt "$fmt" \
+      '{success: true, errors: [], messages: ["dry-run: no changes applied"],
+        result: {dry_run: true, account_id: $account, name: $name,
+                 from_file: $from_file, format: $fmt,
+                 would_put: {metadata: $metadata}}}'
+    exit 0
+  fi
+  _render_summary_md "**Dry-run — no changes applied**"
+  # shellcheck disable=SC2016  # literal backticks wrap markdown inline code
+  printf '\n**would PUT** `/accounts/%s/workers/scripts/%s`\n\n' "$CLOUDFLARE_ACCOUNT_ID" "$name"
+  # shellcheck disable=SC2016  # literal backticks fence a markdown code block
+  printf 'metadata:\n\n```json\n%s\n```\n\n' "$metadata"
+  # shellcheck disable=SC2016  # literal backticks open a markdown code fence
+  printf 'worker.js preview (first 20 lines):\n\n```javascript\n'
+  head -20 "$from_file"
+  printf '```\n'
+  exit 0
+fi
+
+# Live upload. Multipart form-data with two parts:
+#   * metadata (application/json) — the JSON we built above
+#   * worker.js ($part_ct) — the script source
+# curl's -F handles the multipart assembly and sets the
+# Content-Type + boundary automatically. We write metadata to a
+# temp file so curl's @-reference reads it byte-for-byte without
+# shell re-quoting surprises.
+meta_tmp=$(mktemp "${TMPDIR:-/tmp}/cf-worker-metadata.XXXXXX.json")
+trap 'rm -f "$meta_tmp"' EXIT
+printf '%s' "$metadata" > "$meta_tmp"
+
+url_upload="$CF_API_BASE/accounts/$CLOUDFLARE_ACCOUNT_ID/workers/scripts/$name"
+# Use curl directly — cf_api fixes Content-Type to application/json,
+# which would conflict with the multipart boundary curl computes.
+response=$(curl -sS -X PUT \
+  -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+  -F "metadata=@$meta_tmp;type=application/json" \
+  -F "worker.js=@$from_file;type=$part_ct" \
+  "$url_upload")
+
+if ! printf '%s' "$response" | jq -e '.success == true' >/dev/null 2>&1; then
+  echo "ERROR: CloudFlare API request failed: PUT /accounts/$CLOUDFLARE_ACCOUNT_ID/workers/scripts/$name" >&2
+  printf '%s' "$response" | jq '.errors // .' >&2 || printf '%s\n' "$response" >&2
+  exit 1
+fi
+
+if [[ "$mode" == "json" ]]; then
+  printf '%s\n' "$response"
+  exit 0
+fi
+
+_render_summary_md "**Worker uploaded**"
+etag=$(printf '%s' "$response" | jq -r '.result.etag // "—"')
+modified=$(printf '%s' "$response" | jq -r '.result.modified_on // "—"')
+printf -- '- **etag:** %s\n' "$etag"
+printf -- '- **modified_on:** %s\n' "$modified"

--- a/.claude/skills/cloudflare-write/scripts/cf-workers-route-create.sh
+++ b/.claude/skills/cloudflare-write/scripts/cf-workers-route-create.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+# Create a Workers route on a CloudFlare zone.
+#
+# Usage:
+#   cf-workers-route-create.sh ZONE PATTERN SCRIPT [--apply] [--json]
+#
+# Default is DRY-RUN: resolves the zone, checks no matching
+# {pattern,script} route already exists, prints the JSON body it
+# would POST, and exits 0 WITHOUT mutating anything. Pass --apply
+# to actually create the route.
+#
+# Arguments:
+#   ZONE      zone name (e.g. culture.dev), resolved to id internally
+#   PATTERN   URL pattern matching incoming requests, e.g.
+#             'culture.dev/afi*'. CF's pattern syntax is domain + path
+#             with optional `*` wildcards. Quote it in the shell so
+#             the glob doesn't expand.
+#   SCRIPT    name of an existing Workers script to route to
+#
+# Prerequisites for --apply to succeed against the live API:
+#   * CLOUDFLARE_API_TOKEN has Zone · Workers Routes · Edit on the zone
+#     (all AgentCulture zones if the token is scoped that way; per-zone
+#     tokens work too)
+#   * SCRIPT must already be uploaded (see cf-worker-create.sh). The
+#     CF POST errors out with "script not found" otherwise — we don't
+#     pre-check script existence here because the Workers-scripts
+#     endpoint requires Account · Workers Scripts · Read, which not
+#     every route-creation token will carry.
+#
+# Flags:
+#   --apply   actually POST (without it, dry-run)
+#   --json    raw CF response envelope (or simulated body in dry-run)
+#
+# Exits 1 on: zone not found, matching {pattern,script} route already
+#   exists, API error. Exits 2 on usage error.
+
+set -euo pipefail
+shopt -s inherit_errexit
+
+mode=md
+apply=0
+positional=()
+
+for arg in "$@"; do
+  case "$arg" in
+    --json)   mode=json ;;
+    --apply)  apply=1 ;;
+    -h|--help)
+      awk 'NR==1{next} /^#/{sub(/^# ?/, ""); print; next} {exit}' "$0"
+      exit 0
+      ;;
+    -*)
+      echo "ERROR: unknown flag: $arg" >&2
+      exit 2
+      ;;
+    *)
+      positional+=("$arg")
+      ;;
+  esac
+done
+
+if (( ${#positional[@]} != 3 )); then
+  echo "ERROR: expected ZONE, PATTERN, and SCRIPT positional args, got ${#positional[@]}" >&2
+  echo "usage: cf-workers-route-create.sh ZONE PATTERN SCRIPT [--apply] [--json]" >&2
+  exit 2
+fi
+zone_name="${positional[0]}"
+pattern="${positional[1]}"
+script_name="${positional[2]}"
+
+# Basic shape check on pattern: non-empty, no newlines, no leading
+# scheme (CF patterns are scheme-less — `https://culture.dev/foo*` is
+# invalid, `culture.dev/foo*` is correct). Catch the most common
+# mistake locally instead of chasing a cryptic CF 400.
+if [[ -z "$pattern" || "$pattern" == *$'\n'* ]]; then
+  echo "ERROR: invalid route pattern: $pattern" >&2
+  exit 2
+fi
+if [[ "$pattern" == http://* || "$pattern" == https://* ]]; then
+  echo "ERROR: route pattern must be scheme-less (e.g. 'culture.dev/afi*'), got: $pattern" >&2
+  exit 2
+fi
+
+# Worker script names: 1-63 chars, [a-z0-9_-], cannot start/end with
+# hyphen or underscore. Same rule as cf-worker-create.sh.
+if [[ ! "$script_name" =~ ^[a-z0-9]([a-z0-9_-]{0,61}[a-z0-9])?$ ]]; then
+  echo "ERROR: invalid script name: $script_name" >&2
+  echo "       must be 1-63 chars, lowercase a-z 0-9 _ -, no leading/trailing _ or -" >&2
+  exit 2
+fi
+
+# shellcheck source=../../cloudflare/scripts/_lib.sh
+source "$(dirname "${BASH_SOURCE[0]}")/_lib.sh"
+
+# Resolve ZONE to a zone ID — same pattern as cf-dns-create.sh.
+zones_json=$(cf_api_paginated /zones)
+# shellcheck disable=SC2016  # single-quoted jq filter
+zone_id=$(printf '%s' "$zones_json" | jq -r --arg name "$zone_name" \
+  '[.result[] | select(.name == $name) | .id] | .[0] // ""')
+
+if [[ -z "$zone_id" ]]; then
+  echo "ERROR: zone $zone_name not found in this account" >&2
+  exit 1
+fi
+
+# Idempotency: bail if a route with the same {pattern, script} pair
+# already exists on the zone. (CF allows multiple routes with the
+# same pattern routing to different scripts, or the same script
+# pattern-matching different URLs — only the exact pair is a dup.)
+existing_json=$(cf_api_paginated "/zones/$zone_id/workers/routes")
+# shellcheck disable=SC2016  # single-quoted jq filter
+existing_id=$(printf '%s' "$existing_json" | jq -r \
+  --arg p "$pattern" --arg s "$script_name" \
+  '[.result[] | select(.pattern == $p and .script == $s) | .id] | .[0] // ""')
+if [[ -n "$existing_id" ]]; then
+  echo "ERROR: Workers route already exists on $zone_name: $pattern → $script_name (id=$existing_id)" >&2
+  echo "       nothing to do. Delete it first via the dashboard or a future cf-workers-route-delete.sh." >&2
+  exit 1
+fi
+
+# Build the request body.
+# shellcheck disable=SC2016  # single-quoted jq filter
+body=$(jq -n \
+  --arg pattern "$pattern" \
+  --arg script  "$script_name" \
+  '{pattern: $pattern, script: $script}')
+
+_render_summary_md() {
+  local banner="$1"
+  printf '%s\n\n' "$banner"
+  printf -- '- **zone:** %s (id=%s)\n' "$zone_name" "$zone_id"
+  printf -- '- **pattern:** %s\n' "$pattern"
+  printf -- '- **script:** %s\n' "$script_name"
+}
+
+if (( apply == 0 )); then
+  if [[ "$mode" == "json" ]]; then
+    # shellcheck disable=SC2016  # single-quoted jq filter
+    jq -n --argjson body "$body" --arg zone_id "$zone_id" --arg zone "$zone_name" \
+      '{success: true, errors: [], messages: ["dry-run: no changes applied"],
+        result: {dry_run: true, zone: $zone, zone_id: $zone_id, would_post: $body}}'
+    exit 0
+  fi
+  _render_summary_md "**Dry-run — no changes applied**"
+  # shellcheck disable=SC2016  # literal backticks wrap markdown inline code
+  printf '\n**would POST** `/zones/%s/workers/routes`:\n\n' "$zone_id"
+  # shellcheck disable=SC2016  # literal backticks fence a markdown code block
+  printf '```json\n%s\n```\n' "$body"
+  exit 0
+fi
+
+response=$(cf_api "/zones/$zone_id/workers/routes" -X POST --data-binary "$body")
+
+if [[ "$mode" == "json" ]]; then
+  printf '%s\n' "$response"
+  exit 0
+fi
+
+new_id=$(printf '%s' "$response" | jq -r '.result.id // "—"')
+_render_summary_md "**Workers route created**"
+printf -- '- **route_id:** %s\n' "$new_id"

--- a/.claude/skills/cloudflare-write/scripts/cf-workers-route-create.sh
+++ b/.claude/skills/cloudflare-write/scripts/cf-workers-route-create.sh
@@ -131,6 +131,7 @@ _render_summary_md() {
   printf -- '- **zone:** %s (id=%s)\n' "$zone_name" "$zone_id"
   printf -- '- **pattern:** %s\n' "$pattern"
   printf -- '- **script:** %s\n' "$script_name"
+  return 0
 }
 
 if (( apply == 0 )); then

--- a/.claude/skills/cloudflare-write/templates/subpath-proxy.js
+++ b/.claude/skills/cloudflare-write/templates/subpath-proxy.js
@@ -14,6 +14,10 @@
 // redirect follow, same-origin Location rewrite).
 
 const UPSTREAM = "__UPSTREAM__";
+// Parse once so the same-origin check below is tolerant of trailing
+// slashes / paths in the rendered UPSTREAM string — we only care
+// about the scheme+host+port triple, not the full URL.
+const UPSTREAM_ORIGIN = new URL(UPSTREAM).origin;
 
 export default {
   async fetch(request) {
@@ -48,7 +52,7 @@ export default {
       const location = response.headers.get("location");
       if (location) {
         const locationUrl = new URL(location, upstreamUrl);
-        if (locationUrl.origin === UPSTREAM) {
+        if (locationUrl.origin === UPSTREAM_ORIGIN) {
           const rewritten = new URL(request.url);
           rewritten.pathname = "/__SUBPATH__" + locationUrl.pathname;
           rewritten.search = locationUrl.search;

--- a/.claude/skills/cloudflare-write/templates/subpath-proxy.js
+++ b/.claude/skills/cloudflare-write/templates/subpath-proxy.js
@@ -1,0 +1,71 @@
+// Subpath-proxy Worker template for culture.dev/<subpath>/* sites.
+//
+// Two placeholders — SUBPATH and UPSTREAM (both double-underscored in
+// this file to make sed substitution unambiguous). See
+// references/subpath-site-pattern.md for the render-and-deploy recipe.
+//
+// Do NOT put literal example sed commands in this header — this file
+// is itself processed by sed, so any example substitution patterns
+// get rewritten in the output and become nonsense to a reader of the
+// rendered worker.
+//
+// Derived from the live `agex-proxy` Worker fetched via the CF API —
+// behavior matched line-for-line (path guard, upstream strip, manual
+// redirect follow, same-origin Location rewrite).
+
+const UPSTREAM = "__UPSTREAM__";
+
+export default {
+  async fetch(request) {
+    const incomingUrl = new URL(request.url);
+
+    // Only handle /__SUBPATH__ and /__SUBPATH__/*
+    if (
+      incomingUrl.pathname !== "/__SUBPATH__" &&
+      !incomingUrl.pathname.startsWith("/__SUBPATH__/")
+    ) {
+      return fetch(request);
+    }
+
+    // Strip /__SUBPATH__ before hitting upstream — upstream serves at root.
+    const upstreamPath = incomingUrl.pathname.replace(/^\/__SUBPATH__/, "") || "/";
+    const upstreamUrl = new URL(upstreamPath + incomingUrl.search, UPSTREAM);
+
+    const headers = new Headers(request.headers);
+    headers.delete("host");
+
+    const upstreamRequest = new Request(upstreamUrl.toString(), {
+      method: request.method,
+      headers,
+      body: request.method === "GET" || request.method === "HEAD" ? undefined : request.body,
+      redirect: "manual",
+    });
+
+    const response = await fetch(upstreamRequest);
+
+    // Rewrite upstream same-origin redirect Location back under /__SUBPATH__/*.
+    if (response.status >= 300 && response.status < 400) {
+      const location = response.headers.get("location");
+      if (location) {
+        const locationUrl = new URL(location, upstreamUrl);
+        if (locationUrl.origin === UPSTREAM) {
+          const rewritten = new URL(request.url);
+          rewritten.pathname = "/__SUBPATH__" + locationUrl.pathname;
+          rewritten.search = locationUrl.search;
+          rewritten.hash = locationUrl.hash;
+
+          const outHeaders = new Headers(response.headers);
+          outHeaders.set("location", rewritten.toString());
+
+          return new Response(response.body, {
+            status: response.status,
+            statusText: response.statusText,
+            headers: outHeaders,
+          });
+        }
+      }
+    }
+
+    return response;
+  },
+};

--- a/tests/bats/cf-pages-project-create.bats
+++ b/tests/bats/cf-pages-project-create.bats
@@ -225,3 +225,59 @@ _assert_no_post() {
   echo "$output" | jq -e '.result.would_post.production_branch == "develop"'
   echo "$output" | jq -e '.result.would_post.source.config.production_branch == "develop"'
 }
+
+# --- --direct-upload ---
+
+@test "cf-pages-project-create.sh --direct-upload dry-run omits source and reports direct_upload" {
+  cf_mock "/pages/projects?per_page" "pages_projects_with_culture_dev.json"
+  run bash "$WRITE_SCRIPTS/cf-pages-project-create.sh" afi --direct-upload \
+    --compatibility-date=2026-04-20
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"**Dry-run — no changes applied**"* ]]
+  [[ "$output" == *"**name:** afi"* ]]
+  [[ "$output" == *"**source:** direct_upload"* ]]
+  [[ "$output" != *'"type": "github"'* ]]
+  [[ "$output" != *'"source":'* ]]
+  _assert_no_post
+}
+
+@test "cf-pages-project-create.sh --direct-upload --json has no source key" {
+  cf_mock "/pages/projects?per_page" "pages_projects_with_culture_dev.json"
+  run bash "$WRITE_SCRIPTS/cf-pages-project-create.sh" afi --direct-upload --json
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.result.would_post.name == "afi"'
+  echo "$output" | jq -e '.result.would_post | has("source") | not'
+  echo "$output" | jq -e '.result.would_post.production_branch == "main"'
+  _assert_no_post
+}
+
+@test "cf-pages-project-create.sh --direct-upload rejects extra positional args" {
+  run bash "$WRITE_SCRIPTS/cf-pages-project-create.sh" afi agentculture afi-cli --direct-upload
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"--direct-upload takes exactly one positional arg"* ]]
+}
+
+@test "cf-pages-project-create.sh --direct-upload requires NAME" {
+  run bash "$WRITE_SCRIPTS/cf-pages-project-create.sh" --direct-upload
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"--direct-upload takes exactly one positional arg"* ]]
+}
+
+@test "cf-pages-project-create.sh --direct-upload --apply POSTs source-less body" {
+  cf_mock "/pages/projects?per_page" "pages_projects_with_culture_dev.json"
+  cf_mock "/pages/projects"          "pages_project_create_direct_upload_ok.json"
+  run bash "$WRITE_SCRIPTS/cf-pages-project-create.sh" afi --direct-upload \
+    --compatibility-date=2026-04-20 --apply
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"**Pages project created**"* ]]
+  [[ "$output" == *"proj-id-afi-new-12345678"* ]]
+  [[ "$output" == *"https://afi.pages.dev"* ]]
+  cf_assert_called "-X	POST"
+  cf_assert_called "/accounts/test-account-id/pages/projects"
+  # The request body must not contain a source field — grep the full
+  # curl.log for "source" and confirm it's absent.
+  if grep -F '"source"' "$BATS_TEST_TMPDIR/curl.log"; then
+    echo "--direct-upload must not include source field in POST body" >&2
+    return 1
+  fi
+}

--- a/tests/bats/cf-worker-create.bats
+++ b/tests/bats/cf-worker-create.bats
@@ -170,6 +170,34 @@ _assert_no_mutation() {
   [[ "$output" == *"unknown flag"* ]]
 }
 
+@test "cf-worker-create.sh exits 2 when both --module and --service-worker are given" {
+  run bash "$WRITE_SCRIPTS/cf-worker-create.sh" afi-proxy \
+    --from-file="$WORKER_SRC" --module --service-worker
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"mutually exclusive"* ]]
+}
+
+@test "cf-worker-create.sh --service-worker --apply sends part named 'script'" {
+  cf_mock "/workers/scripts?per_page"            "workers_scripts_empty.json"
+  cf_mock "/workers/scripts/my-worker"           "workers_script_create_ok.json"
+  cf_mock "/workers/scripts/my-worker/subdomain" "workers_script_subdomain_enabled.json"
+  run bash "$WRITE_SCRIPTS/cf-worker-create.sh" my-worker \
+    --from-file="$WORKER_SRC" --service-worker --apply
+  [ "$status" -eq 0 ]
+  # metadata.body_part="script" — the multipart part MUST be named
+  # "script" with filename="script", not "worker.js". Otherwise CF
+  # rejects with a module-not-found error (service-worker format).
+  cf_assert_called "script=@"
+  cf_assert_called "application/javascript"
+  cf_assert_called ";filename=script"
+  # Negative: the old bug (always sending worker.js) must not regress.
+  if grep -qF 'worker.js=@' "$BATS_TEST_TMPDIR/curl.log"; then
+    echo "--service-worker leaked worker.js=@ form field; curl log:" >&2
+    cat "$BATS_TEST_TMPDIR/curl.log" >&2
+    return 1
+  fi
+}
+
 @test "cf-worker-create.sh uses today's date when --compatibility-date omitted" {
   cf_mock "/workers/scripts?per_page" "workers_scripts_empty.json"
   run bash "$WRITE_SCRIPTS/cf-worker-create.sh" afi-proxy \

--- a/tests/bats/cf-worker-create.bats
+++ b/tests/bats/cf-worker-create.bats
@@ -1,0 +1,160 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+setup() {
+  cf_bats_setup
+  WRITE_SCRIPTS="$SKILL_DIR/../cloudflare-write/scripts"
+  # Minimal worker source used across tests. Content is irrelevant
+  # for the curl-stub harness — it only shows up in the source
+  # preview (markdown mode) and in --from-file byte-count reporting.
+  WORKER_SRC="$BATS_TEST_TMPDIR/worker.js"
+  cat > "$WORKER_SRC" <<'EOF'
+// test worker
+export default { async fetch(req) { return new Response("hi"); } };
+EOF
+}
+
+_assert_no_mutation() {
+  # No -X POST, -X PUT, or -X DELETE should have been issued.
+  for method in POST PUT DELETE; do
+    if grep -qF -- "-X	$method" "$BATS_TEST_TMPDIR/curl.log" 2>/dev/null; then
+      echo "expected no $method, but curl.log contains one:" >&2
+      cat "$BATS_TEST_TMPDIR/curl.log" >&2
+      return 1
+    fi
+  done
+  return 0
+}
+
+# --- dry-run (default, no --apply) ---
+
+@test "cf-worker-create.sh dry-run prints metadata + source preview" {
+  cf_mock "/workers/scripts?per_page" "workers_scripts_empty.json"
+  run bash "$WRITE_SCRIPTS/cf-worker-create.sh" afi-proxy \
+    --from-file="$WORKER_SRC" --compatibility-date=2026-04-20
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"**Dry-run — no changes applied**"* ]]
+  [[ "$output" == *"**name:** afi-proxy"* ]]
+  [[ "$output" == *"**format:** module"* ]]
+  [[ "$output" == *"**compatibility_date:** 2026-04-20"* ]]
+  [[ "$output" == *'"main_module": "worker.js"'* ]]
+  [[ "$output" == *"would PUT"* ]]
+  [[ "$output" == *"test worker"* ]]
+  _assert_no_mutation
+}
+
+@test "cf-worker-create.sh dry-run --json emits synthetic envelope" {
+  cf_mock "/workers/scripts?per_page" "workers_scripts_empty.json"
+  run bash "$WRITE_SCRIPTS/cf-worker-create.sh" afi-proxy \
+    --from-file="$WORKER_SRC" --compatibility-date=2026-04-20 --json
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.success == true'
+  echo "$output" | jq -e '.result.dry_run == true'
+  echo "$output" | jq -e '.result.name == "afi-proxy"'
+  echo "$output" | jq -e '.result.format == "module"'
+  echo "$output" | jq -e '.result.would_put.metadata.main_module == "worker.js"'
+  echo "$output" | jq -e '.result.would_put.metadata.compatibility_date == "2026-04-20"'
+  [[ "$output" != *"Dry-run — no changes applied"* ]]
+  _assert_no_mutation
+}
+
+@test "cf-worker-create.sh --service-worker changes metadata and content-type" {
+  cf_mock "/workers/scripts?per_page" "workers_scripts_empty.json"
+  run bash "$WRITE_SCRIPTS/cf-worker-create.sh" my-worker \
+    --from-file="$WORKER_SRC" --service-worker \
+    --compatibility-date=2026-04-20 --json
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.result.format == "service-worker"'
+  echo "$output" | jq -e '.result.would_put.metadata.body_part == "script"'
+  echo "$output" | jq -e '.result.would_put.metadata | has("main_module") | not'
+}
+
+# --- apply ---
+
+@test "cf-worker-create.sh --apply PUTs the script and reports etag" {
+  cf_mock "/workers/scripts?per_page"          "workers_scripts_empty.json"
+  cf_mock "/workers/scripts/afi-proxy"         "workers_script_create_ok.json"
+  run bash "$WRITE_SCRIPTS/cf-worker-create.sh" afi-proxy \
+    --from-file="$WORKER_SRC" --compatibility-date=2026-04-20 --apply
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"**Worker uploaded**"* ]]
+  [[ "$output" == *"test-etag-afi-proxy-12345"* ]]
+  cf_assert_called "-X	PUT"
+  cf_assert_called "/accounts/test-account-id/workers/scripts/afi-proxy"
+  # Multipart parts — -F flags are present.
+  cf_assert_called "metadata=@"
+  cf_assert_called "worker.js=@"
+  cf_assert_called "application/javascript+module"
+}
+
+@test "cf-worker-create.sh --apply --json passes CF envelope through" {
+  cf_mock "/workers/scripts?per_page"  "workers_scripts_empty.json"
+  cf_mock "/workers/scripts/afi-proxy" "workers_script_create_ok.json"
+  run bash "$WRITE_SCRIPTS/cf-worker-create.sh" afi-proxy \
+    --from-file="$WORKER_SRC" --apply --json
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.success == true'
+  echo "$output" | jq -e '.result.id == "afi-proxy"'
+  echo "$output" | jq -e '.result.etag == "test-etag-afi-proxy-12345"'
+}
+
+# --- idempotency & validation ---
+
+@test "cf-worker-create.sh exits 1 when a worker with NAME already exists" {
+  cf_mock "/workers/scripts?per_page" "workers_scripts_with_afi_proxy.json"
+  run bash "$WRITE_SCRIPTS/cf-worker-create.sh" afi-proxy --from-file="$WORKER_SRC"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"already exists in account"* ]]
+  [[ "$output" == *"afi-proxy"* ]]
+  _assert_no_mutation
+}
+
+@test "cf-worker-create.sh exits 2 when positional NAME is missing" {
+  run bash "$WRITE_SCRIPTS/cf-worker-create.sh" --from-file="$WORKER_SRC"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"expected NAME"* ]]
+}
+
+@test "cf-worker-create.sh exits 2 when --from-file is missing" {
+  run bash "$WRITE_SCRIPTS/cf-worker-create.sh" afi-proxy
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"--from-file=PATH is required"* ]]
+}
+
+@test "cf-worker-create.sh exits 1 when --from-file target does not exist" {
+  run bash "$WRITE_SCRIPTS/cf-worker-create.sh" afi-proxy \
+    --from-file=/nonexistent/path/to/worker.js
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"--from-file not found"* ]]
+}
+
+@test "cf-worker-create.sh exits 2 on invalid worker name (uppercase)" {
+  run bash "$WRITE_SCRIPTS/cf-worker-create.sh" AfiProxy --from-file="$WORKER_SRC"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"invalid worker name"* ]]
+}
+
+@test "cf-worker-create.sh exits 2 on malformed --compatibility-date" {
+  run bash "$WRITE_SCRIPTS/cf-worker-create.sh" afi-proxy \
+    --from-file="$WORKER_SRC" --compatibility-date=20260420
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"YYYY-MM-DD"* ]]
+}
+
+@test "cf-worker-create.sh exits 2 on unknown flag" {
+  run bash "$WRITE_SCRIPTS/cf-worker-create.sh" afi-proxy \
+    --from-file="$WORKER_SRC" --bogus
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"unknown flag"* ]]
+}
+
+@test "cf-worker-create.sh uses today's date when --compatibility-date omitted" {
+  cf_mock "/workers/scripts?per_page" "workers_scripts_empty.json"
+  run bash "$WRITE_SCRIPTS/cf-worker-create.sh" afi-proxy \
+    --from-file="$WORKER_SRC" --json
+  [ "$status" -eq 0 ]
+  # Today-in-UTC format — check it's a plausible 2026 date, not a
+  # hard-coded string (tests shouldn't break on the next UTC tick).
+  echo "$output" | jq -e '.result.would_put.metadata.compatibility_date | test("^20[0-9][0-9]-[0-9]{2}-[0-9]{2}$")'
+}

--- a/tests/bats/cf-worker-create.bats
+++ b/tests/bats/cf-worker-create.bats
@@ -72,31 +72,52 @@ _assert_no_mutation() {
 
 # --- apply ---
 
-@test "cf-worker-create.sh --apply PUTs the script and reports etag" {
-  cf_mock "/workers/scripts?per_page"          "workers_scripts_empty.json"
-  cf_mock "/workers/scripts/afi-proxy"         "workers_script_create_ok.json"
+@test "cf-worker-create.sh --apply PUTs the script, enables workers.dev, reports etag" {
+  cf_mock "/workers/scripts?per_page"               "workers_scripts_empty.json"
+  cf_mock "/workers/scripts/afi-proxy"              "workers_script_create_ok.json"
+  cf_mock "/workers/scripts/afi-proxy/subdomain"    "workers_script_subdomain_enabled.json"
   run bash "$WRITE_SCRIPTS/cf-worker-create.sh" afi-proxy \
     --from-file="$WORKER_SRC" --compatibility-date=2026-04-20 --apply
   [ "$status" -eq 0 ]
   [[ "$output" == *"**Worker uploaded**"* ]]
   [[ "$output" == *"test-etag-afi-proxy-12345"* ]]
+  [[ "$output" == *"**workers_dev_enabled:** true"* ]]
   cf_assert_called "-X	PUT"
   cf_assert_called "/accounts/test-account-id/workers/scripts/afi-proxy"
-  # Multipart parts — -F flags are present.
+  cf_assert_called "/accounts/test-account-id/workers/scripts/afi-proxy/subdomain"
+  # Multipart parts — -F flags are present with the filename override
+  # that forces CF to match main_module by filename, not by source path.
   cf_assert_called "metadata=@"
   cf_assert_called "worker.js=@"
   cf_assert_called "application/javascript+module"
+  cf_assert_called ";filename=worker.js"
 }
 
-@test "cf-worker-create.sh --apply --json passes CF envelope through" {
-  cf_mock "/workers/scripts?per_page"  "workers_scripts_empty.json"
-  cf_mock "/workers/scripts/afi-proxy" "workers_script_create_ok.json"
+@test "cf-worker-create.sh --apply --json merges upload + subdomain envelopes" {
+  cf_mock "/workers/scripts?per_page"            "workers_scripts_empty.json"
+  cf_mock "/workers/scripts/afi-proxy"           "workers_script_create_ok.json"
+  cf_mock "/workers/scripts/afi-proxy/subdomain" "workers_script_subdomain_enabled.json"
   run bash "$WRITE_SCRIPTS/cf-worker-create.sh" afi-proxy \
     --from-file="$WORKER_SRC" --apply --json
   [ "$status" -eq 0 ]
   echo "$output" | jq -e '.success == true'
-  echo "$output" | jq -e '.result.id == "afi-proxy"'
-  echo "$output" | jq -e '.result.etag == "test-etag-afi-proxy-12345"'
+  echo "$output" | jq -e '.result.upload.id == "afi-proxy"'
+  echo "$output" | jq -e '.result.upload.etag == "test-etag-afi-proxy-12345"'
+  echo "$output" | jq -e '.result.subdomain.enabled == true'
+}
+
+@test "cf-worker-create.sh --apply --no-workers-dev sets subdomain disabled" {
+  cf_mock "/workers/scripts?per_page"            "workers_scripts_empty.json"
+  cf_mock "/workers/scripts/afi-proxy"           "workers_script_create_ok.json"
+  cf_mock "/workers/scripts/afi-proxy/subdomain" "workers_script_subdomain_disabled.json"
+  run bash "$WRITE_SCRIPTS/cf-worker-create.sh" afi-proxy \
+    --from-file="$WORKER_SRC" --apply --no-workers-dev --json
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.result.subdomain.enabled == false'
+  # The request body must carry `enabled: false` — grep the curl log
+  # (jq's default output uses ": " with a space, not the compact form).
+  grep -qE '"enabled":[[:space:]]*false' "$BATS_TEST_TMPDIR/curl.log" \
+    || { echo "expected enabled:false in PUT body, curl log:" >&2; cat "$BATS_TEST_TMPDIR/curl.log" >&2; return 1; }
 }
 
 # --- idempotency & validation ---

--- a/tests/bats/cf-workers-route-create.bats
+++ b/tests/bats/cf-workers-route-create.bats
@@ -1,0 +1,105 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+setup() {
+  cf_bats_setup
+  WRITE_SCRIPTS="$SKILL_DIR/../cloudflare-write/scripts"
+}
+
+_assert_no_post() {
+  if grep -qF -- "-X	POST" "$BATS_TEST_TMPDIR/curl.log" 2>/dev/null; then
+    echo "expected no POST, but curl.log contains one:" >&2
+    cat "$BATS_TEST_TMPDIR/curl.log" >&2
+    return 1
+  fi
+  return 0
+}
+
+# --- dry-run (default, no --apply) ---
+
+@test "cf-workers-route-create.sh dry-run resolves zone and prints would-POST body" {
+  cf_mock "/zones?per_page"                                              "zones.json"
+  cf_mock "/zones/zone-id-culture-dev-0123456789abcdef/workers/routes?per_page" "routes_empty.json"
+  run bash "$WRITE_SCRIPTS/cf-workers-route-create.sh" culture.dev 'culture.dev/afi*' afi-proxy
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"**Dry-run — no changes applied**"* ]]
+  [[ "$output" == *"**zone:** culture.dev"* ]]
+  [[ "$output" == *"**pattern:** culture.dev/afi*"* ]]
+  [[ "$output" == *"**script:** afi-proxy"* ]]
+  [[ "$output" == *'"pattern": "culture.dev/afi*"'* ]]
+  [[ "$output" == *'"script": "afi-proxy"'* ]]
+  _assert_no_post
+}
+
+@test "cf-workers-route-create.sh dry-run --json emits synthetic envelope" {
+  cf_mock "/zones?per_page"                                              "zones.json"
+  cf_mock "/zones/zone-id-culture-dev-0123456789abcdef/workers/routes?per_page" "routes_empty.json"
+  run bash "$WRITE_SCRIPTS/cf-workers-route-create.sh" culture.dev 'culture.dev/afi*' afi-proxy --json
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.success == true'
+  echo "$output" | jq -e '.result.dry_run == true'
+  echo "$output" | jq -e '.result.zone == "culture.dev"'
+  echo "$output" | jq -e '.result.would_post.pattern == "culture.dev/afi*"'
+  echo "$output" | jq -e '.result.would_post.script == "afi-proxy"'
+  _assert_no_post
+}
+
+# --- apply path ---
+
+@test "cf-workers-route-create.sh --apply POSTs and reports new route id" {
+  cf_mock "/zones?per_page"                                              "zones.json"
+  cf_mock "/zones/zone-id-culture-dev-0123456789abcdef/workers/routes?per_page" "routes_empty.json"
+  cf_mock "/zones/zone-id-culture-dev-0123456789abcdef/workers/routes"        "workers_route_create_ok.json"
+  run bash "$WRITE_SCRIPTS/cf-workers-route-create.sh" culture.dev 'culture.dev/afi*' afi-proxy --apply
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"**Workers route created**"* ]]
+  [[ "$output" == *"route-culture-dev-afi-99999999"* ]]
+  cf_assert_called "-X	POST"
+  cf_assert_called "/zones/zone-id-culture-dev-0123456789abcdef/workers/routes"
+}
+
+# --- idempotency & validation ---
+
+@test "cf-workers-route-create.sh exits 1 when zone not found" {
+  cf_mock "/zones?per_page" "zone_lookup_empty.json"
+  run bash "$WRITE_SCRIPTS/cf-workers-route-create.sh" nosuch.dev 'nosuch.dev/foo*' afi-proxy
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"zone nosuch.dev not found"* ]]
+  _assert_no_post
+}
+
+@test "cf-workers-route-create.sh exits 1 when identical route already exists" {
+  cf_mock "/zones?per_page"                                              "zones.json"
+  cf_mock "/zones/zone-id-culture-dev-0123456789abcdef/workers/routes?per_page" "routes_culture.json"
+  # routes_culture.json contains {pattern:"culture.dev/*", script:"culture-dev-router"}.
+  run bash "$WRITE_SCRIPTS/cf-workers-route-create.sh" culture.dev 'culture.dev/*' culture-dev-router
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"Workers route already exists"* ]]
+  [[ "$output" == *"culture.dev/*"* ]]
+  _assert_no_post
+}
+
+@test "cf-workers-route-create.sh exits 2 when positional args missing" {
+  run bash "$WRITE_SCRIPTS/cf-workers-route-create.sh" culture.dev
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"expected ZONE, PATTERN, and SCRIPT"* ]]
+}
+
+@test "cf-workers-route-create.sh exits 2 when pattern has a scheme" {
+  run bash "$WRITE_SCRIPTS/cf-workers-route-create.sh" culture.dev 'https://culture.dev/afi*' afi-proxy
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"scheme-less"* ]]
+}
+
+@test "cf-workers-route-create.sh exits 2 on invalid script name" {
+  run bash "$WRITE_SCRIPTS/cf-workers-route-create.sh" culture.dev 'culture.dev/afi*' 'Bad_Name'
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"invalid script name"* ]]
+}
+
+@test "cf-workers-route-create.sh exits 2 on unknown flag" {
+  run bash "$WRITE_SCRIPTS/cf-workers-route-create.sh" culture.dev 'culture.dev/afi*' afi-proxy --bogus
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"unknown flag"* ]]
+}

--- a/tests/fixtures/pages_project_create_direct_upload_ok.json
+++ b/tests/fixtures/pages_project_create_direct_upload_ok.json
@@ -1,0 +1,35 @@
+{
+  "success": true,
+  "errors": [],
+  "messages": [],
+  "result": {
+    "name": "afi",
+    "id": "proj-id-afi-new-12345678",
+    "created_on": "2026-04-23T16:30:00.000000Z",
+    "subdomain": "afi.pages.dev",
+    "domains": ["afi.pages.dev"],
+    "production_branch": "main",
+    "source": null,
+    "build_config": {
+      "build_command": "",
+      "destination_dir": "",
+      "root_dir": ""
+    },
+    "deployment_configs": {
+      "preview": {
+        "fail_open": true,
+        "always_use_latest_compatibility_date": false,
+        "compatibility_date": "2026-04-20",
+        "build_image_major_version": 3,
+        "usage_model": "standard"
+      },
+      "production": {
+        "fail_open": true,
+        "always_use_latest_compatibility_date": false,
+        "compatibility_date": "2026-04-20",
+        "build_image_major_version": 3,
+        "usage_model": "standard"
+      }
+    }
+  }
+}

--- a/tests/fixtures/routes_empty.json
+++ b/tests/fixtures/routes_empty.json
@@ -1,0 +1,7 @@
+{
+  "success": true,
+  "errors": [],
+  "messages": [],
+  "result": [],
+  "result_info": {"page": 1, "per_page": 20, "total_pages": 1, "count": 0, "total_count": 0}
+}

--- a/tests/fixtures/workers_route_create_ok.json
+++ b/tests/fixtures/workers_route_create_ok.json
@@ -1,0 +1,10 @@
+{
+  "success": true,
+  "errors": [],
+  "messages": [],
+  "result": {
+    "id": "route-culture-dev-afi-99999999",
+    "pattern": "culture.dev/afi*",
+    "script": "afi-proxy"
+  }
+}

--- a/tests/fixtures/workers_script_create_ok.json
+++ b/tests/fixtures/workers_script_create_ok.json
@@ -1,0 +1,14 @@
+{
+  "success": true,
+  "errors": [],
+  "messages": [],
+  "result": {
+    "id": "afi-proxy",
+    "etag": "test-etag-afi-proxy-12345",
+    "modified_on": "2026-04-23T16:45:00.000000Z",
+    "size": 2330,
+    "handlers": ["fetch"],
+    "compatibility_date": "2026-04-20",
+    "usage_model": "standard"
+  }
+}

--- a/tests/fixtures/workers_script_subdomain_disabled.json
+++ b/tests/fixtures/workers_script_subdomain_disabled.json
@@ -1,0 +1,9 @@
+{
+  "success": true,
+  "errors": [],
+  "messages": [],
+  "result": {
+    "enabled": false,
+    "previews_enabled": false
+  }
+}

--- a/tests/fixtures/workers_script_subdomain_enabled.json
+++ b/tests/fixtures/workers_script_subdomain_enabled.json
@@ -1,0 +1,9 @@
+{
+  "success": true,
+  "errors": [],
+  "messages": [],
+  "result": {
+    "enabled": true,
+    "previews_enabled": false
+  }
+}

--- a/tests/fixtures/workers_scripts_empty.json
+++ b/tests/fixtures/workers_scripts_empty.json
@@ -1,0 +1,7 @@
+{
+  "success": true,
+  "errors": [],
+  "messages": [],
+  "result": [],
+  "result_info": {"page": 1, "per_page": 20, "total_pages": 1, "count": 0, "total_count": 0}
+}

--- a/tests/fixtures/workers_scripts_with_afi_proxy.json
+++ b/tests/fixtures/workers_scripts_with_afi_proxy.json
@@ -1,0 +1,17 @@
+{
+  "success": true,
+  "errors": [],
+  "messages": [],
+  "result": [
+    {
+      "id": "afi-proxy",
+      "etag": "existing-etag-afi-proxy",
+      "handlers": ["fetch"],
+      "modified_on": "2026-04-23T16:00:00.000000Z",
+      "created_on": "2026-04-23T16:00:00.000000Z",
+      "usage_model": "standard",
+      "logpush": false
+    }
+  ],
+  "result_info": {"page": 1, "per_page": 20, "total_pages": 1, "count": 1, "total_count": 1}
+}


### PR DESCRIPTION
## Summary

Stands up the CloudFlare side of `culture.dev/afi` — a 1:1 mirror of the existing `agex` / `citation-cli` sub-site pattern — and ships the three skill primitives that made it trivial (and will make the next one, `zehut` / `shushu`, trivial too).

Structure (one PR, per the "successful live apply is the final test" directive):

- **Phase A — skill capability (this commit).** Three new scripts + one worker template + one reference doc + SKILL.md updates + 22 new bats cases (201 passing total). No live writes.
- **Phase B — provisioning afi (follow-up commit on this branch).** Uses the Phase A scripts with `--apply` to create the Pages project, upload `afi-proxy`, and bind the Workers route. Memory files record the resource IDs.

## Context (issue #16 + corrections)

The issue asked for a Pages project named `afi`, a route `culture.dev/afi*` served by a proxy script (issue called it `culture-dev-router`), and GH secrets on `agentculture/afi-cli`.

Two corrections from live inspection:

1. **There is no `culture-dev-router` Worker.** `cf-workers-routes.sh` shows the real pattern is one Worker per sub-path (`agex-proxy`, `citation-cli-proxy`). Mirroring agex therefore means a new `afi-proxy` Worker, not a route appended to a shared router.
2. **`agentculture/afi-cli` already has both secrets set** (dated today per `gh secret list`). Item 3 of the issue is done — this PR doesn't touch it.

## What's in Phase A

### Scripts (cloudflare-write)

- `cf-pages-project-create.sh` gains `--direct-upload` — drops the `source` field from the POST body (CF treats absent-source as Direct Upload; verified: `agex.source == null`), collapses positional args to NAME only. `agex` / `citation-cli` / new `afi` all use this mode.
- `cf-worker-create.sh` — multipart PUT to `/accounts/{id}/workers/scripts/{name}`. Module format by default, `--service-worker` opts out. Pre-flight lists account scripts and refuses with exit 1 on duplicates. Dry-run default prints metadata + source preview.
- `cf-workers-route-create.sh` — POST `/zones/{id}/workers/routes` with `{pattern, script}`. Zone resolved from name. Scheme-prefixed patterns and duplicate `{pattern, script}` pairs rejected up-front.

### Asset

- `templates/subpath-proxy.js` — the subpath-proxy Worker template with `__SUBPATH__` and `__UPSTREAM__` placeholders. Derived from the live `agex-proxy` script (fetched via the CF Workers API), behavior matched line-for-line.

### Reference

- `references/subpath-site-pattern.md` — architecture note + step-by-step recipe for standing up a new `culture.dev/NAME` sub-site. This is the contract the skill locks in for zehut / shushu.

### SKILL.md updates

New token-scope rows (Workers Scripts · Edit; Workers Routes · Edit on **all zones** per the `zone_ids` memory), new script rows in the actions table, new §3.5 sub-site quickstart, new §3.6 Templates/References appendix.

## Test plan

- [x] `bash tests/shellcheck.sh` clean
- [x] `bash tests/markdownlint.sh` clean
- [x] `bats tests/bats/` — 201 tests green (22 new)
- [x] Live dry-runs with the read token — `cf-pages-project-create.sh afi --direct-upload`, `cf-worker-create.sh afi-proxy --from-file=...`, `cf-workers-route-create.sh culture.dev 'culture.dev/afi*' afi-proxy` all parse, resolve, and print plausible bodies.
- [ ] Phase B: apply the three scripts under the write token, confirm `https://afi.pages.dev/`, `https://culture.dev/afi/`, and `https://main.afi.pages.dev/` all serve.
- [ ] Phase B: memory files `culture_dev_sites.md` + `afi_subpath_site_applied.md` updated with resource IDs.
- [ ] Close #16.

Refs #16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)