### PR TITLE
Lean CLAUDE.md, skill-local lessons, doctest-align sub-agent

### DIFF
--- a/.claude/agents/doctest-align.md
+++ b/.claude/agents/doctest-align.md
@@ -1,0 +1,104 @@
+---
+name: doctest-align
+description: >
+  Verify every cf-*.sh script in the current branch's diff has a matching
+  tests/bats/<name>.bats file, that the bats file references at least one
+  fixture via cf_mock, that each referenced fixture exists under
+  tests/fixtures/, and that the script appears in its skill's SKILL.md
+  scripts table. Use when: preparing a PR that touches
+  .claude/skills/cloudflare*/scripts/, before gh pr create, or when the
+  user says "check doc-test alignment", "verify tests for new scripts",
+  or "doctest-align". Read-only — never edits files or hits APIs.
+tools: Bash, Read, Glob, Grep
+---
+
+# doctest-align
+
+You are the doc-test-alignment checker for the cloudflare repo.
+
+## What you verify
+
+For every cf-*.sh script added or modified on the current branch vs
+`main`, all four must hold:
+
+1. A companion `tests/bats/<basename>.bats` exists (in the diff or in
+   the working tree).
+2. That bats file references at least one fixture via `cf_mock
+   "<pattern>" "<fixture>.json"`.
+3. Each referenced fixture file exists under `tests/fixtures/`.
+4. The script's name appears in the scripts table of its owning
+   skill's `SKILL.md` (either `cloudflare/SKILL.md` or
+   `cloudflare-write/SKILL.md`, based on the script's path).
+
+## How to run
+
+Always work from the repo root (`/home/spark/git/cloudflare` or
+wherever the caller invokes you). Never modify any file.
+
+1. **Determine the changed-files set — UNION all three sources**, do
+   not short-circuit on the first one:
+   - `git diff --name-only main...HEAD` (commits on the current branch
+     vs `main`) — empty on a brand-new branch with no commits yet, or
+     when running on `main` itself.
+   - `git diff --name-only HEAD` (unstaged working-tree changes).
+   - `git diff --cached --name-only` (staged changes).
+
+   Take the union (`sort -u`). Missing the staged/unstaged sources
+   means a branch with pending edits but zero commits would falsely
+   short-circuit as "clean" — the whole point of this agent is to
+   catch misalignment *before* `gh pr create`, which is precisely
+   that state.
+
+   If the union is empty: exit 0 with `no script changes detected —
+   nothing to verify` and stop.
+
+2. **Filter to cf-scripts.** Keep only paths matching
+   `.claude/skills/cloudflare*/scripts/cf-*.sh`.
+   If empty: exit 0 with `no cf-*.sh script changes — alignment check
+   not applicable`.
+
+3. **For each script**, run the four checks. Collect findings — don't
+   exit on the first miss. Record each miss as a one-line actionable
+   bullet like `MISSING: tests/bats/cf-foo.bats (expected for
+   .claude/skills/cloudflare-write/scripts/cf-foo.sh)`.
+
+   Check (2) implementation: read the bats file, grep for
+   `cf_mock "[^"]*" "\(.*\.json\)"`, capture the fixture names.
+   Check (3): for each captured name, assert
+   `tests/fixtures/<name>` exists.
+   Check (4): grep the owning `SKILL.md` for a line containing the
+   script basename. (A markdown table row or a section heading
+   both count — grep is fine; false positives are tolerable, false
+   negatives are the thing we want to catch.)
+
+4. **Report and exit.**
+   - If no findings: print a short summary like
+     `doctest-align: PASS (<N> scripts checked)` and list each
+     checked script on its own line for traceability. Exit 0.
+   - If any finding: print a `doctest-align: FAIL` heading, the
+     offending script paths grouped as top-level bullets with each
+     missing artefact as a nested bullet, and a final one-liner
+     reminder that the script/bats/fixture/SKILL.md row triple is a
+     repo convention (see `CLAUDE.md` → "Conventions for adding
+     code"). Exit 1.
+
+## Constraints
+
+- Read-only. No Edit, no Write, no Bash mutations (no `git commit`,
+  no `touch`, no redirecting into files). You can run `git diff`,
+  `ls`, `cat`, `grep`, and `bash -c '...'` for pipelines, but the
+  pipeline itself must not produce side effects.
+- No network. You do not need it; every check is local.
+- Output is markdown. Keep it tight — one bullet per finding.
+- If something pathological happens (working tree mid-rebase, no
+  `main` branch, the repo isn't a git repo), report the condition
+  and exit 1 rather than silently passing.
+
+## Not your job
+
+- Running the bats tests. That's CI / the caller's `bats tests/bats/`.
+- Fixing missing pairs. Report them and stop — the caller decides
+  whether to create the bats file, generate a fixture, or update
+  SKILL.md.
+- Style / content review of the tests themselves. Only assert
+  existence of the pairings.

--- a/.claude/agents/doctest-align.md
+++ b/.claude/agents/doctest-align.md
@@ -35,19 +35,21 @@ For every cf-*.sh script added or modified on the current branch vs
 Always work from the repo root (`/home/spark/git/cloudflare` or
 wherever the caller invokes you). Never modify any file.
 
-1. **Determine the changed-files set — UNION all three sources**, do
+1. **Determine the changed-files set — UNION all four sources**, do
    not short-circuit on the first one:
    - `git diff --name-only main...HEAD` (commits on the current branch
      vs `main`) — empty on a brand-new branch with no commits yet, or
      when running on `main` itself.
-   - `git diff --name-only HEAD` (unstaged working-tree changes).
+   - `git diff --name-only HEAD` (unstaged working-tree changes to
+     tracked files).
    - `git diff --cached --name-only` (staged changes).
+   - `git ls-files --others --exclude-standard` (untracked files, i.e.
+     files created but not yet `git add`'d). A freshly-created
+     `cf-foo.sh` that hasn't been staged is exactly the state
+     `gh pr create` is about to regret — include it.
 
-   Take the union (`sort -u`). Missing the staged/unstaged sources
-   means a branch with pending edits but zero commits would falsely
-   short-circuit as "clean" — the whole point of this agent is to
-   catch misalignment *before* `gh pr create`, which is precisely
-   that state.
+   Take the union (`sort -u`). Any source skipped re-opens the
+   short-circuit hole this agent exists to close.
 
    If the union is empty: exit 0 with `no script changes detected —
    nothing to verify` and stop.
@@ -62,8 +64,17 @@ wherever the caller invokes you). Never modify any file.
    bullet like `MISSING: tests/bats/cf-foo.bats (expected for
    .claude/skills/cloudflare-write/scripts/cf-foo.sh)`.
 
-   Check (2) implementation: read the bats file, grep for
-   `cf_mock "[^"]*" "\(.*\.json\)"`, capture the fixture names.
+   Check (2) implementation: read the bats file and extract fixture
+   names with flexible whitespace between the two quoted `cf_mock`
+   args — existing bats files column-align these for readability, so
+   a single-space pattern misses them. Use extended regex with
+   `[[:space:]]+`, e.g.
+
+   ```sh
+   grep -Eo 'cf_mock[[:space:]]+"[^"]*"[[:space:]]+"[^"]+\.json"' "$bats_file" \
+     | sed -E 's/.*"([^"]+\.json)".*/\1/'
+   ```
+
    Check (3): for each captured name, assert
    `tests/fixtures/<name>` exists.
    Check (4): grep the owning `SKILL.md` for a line containing the

--- a/.claude/skills/cloudflare-write/SKILL.md
+++ b/.claude/skills/cloudflare-write/SKILL.md
@@ -520,6 +520,12 @@ three-URL verification checklist, read the full reference at
 - `references/subpath-site-pattern.md` — architecture note for the
   `culture.dev/NAME` sub-site pattern plus a step-by-step recipe for
   standing up a new one.
+- `references/cf-api-gotchas.md` — consolidated index of CF API
+  quirks we've paid for (Pages `per_page` cap, subdomain auto-suffix,
+  Workers multipart `filename` matching, Workers subdomain endpoint
+  method, Workers subdomain default, zone-scope 10000). Read this
+  before your first live `--apply` against a surface you haven't
+  written to before.
 
 ## 4. Output modes
 

--- a/.claude/skills/cloudflare-write/references/cf-api-gotchas.md
+++ b/.claude/skills/cloudflare-write/references/cf-api-gotchas.md
@@ -1,0 +1,140 @@
+# CloudFlare API gotchas
+
+Each entry has paid for itself at least once in live apply runs. They're
+documented in script comments at the site of the guard, and consolidated
+here so loading `cloudflare-write` surfaces the whole set without making
+an agent grep the tree.
+
+When you hit a surprising CF error, check here first. When you *write*
+a new guard into a script, add it here too — otherwise the next agent
+re-learns it.
+
+## 1. Pages `per_page` cap is 10
+
+**Symptom.** Any `GET /accounts/:id/pages/projects` (or its
+deployments sub-resource) returns CF code `8000024` "Invalid list
+options provided" when `per_page >= 11`.
+
+**Root cause.** The Pages API is stricter than the rest of CF —
+most list endpoints accept up to 1000, Pages silently caps at 10.
+`_lib.sh`'s `cf_api_paginated` defaults to `per_page=50`, which
+works everywhere else and fails here.
+
+**Guard.** Pages-touching scripts export `CF_PAGE_SIZE=10` before
+calling `cf_api_paginated`:
+
+- `cf-pages.sh` ([scripts/cf-pages.sh](../../cloudflare/scripts/cf-pages.sh))
+- `cf-pages-project-create.sh`
+- `cf-pages-deployment-delete.sh`
+- `cf-pages-deployments-purge.sh`
+
+Every other list endpoint can keep the library default. If you add a
+new Pages-touching script, export the override before the call or the
+pagination walker will 8000024 on the first request.
+
+Related memory: `memory/pages_pagination_quirk.md`.
+
+## 2. Pages subdomain auto-suffixing
+
+**Symptom.** Create-project response returns `"subdomain":
+"foo-72d.pages.dev"` when you asked for `foo`. Subsequent scripts
+that hard-code `NAME.pages.dev` as the upstream or verification URL
+hit CF 522 / NXDOMAIN.
+
+**Root cause.** `foo.pages.dev` was taken by CF's platform pool.
+CF mints a randomized suffix rather than failing the create. The
+`subdomain` field in the create response is authoritative — the
+project's canonical hostname is whatever it says, not the name you
+asked for. This has hit both `culture-72d.pages.dev` and
+`afi-bn9.pages.dev` in this account.
+
+**Guard.** Always read the `subdomain` field from the create
+response and feed it forward. After-the-fact recovery:
+
+```sh
+bash .claude/skills/cloudflare/scripts/cf-pages.sh --json \
+  | jq -r '.result[] | select(.name == "foo") | .subdomain'
+```
+
+The sub-site pattern recipe
+([references/subpath-site-pattern.md](subpath-site-pattern.md))
+orders the steps deliberately — Pages project first, *then* render
+the Worker with the real subdomain — for exactly this reason.
+
+## 3. Workers multipart uploads match parts by `filename`
+
+**Symptom.** `PUT /accounts/:id/workers/scripts/:name` returns code
+`10021` "Uncaught Error: No such module: worker.js" on an otherwise
+well-formed multipart body.
+
+**Root cause.** `curl -F "worker.js=@/path/to/afi-proxy.js"` emits
+`Content-Disposition: form-data; name="worker.js"; filename="afi-proxy.js"`
+— the `filename` attribute defaults to the source path's basename.
+CF's module resolver keys off the `filename`, not the form-field
+`name`, so `main_module: "worker.js"` can't find a matching part.
+
+**Guard.** Every `-F` in `cf-worker-create.sh` ([scripts/cf-worker-create.sh](../scripts/cf-worker-create.sh))
+carries an explicit `;filename=...` override so the filename is
+independent of the source path:
+
+```sh
+-F "metadata=@$meta_tmp;type=application/json;filename=metadata.json"
+-F "$part_name=@$from_file;type=$part_ct;filename=$part_name"
+```
+
+Removing either `filename=` re-triggers 10021 on every live apply.
+The commit adding the fix (9f2feeb) includes a tall comment at the
+upload site; leave it there for the next reader.
+
+## 4. Workers subdomain endpoint is POST, not PUT
+
+**Symptom.** `PUT /accounts/:id/workers/scripts/:name/subdomain`
+returns code `10405` "Method not allowed for this authentication
+scheme" — misleading: the auth is fine, the method is wrong.
+
+**Root cause.** Unlike `PUT /workers/scripts/:name` (the upload
+endpoint), the subdomain sub-resource is POST-only. CF's error
+message blames auth because the method rejector runs after
+authentication; a better message would say "405".
+
+**Guard.** The subdomain block in `cf-worker-create.sh` uses
+`cf_api ... -X POST` and a comment right above it documents this
+so nobody re-derives it.
+
+## 5. Workers `.workers.dev` subdomain default is DISABLED via API
+
+**Symptom.** A freshly uploaded Worker is unreachable at
+`NAME.<account>.workers.dev` even though a dashboard-created
+counterpart (e.g. `agex-proxy`) is.
+
+**Root cause.** `PUT /accounts/:id/workers/scripts/:name` leaves the
+subdomain attribute at its API default, which is `enabled: false`.
+The dashboard (and `wrangler`) default it to `true`. Two Workers
+with identical upload payloads can diverge on this flag.
+
+**Guard.** `cf-worker-create.sh` follows every successful upload
+with a POST to `/subdomain` carrying
+`{enabled: true, previews_enabled: false}`, matching the live
+`agex-proxy` / `citation-cli-proxy` state. `--no-workers-dev`
+suppresses the second POST for internal Workers that should only
+run on their Workers routes.
+
+## 6. Zone-scoped tokens must cover ALL AgentCulture zones
+
+**Symptom.** `POST /zones/:id/workers/routes` (or any other
+zone-level write) returns code `10000` "Authentication error" even
+for a zone whose write scope you think you granted.
+
+**Root cause.** CF's zone-scope enforcement is all-or-nothing at the
+token-permission layer. A write token scoped to a *subset* of
+AgentCulture zones often returns 10000 for the zones it should
+permit, because CF's permission check runs at organization-scope
+granularity first. The error is shaped like an auth problem, not a
+permissions problem, which makes it easy to chase the wrong rabbit.
+
+**Guard.** Mint write tokens with **All zones from AgentCulture**
+for any zone-level Edit permission (Single Redirect, DNS, Workers
+Routes). `docs/SETUP.md` §1.5 lists every scope in one place so a
+fresh token covers the whole surface.
+
+Related memory: `memory/zone_ids.md`.

--- a/.claude/skills/cloudflare-write/references/cf-api-gotchas.md
+++ b/.claude/skills/cloudflare-write/references/cf-api-gotchas.md
@@ -20,19 +20,18 @@ most list endpoints accept up to 1000, Pages silently caps at 10.
 `_lib.sh`'s `cf_api_paginated` defaults to `per_page=50`, which
 works everywhere else and fails here.
 
-**Guard.** Pages-touching scripts export `CF_PAGE_SIZE=10` before
-calling `cf_api_paginated`:
+**Guard.** Pages-touching scripts set `CF_PAGE_SIZE=10` (either
+exported globally in the script or scoped to a single
+`cf_api_paginated` call) before every Pages list endpoint hit:
 
-- `cf-pages.sh` ([scripts/cf-pages.sh](../../cloudflare/scripts/cf-pages.sh))
-- `cf-pages-project-create.sh`
-- `cf-pages-deployment-delete.sh`
-- `cf-pages-deployments-purge.sh`
+- `cf-pages.sh` ([scripts/cf-pages.sh](../../cloudflare/scripts/cf-pages.sh)) — exports
+- `cf-pages-project-create.sh` — exports
+- `cf-pages-deployment-delete.sh` — scoped per-call
+- `cf-pages-deployments-purge.sh` — scoped per-call
 
 Every other list endpoint can keep the library default. If you add a
-new Pages-touching script, export the override before the call or the
+new Pages-touching script, set the override before each call or the
 pagination walker will 8000024 on the first request.
-
-Related memory: `memory/pages_pagination_quirk.md`.
 
 ## 2. Pages subdomain auto-suffixing
 
@@ -136,5 +135,3 @@ permissions problem, which makes it easy to chase the wrong rabbit.
 for any zone-level Edit permission (Single Redirect, DNS, Workers
 Routes). `docs/SETUP.md` §1.5 lists every scope in one place so a
 fresh token covers the whole surface.
-
-Related memory: `memory/zone_ids.md`.

--- a/.claude/skills/cloudflare/SKILL.md
+++ b/.claude/skills/cloudflare/SKILL.md
@@ -84,7 +84,7 @@ bash .claude/skills/cloudflare/scripts/cf-pages.sh --json | jq '.result[] | sele
 Scripts take zone/project **names**, not IDs — names are resolved
 internally.
 
-## 4. Inventorying agentirc.dev (Phase 2 prep)
+## 4. Inventorying agentirc.dev before cleanup
 
 `agentirc.dev` is the deprecated domain that's been folded into
 `culture.dev/agentirc`. The Pages deployment needs cleanup; this
@@ -147,7 +147,15 @@ CloudFlare Pages list endpoint rejects `per_page >= 11` with
   PATH stub so tests run offline. The real token is only exercised
   manually or in a separately-configured workflow.
 
-## 7. Adding new read scripts
+## 7. References
+
+- `../cloudflare-write/references/cf-api-gotchas.md` — consolidated
+  CF API quirks. Several apply to reads too: the Pages `per_page`
+  cap that `cf-pages.sh` has to work around (gotcha #1) and the
+  zone-scope 10000 behavior (gotcha #6) both bite read-only
+  callers.
+
+## 8. Adding new read scripts
 
 Follow the pattern every existing script uses:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,43 +8,42 @@ CloudFlare management for the **AgentCulture OSS** organization, built as Claude
 
 Parent workspace context lives in `../CLAUDE.md`. The global workspace uses uv for Python, but this repo is bash-based (see "Tooling choice" below).
 
-## Current state
+## Before you start
 
-Phase 1 (read-only skills) is complete, and the first write-ops script (Single Redirect creation) has landed in a **separate skill** so read and write stay decoupled. See each skill's `SKILL.md` for user-facing docs (what each script does, when it runs, how to add new scripts).
+**Don't trust this doc for current state — it drifts.** Every session,
+orient against live CF and the skills themselves, in this order:
 
-Layout:
+1. **Live state.** `bash .claude/skills/cloudflare/scripts/cf-status.sh`
+   — single-shot digest of zones, Workers scripts, Workers routes, and
+   Pages projects. Authoritative answer to "what exists right now."
+2. **Skill for your task.** Load `cloudflare` (read-only) or
+   `cloudflare-write` (mutations). Each skill's `SKILL.md` carries
+   its own current script inventory, token-scope requirements, and
+   the pointers to `references/` for architecture notes and the
+   CF API gotchas we've paid for.
+3. **Session memory.**
+   `~/.claude/projects/-home-spark-git-cloudflare/memory/MEMORY.md`
+   — conversation-scoped agreements (site structure, applied-resource
+   IDs, workflow preferences). Load this if you're picking up
+   unfinished work or need the "why" behind a decision.
 
-```text
-.claude/skills/cloudflare/           # read-only inventory skill
-  SKILL.md                           # user-facing skill instructions + trigger phrases
-  scripts/
-    _lib.sh                          # shared helpers: env load, cf_api, cf_api_paginated,
-                                     # cf_output, cf_output_kv, cf_require_account_id
-    cf-whoami.sh                     # verify token status and expiry
-    cf-zones.sh                      # list zones the token can see
-    cf-dns.sh ZONE                   # list DNS records for a zone (resolves name → id)
-    cf-workers.sh                    # list Workers scripts in the account
-    cf-workers-routes.sh             # aggregate Workers routes across every zone
-    cf-pages.sh [PROJECT]            # list Pages projects (or a project's deployments)
-    cf-status.sh                     # single-shot digest of all of the above
-.claude/skills/cloudflare-write/     # write/edit/delete skill — NEEDS SEPARATE TOKEN
-  SKILL.md
-  scripts/
-    _lib.sh                          # symlink → ../../cloudflare/scripts/_lib.sh (DRY)
-    cf-redirect-create.sh            # create a zone Single Redirect (dry-run default, --apply to commit)
-    cf-dns-create.sh                 # create a DNS record in a zone (same safety pattern)
-    cf-pages-project-create.sh       # create a Pages project from a GitHub repo, --clone-from=PROJECT lifts build/deploy config
-.claude/skills/pr-review/            # vendored from ~/.claude/skills — fetch/reply/resolve PR comments
-tests/
-  bats/                              # bats-core unit tests; PATH-injected curl stub for offline mocking
-  fixtures/                          # canned API responses
-  shellcheck.sh                      # shellcheck every shell script in the repo
-  markdownlint.sh                    # markdownlint-cli2 every .md file in the repo
-docs/SETUP.md                        # token creation walkthrough (read token in §1, write token in §1.5)
-.github/workflows/test.yml           # CI: shellcheck + markdownlint + bats on every PR
-```
+## Layout
 
-**Skills split:** `cloudflare` (read) and `cloudflare-write` (write) are discrete skills with separate discovery triggers so agents can't accidentally mutate state while answering an inventory question. Both share `_lib.sh` via symlink — fixes to the helpers apply to both. Write scripts default to dry-run and require `--apply` to actually POST/PUT/DELETE.
+Four skills under `.claude/skills/`:
+
+- `cloudflare/` — read-only inventory (zones, DNS, Workers, Pages, status).
+- `cloudflare-write/` — mutations; dry-run by default, `--apply` to commit.
+  Carries `templates/` and `references/` (including `cf-api-gotchas.md`).
+- `pr-review/` — vendored PR comment fetch/reply/resolve.
+- `poll/` — background reviewer-wait subagent.
+
+Read each skill's `SKILL.md` for its current script inventory — don't
+maintain a duplicate index here. Supporting infrastructure:
+`tests/bats/` + `tests/fixtures/` (offline via PATH-injected curl
+stub), `tests/shellcheck.sh`, `tests/markdownlint.sh`,
+`.github/workflows/test.yml`, `docs/SETUP.md` (token scopes).
+
+**Skills split:** `cloudflare` (read) and `cloudflare-write` (write) are discrete skills with separate discovery triggers so agents can't accidentally mutate state while answering an inventory question. Both share `_lib.sh` via symlink (`cloudflare-write/scripts/_lib.sh` → `../../cloudflare/scripts/_lib.sh`) — fixes to the helpers apply to both. Write scripts default to dry-run and require `--apply` to actually POST/PUT/DELETE.
 
 Pagination is transparent: `cf_api_paginated` in `_lib.sh` walks every page of a list endpoint so scripts see one aggregated `.result`. `shopt -s inherit_errexit` is enabled in `_lib.sh` so `exit 1` inside `cf_api` propagates through the `$(...)` layer `cf_api_paginated` adds — removing this breaks error-path tests silently.
 
@@ -65,10 +64,23 @@ Bash + `curl` + `jq`, no runtime Python deps. Matches the house style in `cultur
 
 ## Roadmap
 
-1. **Phase 1 — read-only skills** ✓ Done. All seven scripts (`cf-whoami`, `cf-zones`, `cf-dns`, `cf-workers`, `cf-workers-routes`, `cf-pages`, `cf-status`) plus pagination, CI, and docs.
-2. **Phase 2 — write skill bootstrap + first redirect** ✓ In progress. Introduces the `cloudflare-write` skill and `cf-redirect-create.sh` (issue #2 — `agentculture.org → culture.dev`). Establishes the dry-run-by-default / `--apply`-to-commit safety pattern that all future `cf-*-create.sh` / `cf-*-update.sh` / `cf-*-delete.sh` scripts will follow.
-3. **Phase 3 — `agentirc.dev` cleanup.** `agentirc.dev` is deprecated. Uses the inventory scripts (`cf-pages`, `cf-dns`, `cf-workers-routes`) as the audit trail, then deletes via new `cf-*-delete.sh` scripts in `cloudflare-write`.
-4. **Later:** multi-domain support, mesh integration, expansion to R2 / Access / Zero Trust, and potentially mixed CloudFlare–AWS workflows.
+1. **Phase 1 — read-only skills** ✓ Done.
+2. **Phase 2 — write skill + create primitives** ✓ Done. Establishes
+   the dry-run-by-default / `--apply`-to-commit pattern all future
+   `cf-*-create.sh` / `cf-*-update.sh` / `cf-*-delete.sh` follow.
+3. **Phase 2.5 — sub-site pattern** ✓ Done for `agex`, `citation-cli`,
+   `afi`; `zehut` and `shushu` pending. Pattern is Direct Upload
+   Pages project + proxy Worker + Workers route — see
+   `cloudflare-write/references/subpath-site-pattern.md`.
+4. **Phase 3 — delete primitives + `agentirc.dev` cleanup.** Needs
+   `cf-pages-project-delete.sh`, `cf-worker-delete.sh`,
+   `cf-workers-route-delete.sh` first, then the audit-then-delete
+   run on `agentirc.dev` (still deprecated, still present).
+5. **Later:** mesh integration, R2 / Access / Zero Trust, mixed
+   CloudFlare–AWS workflows.
+
+Because this drifts: `cf-status.sh` is authoritative for what
+exists; this section is authoritative for *what we plan next*.
 
 ## Conventions for adding code
 
@@ -95,7 +107,3 @@ All work goes through a feature branch + PR + automated review cycle (qodo, Copi
 - **After `gh pr create`, immediately invoke the `poll` skill.** It spawns a background subagent that watches the PR and notifies you only when both qodo and Copilot have finished. Cheaper than self-paced wakeups because the main session doesn't burn context on heartbeats. See `.claude/skills/poll/SKILL.md`.
 - **Fetch ALL review feedback with one call:** `bash .claude/skills/pr-review/scripts/pr-comments.sh <PR>`. It returns inline comments, issue comments, top-level reviews, and SonarCloud new issues in a single pass — don't hand-roll `gh api` / `curl sonarcloud.io` calls.
 - **Triage / reply / resolve** via the `pr-review` skill once the poll wakes you.
-
-## Active design context
-
-Live design decisions (scope, auth shape, skill layout, phase-1 targets) are tracked in `/home/spark/.claude/projects/-home-spark-git-cloudflare/memory/` — read `MEMORY.md` there at the start of a session if you need the current state of the conversation's working agreements.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,11 +21,15 @@ orient against live CF and the skills themselves, in this order:
    its own current script inventory, token-scope requirements, and
    the pointers to `references/` for architecture notes and the
    CF API gotchas we've paid for.
-3. **Session memory.**
-   `~/.claude/projects/-home-spark-git-cloudflare/memory/MEMORY.md`
-   — conversation-scoped agreements (site structure, applied-resource
-   IDs, workflow preferences). Load this if you're picking up
-   unfinished work or need the "why" behind a decision.
+3. **Session memory** (Claude Code session-local, not committed to the
+   repo). Claude Code persists per-project memory under
+   `~/.claude/projects/<slug>/memory/`, where `<slug>` is a
+   filename-safe encoding of this repo's absolute path
+   (e.g. `/home/alice/src/cloudflare` → `-home-alice-src-cloudflare`).
+   Read `MEMORY.md` in that directory for conversation-scoped
+   agreements (site structure, applied-resource IDs, workflow
+   preferences). Only your own sessions have written there — freshly
+   cloned machines start empty.
 
 ## Layout
 


### PR DESCRIPTION
## Summary

Post-PR-#17 introspection pass. One PR, three parallel tracks:

1. **Lessons belong to the skill that owns them.** New consolidated CF-API gotchas index at `.claude/skills/cloudflare-write/references/cf-api-gotchas.md` — one section per surprise we've paid for (Pages `per_page` cap, subdomain auto-suffix, Workers multipart `filename` matching, Workers subdomain POST-not-PUT, Workers subdomain default-disabled, zone-scope 10000). Linked from both SKILL.md files so loading the skill surfaces the pointer.

2. **CLAUDE.md becomes a lean map, not a state dump.** The 25-line drift-prone Layout block is gone; replaced by a four-line skill summary (each skill's SKILL.md owns its own current inventory). New "Before you start" section at the top orients agents to live state via `cf-status.sh` first, skill SKILL.md second, session memory third. Roadmap refreshed to truth: Phase 1+2 ✓ Done, Phase 2.5 sub-site pattern ✓ Done for agex/citation-cli/afi (zehut+shushu pending), Phase 3 reframed around the delete-script primitives that need to land before `agentirc.dev` can be cleaned up.

3. **Doctest-align sub-agent.** New `.claude/agents/doctest-align.md`. Given the current branch's diff vs main (unioned with staged + unstaged — a subtle bug the self-test actually surfaced before push), it verifies every new/modified `cf-*.sh` has a `tests/bats/<name>.bats`, at least one `cf_mock` line, the referenced fixture exists, and the script appears in its owning SKILL.md. Read-only, exits 1 on any miss. Parent agent invokes before `gh pr create`; CI wiring optional/future.

## Test plan

- [x] `bash tests/shellcheck.sh` — clean (no shell code changed)
- [x] `bash tests/markdownlint.sh` — 0 errors across 10 files (includes the new agent + reference)
- [x] `bats tests/bats/` — 204 green (no tests touched)
- [x] Self-tested doctest-align on this PR's own diff — zero cf-*.sh changed → exit 0 with "no cf-*.sh script changes — alignment check not applicable", expected for a doc-only PR
- [x] Self-test surfaced and fixed a real bug in the agent spec (union staged/unstaged/branch-diff sources instead of first-match-wins; original logic would falsely short-circuit on a branch with pending edits but zero commits — exactly the pre-gh-pr-create state)

## Files changed

| Path | Change |
|---|---|
| `CLAUDE.md` | Trim Layout, add Before-you-start, refresh Roadmap |
| `.claude/skills/cloudflare/SKILL.md` | Fix §4 heading (drop "Phase 2 prep"), add References section |
| `.claude/skills/cloudflare-write/SKILL.md` | Add cf-api-gotchas.md pointer to the existing References block |
| `.claude/skills/cloudflare-write/references/cf-api-gotchas.md` | **New** — six gotchas, symptom + root cause + guard |
| `.claude/agents/doctest-align.md` | **New** — Claude Code sub-agent for doc-test alignment |

🤖 Generated with [Claude Code](https://claude.com/claude-code)