### PR TITLE
docs: rename repo → cfafi (CloudFlare Agent First Interface)

### DIFF
--- a/.claude/agents/doctest-align.md
+++ b/.claude/agents/doctest-align.md
@@ -14,7 +14,7 @@ tools: Bash, Read, Glob, Grep
 
 # doctest-align
 
-You are the doc-test-alignment checker for the cloudflare repo.
+You are the doc-test-alignment checker for the cfafi repo.
 
 ## What you verify
 
@@ -32,7 +32,7 @@ For every cf-*.sh script added or modified on the current branch vs
 
 ## How to run
 
-Always work from the repo root (`/home/spark/git/cloudflare` or
+Always work from the repo root (`/home/spark/git/cfafi` or
 wherever the caller invokes you). Never modify any file.
 
 1. **Determine the changed-files set — UNION all four sources**, do

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,4 +1,4 @@
-# markdownlint-cli2 config for the cloudflare repo.
+# markdownlint-cli2 config for the cfafi repo.
 # Mirrors the workspace's global ~/.markdownlint-cli2.yaml so clones get
 # identical behaviour without depending on per-machine setup.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,9 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What this repo is
 
-CloudFlare management for the **AgentCulture OSS** organization, built as Claude Code **skills and subagents** ("ClaudeFlare"). Part of the Culture workspace (see `culture` CLI / <https://culture.dev>). Maintained jointly by agents and one human (Ori Nachum).
+**cfafi** — **C**loud**F**lare **A**gent **F**irst **I**nterface. CloudFlare management for the **AgentCulture OSS** organization, built as Claude Code **skills and subagents**. Part of the Culture workspace (see `culture` CLI / <https://culture.dev>). Maintained jointly by agents and one human (Ori Nachum).
+
+Repo lives at <https://github.com/agentculture/cfafi> (renamed from `cloudflare`; the skill directories under `.claude/skills/` are still named `cloudflare/` and `cloudflare-write/` pending the next renovation pass).
 
 Parent workspace context lives in `../CLAUDE.md`. The global workspace uses uv for Python, but this repo is bash-based (see "Tooling choice" below).
 
@@ -25,7 +27,7 @@ orient against live CF and the skills themselves, in this order:
    repo). Claude Code persists per-project memory under
    `~/.claude/projects/<slug>/memory/`, where `<slug>` is a
    filename-safe encoding of this repo's absolute path
-   (e.g. `/home/alice/src/cloudflare` → `-home-alice-src-cloudflare`).
+   (e.g. `/home/alice/src/cfafi` → `-home-alice-src-cfafi`).
    Read `MEMORY.md` in that directory for conversation-scoped
    agreements (site structure, applied-resource IDs, workflow
    preferences). Only your own sessions have written there — freshly

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-# cloudflare
+# cfafi
 
-CloudFlare management for the [AgentCulture OSS](https://culture.dev) organization, implemented as Claude Code skills and subagents ("ClaudeFlare"). Part of the Culture workspace.
+**C**loud**F**lare **A**gent **F**irst **I**nterface — CloudFlare management for the [AgentCulture OSS](https://culture.dev) organization, implemented as Claude Code skills and subagents. Part of the Culture workspace.
+
+> Renamed from `cloudflare` → `cfafi`. The skill directories under `.claude/skills/` (`cloudflare/`, `cloudflare-write/`) still use the old names pending a follow-up renovation pass.
 
 ## Setup
 


### PR DESCRIPTION
## Summary
- GitHub repo was renamed `agentculture/cloudflare` → `agentculture/cfafi`; update `README.md` and `CLAUDE.md` to match.
- Expand the name: **cfafi** = **C**loud**F**lare **A**gent **F**irst **I**nterface.
- Flag that `.claude/skills/cloudflare/` and `.claude/skills/cloudflare-write/` still carry the old names — that rename lands in the next session with the script renovation pass.

## Test plan
- [ ] Docs-only change — no scripts or tests touched
- [ ] `bash tests/shellcheck.sh` still green
- [ ] `bash tests/markdownlint.sh` still green
- [ ] `bats tests/bats/` still green

- Claude