### PR TITLE
fix: find_org swallows CF 9999 (Access not enabled) into None

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- `find_org` now swallows CF error 9999 (`access.api.error.not_enabled`) into `None` so setup/show emit cfafi's friendly Zero-Trust-disabled error with a dashboard link instead of bubbling CF's raw 4xx.
+- `find_org` now swallows CF error 9999 (`access.api.error.not_enabled`) into `None` so `setup` raises a curated "Zero Trust is not enabled" message with a dashboard link, and `show` renders the org as `(not found)`, instead of bubbling CF's raw 4xx.
 
 ## [0.2.0] - 2026-05-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented here. The format
 is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.1] - 2026-05-07
+
+### Fixed
+
+- `find_org` now swallows CF error 9999 (`access.api.error.not_enabled`) into `None` so setup/show emit cfafi's friendly Zero-Trust-disabled error with a dashboard link instead of bubbling CF's raw 4xx.
+
 ## [0.2.0] - 2026-05-07
 
 ### Added

--- a/cfafi/__init__.py
+++ b/cfafi/__init__.py
@@ -1,3 +1,3 @@
 """cfafi — CloudFlare Agent First Interface."""
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"

--- a/cfafi/_api.py
+++ b/cfafi/_api.py
@@ -71,14 +71,17 @@ def _raise_http_error(exc: urllib.error.HTTPError) -> NoReturn:
     errors = data.get("errors") or [{"code": exc.code, "message": exc.reason}]
     first = errors[0]
     code_category = EXIT_AUTH if exc.code in (401, 403) else EXIT_API
+    cf_code_raw = first.get("code", exc.code)
+    cf_error_code = cf_code_raw if isinstance(cf_code_raw, int) else None
     raise CfafiError(
         code=code_category,
-        message=f"CloudFlare API {first.get('code', exc.code)}: {first.get('message', exc.reason)}",
+        message=f"CloudFlare API {cf_code_raw}: {first.get('message', exc.reason)}",
         remediation=(
             "check token scopes against docs/SETUP.md"
             if code_category == EXIT_AUTH
             else f"HTTP {exc.code} from CloudFlare; inspect the request body and retry"
         ),
+        cf_error_code=cf_error_code,
     ) from None
 
 

--- a/cfafi/_remote_login/__init__.py
+++ b/cfafi/_remote_login/__init__.py
@@ -147,12 +147,26 @@ def setup(
 
 
 def show(*, ctx: Context) -> ShowResult:
-    """Read every resource setup would create, returning presence/absence."""
+    """Read every resource setup would create, returning presence/absence.
+
+    When Zero Trust is disabled (``find_org`` returns None), every other
+    Access endpoint (`/access/apps`, `/access/service_tokens`) would also
+    return CF error 9999. Skip those probes and report the Access-side
+    fields as None — the operator gets a clean "(not found)" rendering
+    instead of a fresh 4xx mid-`show`. Tunnel and DNS aren't
+    Access-scoped, so we still query them.
+    """
     org = find_org(account_id=ctx.account_id)
     tunnel = find_tunnel(
         account_id=ctx.account_id, name=ctx.names.tunnel_name,
     )
     dns = find_cname(zone_id=ctx.zone_id, hostname=ctx.hostname)
+    if org is None:
+        return ShowResult(
+            team_domain=None,
+            tunnel=tunnel, dns=dns,
+            access_app=None, policy=None, service_token=None,
+        )
     app = find_app(account_id=ctx.account_id, hostname=ctx.hostname)
     policy = (
         find_policy(
@@ -167,7 +181,7 @@ def show(*, ctx: Context) -> ShowResult:
         account_id=ctx.account_id, name=ctx.names.service_token_name,
     )
     return ShowResult(
-        team_domain=(org or {}).get("auth_domain"),
+        team_domain=org.get("auth_domain"),
         tunnel=tunnel,
         dns=dns,
         access_app=app,

--- a/cfafi/_remote_login/_access_org.py
+++ b/cfafi/_remote_login/_access_org.py
@@ -17,8 +17,11 @@ def find_org(*, account_id: str) -> dict | None:
         # any org exists. Treat as "no org" so callers fall into their
         # cleaner Zero-Trust-disabled branch instead of bubbling CF's
         # raw error. Auth/scope errors (401/403) still propagate.
+        # Anchor on the prefix `_raise_http_error` produces (`CloudFlare
+        # API 9999:`) so an unrelated error whose message merely contains
+        # "9999" as a substring can't false-positive.
         msg = exc.message or ""
-        if "9999" in msg and "not_enabled" in msg:
+        if "CloudFlare API 9999:" in msg and "not_enabled" in msg:
             return None
         raise
     return response.get("result") or None

--- a/cfafi/_remote_login/_access_org.py
+++ b/cfafi/_remote_login/_access_org.py
@@ -8,9 +8,19 @@ from cfafi.cli._errors import EXIT_USER_ERROR, CfafiError
 
 def find_org(*, account_id: str) -> dict | None:
     """Return the Access org dict, or None if Zero Trust is not enabled."""
-    response = _api.http_request(
-        "GET", f"/accounts/{account_id}/access/organizations"
-    )
+    try:
+        response = _api.http_request(
+            "GET", f"/accounts/{account_id}/access/organizations"
+        )
+    except CfafiError as exc:
+        # CF returns code 9999 / "access.api.error.not_enabled" before
+        # any org exists. Treat as "no org" so callers fall into their
+        # cleaner Zero-Trust-disabled branch instead of bubbling CF's
+        # raw error. Auth/scope errors (401/403) still propagate.
+        msg = exc.message or ""
+        if "9999" in msg and "not_enabled" in msg:
+            return None
+        raise
     return response.get("result") or None
 
 

--- a/cfafi/_remote_login/_access_org.py
+++ b/cfafi/_remote_login/_access_org.py
@@ -13,15 +13,11 @@ def find_org(*, account_id: str) -> dict | None:
             "GET", f"/accounts/{account_id}/access/organizations"
         )
     except CfafiError as exc:
-        # CF returns code 9999 / "access.api.error.not_enabled" before
+        # CF returns code 9999 ("access.api.error.not_enabled") before
         # any org exists. Treat as "no org" so callers fall into their
         # cleaner Zero-Trust-disabled branch instead of bubbling CF's
         # raw error. Auth/scope errors (401/403) still propagate.
-        # Anchor on the prefix `_raise_http_error` produces (`CloudFlare
-        # API 9999:`) so an unrelated error whose message merely contains
-        # "9999" as a substring can't false-positive.
-        msg = exc.message or ""
-        if "CloudFlare API 9999:" in msg and "not_enabled" in msg:
+        if exc.cf_error_code == 9999:
             return None
         raise
     return response.get("result") or None

--- a/cfafi/cli/_errors.py
+++ b/cfafi/cli/_errors.py
@@ -37,6 +37,11 @@ class CfafiError(Exception):
     code: int
     message: str
     remediation: str = ""
+    # Populated by `_raise_http_error` from the CF response's
+    # `errors[0].code` when present. None for non-CF errors (env,
+    # validation). Lets helpers branch on a structured code without
+    # parsing `message`. See `_remote_login._access_org.find_org`.
+    cf_error_code: int | None = None
 
     def __post_init__(self) -> None:
         super().__init__(self.message)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cfafi"
-version = "0.2.0"
+version = "0.2.1"
 description = "CloudFlare Agent First Interface — agent-first CLI for CloudFlare management in the AgentCulture org."
 readme = "README.md"
 license = "MIT"

--- a/tests/test_remote_login_access_org.py
+++ b/tests/test_remote_login_access_org.py
@@ -68,6 +68,27 @@ def test_find_org_propagates_other_errors(http_stub):
     assert "Authentication error" in exc.value.message
 
 
+def test_find_org_does_not_swallow_unrelated_error_with_9999_substring(http_stub):
+    # The check is anchored on "CloudFlare API 9999:" so an unrelated
+    # error whose message merely contains "9999" or "not_enabled" as
+    # substrings (e.g. an id or a different field) must still propagate.
+    http_stub.set(
+        "GET", "/accounts/acc-1/access/organizations",
+        CfafiError(
+            code=EXIT_API,
+            message=(
+                "CloudFlare API 12345: tunnel id 9999-aaaa not_enabled flag "
+                "in unrelated context"
+            ),
+            remediation="HTTP 500 from CloudFlare; inspect the request body and retry",
+        ),
+    )
+    with pytest.raises(CfafiError) as exc:
+        find_org(account_id="acc-1")
+    assert exc.value.code == EXIT_API
+    assert "12345" in exc.value.message
+
+
 def test_ensure_org_returns_existing_without_posting(http_stub):
     http_stub.set("GET", "/accounts/acc-1/access/organizations", {
         "success": True, "errors": [], "messages": [],

--- a/tests/test_remote_login_access_org.py
+++ b/tests/test_remote_login_access_org.py
@@ -3,7 +3,7 @@
 import pytest
 
 from cfafi._remote_login._access_org import find_org, ensure_org
-from cfafi.cli._errors import CfafiError, EXIT_USER_ERROR
+from cfafi.cli._errors import CfafiError, EXIT_API, EXIT_AUTH, EXIT_USER_ERROR
 
 
 def test_find_org_returns_auth_domain_when_present(http_stub):
@@ -28,6 +28,44 @@ def test_find_org_returns_none_when_result_is_null(http_stub):
         "success": True, "errors": [], "messages": [], "result": None,
     })
     assert find_org(account_id="acc-1") is None
+
+
+def test_find_org_returns_none_when_access_not_enabled(http_stub):
+    # CF returns HTTP 4xx with `code: 9999, message:
+    # "access.api.error.not_enabled: ..."` before Zero Trust is
+    # enabled on the account. The helper must swallow that into None
+    # so callers fall into their cleaner ZT-disabled branch rather
+    # than bubbling CF's raw error.
+    http_stub.set(
+        "GET", "/accounts/acc-1/access/organizations",
+        CfafiError(
+            code=EXIT_API,
+            message=(
+                "CloudFlare API 9999: access.api.error.not_enabled: "
+                "Access is not enabled. Visit the Access dashboard..."
+            ),
+            remediation="HTTP 404 from CloudFlare; inspect the request body and retry",
+        ),
+    )
+    assert find_org(account_id="acc-1") is None
+
+
+def test_find_org_propagates_other_errors(http_stub):
+    # Non-9999 CfafiErrors (e.g. auth / 403 from missing scopes) must
+    # propagate so the operator sees the real cause instead of a
+    # silently-empty org.
+    http_stub.set(
+        "GET", "/accounts/acc-1/access/organizations",
+        CfafiError(
+            code=EXIT_AUTH,
+            message="CloudFlare API 10000: Authentication error",
+            remediation="check token scopes against docs/SETUP.md",
+        ),
+    )
+    with pytest.raises(CfafiError) as exc:
+        find_org(account_id="acc-1")
+    assert exc.value.code == EXIT_AUTH
+    assert "Authentication error" in exc.value.message
 
 
 def test_ensure_org_returns_existing_without_posting(http_stub):

--- a/tests/test_remote_login_access_org.py
+++ b/tests/test_remote_login_access_org.py
@@ -31,9 +31,9 @@ def test_find_org_returns_none_when_result_is_null(http_stub):
 
 
 def test_find_org_returns_none_when_access_not_enabled(http_stub):
-    # CF returns HTTP 4xx with `code: 9999, message:
-    # "access.api.error.not_enabled: ..."` before Zero Trust is
-    # enabled on the account. The helper must swallow that into None
+    # CF returns HTTP 4xx with `errors[0].code == 9999` before Zero
+    # Trust is enabled on the account. The helper branches on the
+    # typed `cf_error_code` field (populated by `_raise_http_error`)
     # so callers fall into their cleaner ZT-disabled branch rather
     # than bubbling CF's raw error.
     http_stub.set(
@@ -45,6 +45,7 @@ def test_find_org_returns_none_when_access_not_enabled(http_stub):
                 "Access is not enabled. Visit the Access dashboard..."
             ),
             remediation="HTTP 404 from CloudFlare; inspect the request body and retry",
+            cf_error_code=9999,
         ),
     )
     assert find_org(account_id="acc-1") is None
@@ -60,6 +61,7 @@ def test_find_org_propagates_other_errors(http_stub):
             code=EXIT_AUTH,
             message="CloudFlare API 10000: Authentication error",
             remediation="check token scopes against docs/SETUP.md",
+            cf_error_code=10000,
         ),
     )
     with pytest.raises(CfafiError) as exc:
@@ -68,10 +70,10 @@ def test_find_org_propagates_other_errors(http_stub):
     assert "Authentication error" in exc.value.message
 
 
-def test_find_org_does_not_swallow_unrelated_error_with_9999_substring(http_stub):
-    # The check is anchored on "CloudFlare API 9999:" so an unrelated
-    # error whose message merely contains "9999" or "not_enabled" as
-    # substrings (e.g. an id or a different field) must still propagate.
+def test_find_org_does_not_swallow_error_with_9999_in_message_only(http_stub):
+    # The match is on the typed `cf_error_code` field, not the message
+    # body. An error whose message merely *contains* "9999" (e.g. as
+    # part of an id) but whose CF code is something else must propagate.
     http_stub.set(
         "GET", "/accounts/acc-1/access/organizations",
         CfafiError(
@@ -81,6 +83,7 @@ def test_find_org_does_not_swallow_unrelated_error_with_9999_substring(http_stub
                 "in unrelated context"
             ),
             remediation="HTTP 500 from CloudFlare; inspect the request body and retry",
+            cf_error_code=12345,
         ),
     )
     with pytest.raises(CfafiError) as exc:

--- a/tests/test_remote_login_orchestrator.py
+++ b/tests/test_remote_login_orchestrator.py
@@ -222,3 +222,31 @@ def test_teardown_keep_tunnel_skips_tunnel_delete(http_stub):
     # tunnel listing is skipped entirely under keep_tunnel
     result = teardown(ctx=_ctx(), keep_tunnel=True)
     assert "tunnel" not in [s.name for s in result.steps]
+
+
+def test_setup_raises_clean_error_when_zt_not_enabled(http_stub):
+    # When Zero Trust isn't enabled, find_org swallows the CF 9999
+    # error into None; setup() should then raise its friendlier
+    # EXIT_USER_ERROR pointing at the dashboard URL rather than
+    # bubbling CF's raw "Access is not enabled" message.
+    from cfafi.cli._errors import EXIT_API, EXIT_USER_ERROR, CfafiError
+
+    http_stub.set(
+        "GET", "/accounts/acc-1/access/organizations",
+        CfafiError(
+            code=EXIT_API,
+            message=(
+                "CloudFlare API 9999: access.api.error.not_enabled: "
+                "Access is not enabled."
+            ),
+            remediation="HTTP 404 from CloudFlare; inspect the request body and retry",
+        ),
+    )
+    with pytest.raises(CfafiError) as exc:
+        setup(
+            ctx=_ctx(), emails=["me@example.com"], domains=[],
+            with_service_token=False, session_duration="24h",
+        )
+    assert exc.value.code == EXIT_USER_ERROR
+    assert "Zero Trust is not enabled" in exc.value.message
+    assert "one.dash.cloudflare.com" in (exc.value.remediation or "")

--- a/tests/test_remote_login_orchestrator.py
+++ b/tests/test_remote_login_orchestrator.py
@@ -240,6 +240,7 @@ def test_setup_raises_clean_error_when_zt_not_enabled(http_stub):
                 "Access is not enabled."
             ),
             remediation="HTTP 404 from CloudFlare; inspect the request body and retry",
+            cf_error_code=9999,
         ),
     )
     with pytest.raises(CfafiError) as exc:
@@ -250,3 +251,35 @@ def test_setup_raises_clean_error_when_zt_not_enabled(http_stub):
     assert exc.value.code == EXIT_USER_ERROR
     assert "Zero Trust is not enabled" in exc.value.message
     assert "one.dash.cloudflare.com" in (exc.value.remediation or "")
+
+
+def test_show_short_circuits_access_endpoints_when_zt_disabled(http_stub):
+    # qodo Bug #2: when find_org returns None, show() must NOT call
+    # /access/apps or /access/service_tokens — those would 9999 too.
+    # Tunnel and DNS are still queried (not Access-scoped).
+    from cfafi.cli._errors import EXIT_API, CfafiError
+
+    http_stub.set(
+        "GET", "/accounts/acc-1/access/organizations",
+        CfafiError(
+            code=EXIT_API,
+            message="CloudFlare API 9999: access.api.error.not_enabled: ...",
+            remediation="...",
+            cf_error_code=9999,
+        ),
+    )
+    http_stub.set("GET", "/accounts/acc-1/cfd_tunnel", _empty_list())
+    http_stub.set("GET", "/zones/zid-1/dns_records", _empty_list())
+
+    result = show(ctx=_ctx())
+    assert result.team_domain is None
+    assert result.access_app is None
+    assert result.policy is None
+    assert result.service_token is None
+    # Tunnel and DNS still queried.
+    paths = [c[1] for c in http_stub.calls]
+    assert "/accounts/acc-1/cfd_tunnel" in paths
+    assert "/zones/zid-1/dns_records" in paths
+    # Access endpoints MUST NOT appear.
+    assert "/accounts/acc-1/access/apps" not in paths
+    assert "/accounts/acc-1/access/service_tokens" not in paths

--- a/uv.lock
+++ b/uv.lock
@@ -69,7 +69,7 @@ wheels = [
 
 [[package]]
 name = "cfafi"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary

Follow-up from the live-smoke discovery on PR #23. On a CF account where Zero Trust isn't yet enabled, `cfafi remote-login show` (and `setup`) bubbles CF's raw `9999 access.api.error.not_enabled` instead of cfafi's curated "Zero Trust is not enabled" message with the dashboard link.

`find_org` now catches `CfafiError` from the `/access/organizations` GET and treats the 9999 / `not_enabled` shape as "no org" (`return None`), so the orchestrator's existing clean-error branch in `setup()` fires and `show` renders `(not found)` for the org. Auth/scope errors still propagate.

Live behaviour after this PR (against a ZT-disabled account):

```
$ cfafi remote-login show --hostname X.example.com
## Remote login state — X.example.com
- **zero-trust-org:** (not found)
- **tunnel:** (not found)
...

$ cfafi remote-login setup --hostname X.example.com --allow me@example.com --apply
error: Zero Trust is not enabled for this account
hint: enable Zero Trust at https://one.dash.cloudflare.com/?to=/:account/access (pick a team subdomain), then re-run setup
```

## Tests

- `test_find_org_returns_none_when_access_not_enabled` — http_stub raises a 9999 CfafiError; `find_org` returns None.
- `test_find_org_propagates_other_errors` — non-9999 CfafiError (e.g. EXIT_AUTH 403) must propagate.
- `test_setup_raises_clean_error_when_zt_not_enabled` — orchestrator-level: `setup()` raises `EXIT_USER_ERROR` with the dashboard URL when `find_org` reports None via the new path.

135 tests pass; markdownlint clean.

## Notes

String-matching CF's error message is brittle. The cleaner long-term move is to expose the underlying CF error code on `CfafiError` (typed `cf_error_code: int | None`) and branch on that. Touches `cfafi/_api.py:_raise_http_error` plus the dataclass; out of scope here, worth doing the next time another helper needs code-aware error handling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)