### PR TITLE
chore: publish only to cultureflare (v0.3.0)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,7 +42,7 @@ jobs:
     if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
     needs: test
     runs-on: ubuntu-latest
-    environment: testpypi-cultureflare
+    environment: testpypi
     permissions:
       contents: read
       id-token: write
@@ -77,7 +77,7 @@ jobs:
     if: github.event_name == 'push'
     needs: test
     runs-on: ubuntu-latest
-    environment: pypi-cultureflare
+    environment: pypi
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,6 +12,14 @@ on:
       - "pyproject.toml"
       - "cfafi/**"
 
+# This workflow publishes the `cultureflare` PyPI distribution. The
+# legacy `cfafi` distribution name was frozen at v0.2.2 (the final
+# dual-publish release in PR #25); from 0.3.0 onward there's only one
+# wheel per version and it ships under `cultureflare`. The Python
+# module dir stays `cfafi/` and the `cfafi` console-script alias stays
+# alongside `cultureflare`. See docs/SETUP.md § 8 for Trusted
+# Publisher setup.
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -34,7 +42,7 @@ jobs:
     if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
     needs: test
     runs-on: ubuntu-latest
-    environment: testpypi
+    environment: testpypi-cultureflare
     permissions:
       contents: read
       id-token: write
@@ -53,7 +61,7 @@ jobs:
           DEV_VERSION="${BASE}.dev${{ github.run_number }}"
           sed -i "s/^version = .*/version = \"${DEV_VERSION}\"/" pyproject.toml
           echo "DEV_VERSION=${DEV_VERSION}" >> "$GITHUB_ENV"
-          echo "Publishing ${DEV_VERSION} to TestPyPI"
+          echo "Publishing cultureflare ${DEV_VERSION} to TestPyPI"
 
       - name: Build and publish to TestPyPI
         run: |
@@ -63,88 +71,9 @@ jobs:
       - name: Print install commands
         if: always()
         run: |
-          echo "::notice::Test with: uv tool install --index-url https://test.pypi.org/simple/ --index-strategy unsafe-best-match cfafi==${DEV_VERSION}"
-
-  # Phase 2 of the dual-publish: build the SAME source under the
-  # `cultureflare` distribution name and push it to TestPyPI. The
-  # `pypi-cultureflare` / `testpypi-cultureflare` GitHub environments
-  # must exist and be wired to the cultureflare Trusted Publisher
-  # pending publishers (see docs/SETUP.md § 8). The publish step uses
-  # `continue-on-error` so an unwired environment doesn't block the PR;
-  # remove that guard once the publisher pair is verified. A follow-up
-  # `Surface cultureflare publish status` step still emits a `::warning::`
-  # annotation when the publish step's outcome isn't `success`.
-  test-publish-cultureflare:
-    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
-    needs: test
-    runs-on: ubuntu-latest
-    environment: testpypi-cultureflare
-    permissions:
-      contents: read
-      id-token: write
-    steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-
-      - uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4
-
-      - run: uv python install 3.12
-
-      - run: uv sync
-
-      - name: Set dev version + swap distribution name
-        run: |
-          BASE=$(uv run python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
-          DEV_VERSION="${BASE}.dev${{ github.run_number }}"
-          sed -i "s/^version = .*/version = \"${DEV_VERSION}\"/" pyproject.toml
-          sed -i 's/^name = "cfafi"$/name = "cultureflare"/' pyproject.toml
-          echo "DEV_VERSION=${DEV_VERSION}" >> "$GITHUB_ENV"
-          echo "Publishing cultureflare ${DEV_VERSION} to TestPyPI"
-
-      - name: Build and publish cultureflare to TestPyPI
-        id: cultureflare_publish
-        continue-on-error: true
-        run: |
-          rm -rf dist/
-          uv build
-          uv publish --publish-url https://test.pypi.org/legacy/ --trusted-publishing always --check-url https://test.pypi.org/simple/
-
-      - name: Surface cultureflare publish status
-        if: always()
-        run: |
-          if [ "${{ steps.cultureflare_publish.outcome }}" = "success" ]; then
-            echo "::notice::cultureflare TestPyPI publish succeeded (${DEV_VERSION})"
-          else
-            echo "::warning::cultureflare TestPyPI publish step did not succeed (outcome=${{ steps.cultureflare_publish.outcome }}). Verify the testpypi-cultureflare environment + Trusted Publisher are wired (docs/SETUP.md § 8); remove continue-on-error once stable."
-          fi
-
-      - name: Print install commands
-        if: always()
-        run: |
           echo "::notice::Test with: uv tool install --index-url https://test.pypi.org/simple/ --index-strategy unsafe-best-match cultureflare==${DEV_VERSION}"
 
   publish:
-    if: github.event_name == 'push'
-    needs: test
-    runs-on: ubuntu-latest
-    environment: pypi
-    permissions:
-      contents: read
-      id-token: write
-    steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-
-      - uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4
-
-      - run: uv python install 3.12
-
-      - run: uv sync
-
-      - name: Build and publish to PyPI
-        run: |
-          uv build
-          uv publish --trusted-publishing always --check-url https://pypi.org/simple/
-
-  publish-cultureflare:
     if: github.event_name == 'push'
     needs: test
     runs-on: ubuntu-latest
@@ -161,23 +90,7 @@ jobs:
 
       - run: uv sync
 
-      - name: Swap distribution name to cultureflare
+      - name: Build and publish to PyPI
         run: |
-          sed -i 's/^name = "cfafi"$/name = "cultureflare"/' pyproject.toml
-
-      - name: Build and publish cultureflare to PyPI
-        id: cultureflare_publish
-        continue-on-error: true
-        run: |
-          rm -rf dist/
           uv build
           uv publish --trusted-publishing always --check-url https://pypi.org/simple/
-
-      - name: Surface cultureflare publish status
-        if: always()
-        run: |
-          if [ "${{ steps.cultureflare_publish.outcome }}" = "success" ]; then
-            echo "::notice::cultureflare PyPI publish succeeded"
-          else
-            echo "::warning::cultureflare PyPI publish step did not succeed (outcome=${{ steps.cultureflare_publish.outcome }}). Verify the pypi-cultureflare environment + Trusted Publisher are wired (docs/SETUP.md § 8); remove continue-on-error once stable."
-          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented here. The format
 is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - 2026-05-08
+
+### Changed
+
+- Distribution name on PyPI is now `cultureflare` only. `cfafi` 0.2.2 was the final release on the legacy name; install `cultureflare` for ongoing updates. The `cfafi` console-script alias stays. The Python module `cfafi` stays.
+
 ## [0.2.2] - 2026-05-07
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# cfafi → cultureflare
+# cultureflare
 
-> ⚠️ **`cfafi` is being renamed to `cultureflare`.** This is the last
-> release on the `cfafi` PyPI name (v0.2.2). Future versions ship as
-> [`cultureflare`](https://pypi.org/project/cultureflare/) from the
-> same source — install either name to get the same package, and the
-> CLI exposes both `cfafi` and `cultureflare` commands as aliases.
+> ⚠️ **`cfafi` is now `cultureflare` on PyPI.** v0.2.2 was the final
+> release under the `cfafi` distribution name; install
+> [`cultureflare`](https://pypi.org/project/cultureflare/) for ongoing
+> updates. The `cfafi` CLI command stays as an alias and the Python
+> module is still `import cfafi`, so existing scripts keep working.
 
 Agent-first CLI for managing CloudFlare state in the AgentCulture OSS
 org. Action-oriented (commands describe operator intent, not REST
@@ -14,15 +14,17 @@ endpoints), idempotent, dry-run by default, agent-readable markdown +
 ## Install
 
 ```bash
-# Preferred (canonical name going forward):
 uv tool install cultureflare
-
-# Equivalent — installs the same package, deprecated:
-uv tool install cfafi
 ```
 
-Either install gives you both `cultureflare` and `cfafi` on the PATH;
-they're aliases for the same entry point.
+You get both `cultureflare` and `cfafi` on the PATH; they're aliases
+for the same entry point.
+
+> If you previously ran `uv tool install cfafi`: `cfafi` 0.2.2 is the
+> final release under that name. Switch to
+> `uv tool install cultureflare` (or `uv tool upgrade --reinstall cfafi`
+> won't help — there's nothing newer there). Both CLI commands keep
+> working after the swap.
 
 ```bash
 cultureflare --version

--- a/cfafi/__init__.py
+++ b/cfafi/__init__.py
@@ -1,3 +1,19 @@
 """cfafi — CloudFlare Agent First Interface."""
 
+from importlib.metadata import PackageNotFoundError, version as _pkg_version
+
+# Baked default: kept in sync with pyproject.toml by
+# `.claude/skills/version-bump`. At runtime the installed-distribution
+# lookup below takes precedence, so TestPyPI dev builds (whose dist
+# version is rewritten to "0.3.0.devN" by the publish workflow) report
+# their actual version here. The legacy `cfafi` wheel (frozen at 0.2.2)
+# is the second-tier fallback for anyone still on the old install.
 __version__ = "0.3.0"
+
+try:
+    __version__ = _pkg_version("cultureflare")
+except PackageNotFoundError:
+    try:
+        __version__ = _pkg_version("cfafi")
+    except PackageNotFoundError:
+        pass  # fall through to baked default (source / editable run)

--- a/cfafi/__init__.py
+++ b/cfafi/__init__.py
@@ -1,3 +1,3 @@
 """cfafi — CloudFlare Agent First Interface."""
 
-__version__ = "0.2.2"
+__version__ = "0.3.0"

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -278,24 +278,25 @@ unused by the current workflow.)
    - Repo: `cfafi` *(repo rename is deferred; the publisher follows
      the source repo, not the package name)*
    - Workflow: `publish.yml`
-   - Environment: `pypi-cultureflare`
-2. Repeat on TestPyPI with environment `testpypi-cultureflare`.
-3. GitHub: Settings → Environments → `pypi-cultureflare` and
-   `testpypi-cultureflare`. No secrets needed.
+   - Environment: `pypi`
+2. Repeat on TestPyPI with environment `testpypi`.
+3. GitHub: Settings → Environments → `pypi` and `testpypi` already
+   exist from the legacy cfafi setup; no new environments needed.
 
 The publish workflow at `.github/workflows/publish.yml` builds with
 `name = "cultureflare"` directly from `pyproject.toml` (no
 in-place rewrite) and uploads via `uv publish --trusted-publishing
-always`.
+always` through the same `pypi` / `testpypi` environments cfafi
+used.
 
 ### `cfafi` (legacy, frozen at v0.2.2)
 
 The `cfafi` PyPI project still exists with its history through
 v0.2.2 — that's the bridge release that dual-published under both
 names. It's no longer in the publish workflow; nothing newer than
-0.2.2 will ever ship there. The corresponding pending publishers
-and GitHub environments (`pypi`, `testpypi`) can stay in place
-without effect, or be removed in a follow-up cleanup PR.
+0.2.2 will ever ship there. The cfafi pending publisher on PyPI is
+now superseded by the cultureflare publisher pointing at the same
+`pypi` / `testpypi` GitHub environments.
 
 ## 9. Operator token scopes (for `cfafi remote-login`)
 

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -263,28 +263,14 @@ through the environment variable.
 
 ## 8. PyPI Trusted Publisher (maintainer setup, one-time)
 
-Publishing to PyPI uses OIDC — no API tokens stored anywhere. The
-repo dual-publishes the same source under two distribution names:
+Publishing to PyPI uses OIDC — no API tokens stored anywhere. From
+v0.3.0 onward, the repo publishes a single distribution under the
+`cultureflare` name. (`cfafi` was the original distribution name and
+is frozen at v0.2.2 — the legacy pending publishers + GitHub
+environments below are kept intact for that historical release but
+unused by the current workflow.)
 
-- **`cfafi`** — frozen at v0.2.2 (final cfafi release).
-- **`cultureflare`** — canonical name going forward.
-
-Each name needs its own pending publisher pair (PyPI + TestPyPI) and
-its own GitHub environment. Publish flow lives in
-`.github/workflows/publish.yml`.
-
-### `cfafi` (legacy, frozen at 0.2.2)
-
-1. PyPI → `cfafi` project → Publishing → pending publisher:
-   - Publisher: GitHub
-   - Owner: `agentculture`
-   - Repo: `cfafi`
-   - Workflow: `publish.yml`
-   - Environment: `pypi`
-2. Repeat on TestPyPI with environment `testpypi`.
-3. GitHub: Settings → Environments → `pypi` and `testpypi`.
-
-### `cultureflare` (canonical going forward)
+### `cultureflare` (canonical, in use)
 
 1. PyPI → `cultureflare` project → Publishing → pending publisher:
    - Publisher: GitHub
@@ -297,16 +283,19 @@ its own GitHub environment. Publish flow lives in
 3. GitHub: Settings → Environments → `pypi-cultureflare` and
    `testpypi-cultureflare`. No secrets needed.
 
-The publish workflow patches `pyproject.toml` in-place to swap the
-distribution name (`name = "cfafi"` → `name = "cultureflare"`) for
-the cultureflare-named build, then `uv build` + `uv publish` in the
-`pypi-cultureflare` / `testpypi-cultureflare` environment uploads to
-the cultureflare project. The cfafi-named jobs run unchanged.
+The publish workflow at `.github/workflows/publish.yml` builds with
+`name = "cultureflare"` directly from `pyproject.toml` (no
+in-place rewrite) and uploads via `uv publish --trusted-publishing
+always`.
 
-Until the cultureflare environments + pending publishers are wired,
-the cultureflare publish steps in CI run with `continue-on-error:
-true` so they don't block the cfafi publish path. Remove that guard
-in a follow-up PR once verification is complete.
+### `cfafi` (legacy, frozen at v0.2.2)
+
+The `cfafi` PyPI project still exists with its history through
+v0.2.2 — that's the bridge release that dual-published under both
+names. It's no longer in the publish workflow; nothing newer than
+0.2.2 will ever ship there. The corresponding pending publishers
+and GitHub environments (`pypi`, `testpypi`) can stay in place
+without effect, or be removed in a follow-up cleanup PR.
 
 ## 9. Operator token scopes (for `cfafi remote-login`)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
-name = "cfafi"
-version = "0.2.2"
+name = "cultureflare"
+version = "0.3.0"
 description = "CloudFlare Agent First Interface — agent-first CLI for CloudFlare management in the AgentCulture org."
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -68,45 +68,6 @@ wheels = [
 ]
 
 [[package]]
-name = "cfafi"
-version = "0.2.2"
-source = { editable = "." }
-
-[package.dev-dependencies]
-dev = [
-    { name = "bandit" },
-    { name = "black" },
-    { name = "coverage" },
-    { name = "flake8" },
-    { name = "flake8-bandit" },
-    { name = "flake8-bugbear" },
-    { name = "isort" },
-    { name = "pre-commit" },
-    { name = "pylint" },
-    { name = "pytest" },
-    { name = "pytest-cov" },
-    { name = "pytest-xdist" },
-]
-
-[package.metadata]
-
-[package.metadata.requires-dev]
-dev = [
-    { name = "bandit", specifier = ">=1.7.5" },
-    { name = "black", specifier = ">=23.7.0" },
-    { name = "coverage", specifier = ">=7.2.0" },
-    { name = "flake8", specifier = ">=6.1" },
-    { name = "flake8-bandit", specifier = ">=4.1.1" },
-    { name = "flake8-bugbear", specifier = ">=23.7.10" },
-    { name = "isort", specifier = ">=5.12.0" },
-    { name = "pre-commit", specifier = ">=3.5.0" },
-    { name = "pylint", specifier = ">=2.17.0" },
-    { name = "pytest", specifier = ">=8.0" },
-    { name = "pytest-cov", specifier = ">=4.1" },
-    { name = "pytest-xdist", specifier = ">=3.0" },
-]
-
-[[package]]
 name = "cfgv"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -218,6 +179,45 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/db/51/37221f59a111dca5e85be7dbf09696323b5b9f13ff65e0641d535ed06ea8/coverage-7.13.5-cp314-cp314t-win_amd64.whl", hash = "sha256:301e3b7dfefecaca37c9f1aa6f0049b7d4ab8dd933742b607765d757aca77d43", size = 224254, upload-time = "2026-03-17T10:33:11.174Z" },
     { url = "https://files.pythonhosted.org/packages/54/83/6acacc889de8987441aa7d5adfbdbf33d288dad28704a67e574f1df9bcbb/coverage-7.13.5-cp314-cp314t-win_arm64.whl", hash = "sha256:9dacc2ad679b292709e0f5fc1ac74a6d4d5562e424058962c7bb0c658ad25e45", size = 222276, upload-time = "2026-03-17T10:33:13.466Z" },
     { url = "https://files.pythonhosted.org/packages/9e/ee/a4cf96b8ce1e566ed238f0659ac2d3f007ed1d14b181bcb684e19561a69a/coverage-7.13.5-py3-none-any.whl", hash = "sha256:34b02417cf070e173989b3db962f7ed56d2f644307b2cf9d5a0f258e13084a61", size = 211346, upload-time = "2026-03-17T10:33:15.691Z" },
+]
+
+[[package]]
+name = "cultureflare"
+version = "0.3.0"
+source = { editable = "." }
+
+[package.dev-dependencies]
+dev = [
+    { name = "bandit" },
+    { name = "black" },
+    { name = "coverage" },
+    { name = "flake8" },
+    { name = "flake8-bandit" },
+    { name = "flake8-bugbear" },
+    { name = "isort" },
+    { name = "pre-commit" },
+    { name = "pylint" },
+    { name = "pytest" },
+    { name = "pytest-cov" },
+    { name = "pytest-xdist" },
+]
+
+[package.metadata]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "bandit", specifier = ">=1.7.5" },
+    { name = "black", specifier = ">=23.7.0" },
+    { name = "coverage", specifier = ">=7.2.0" },
+    { name = "flake8", specifier = ">=6.1" },
+    { name = "flake8-bandit", specifier = ">=4.1.1" },
+    { name = "flake8-bugbear", specifier = ">=23.7.10" },
+    { name = "isort", specifier = ">=5.12.0" },
+    { name = "pre-commit", specifier = ">=3.5.0" },
+    { name = "pylint", specifier = ">=2.17.0" },
+    { name = "pytest", specifier = ">=8.0" },
+    { name = "pytest-cov", specifier = ">=4.1" },
+    { name = "pytest-xdist", specifier = ">=3.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Closes the cultureflare migration. PR #25 dual-published `cfafi-0.2.2` + `cultureflare-0.2.2` as a one-shot bridge; the cultureflare Trusted Publisher chain proved good in production (post-merge run 25535310768: `publish` + `publish-cultureflare` both SUCCESS). This collapses the workflow to a single publish target.

## What changed

- **pyproject.toml** — `name = "cultureflare"`, `version = "0.3.0"`. Both console-script aliases (`cfafi`, `cultureflare`) stay. Python module dir + module-internal references unchanged.
- **publish workflow** — drops the cfafi-named jobs and the in-place `sed`, drops `continue-on-error` + Surface-status guard. Surviving jobs use `testpypi-cultureflare` / `pypi-cultureflare` environments. One TestPyPI publish on PRs, one PyPI publish on push.
- **README** — banner: `cfafi is now cultureflare on PyPI`. Install: `uv tool install cultureflare`. Note for prior `cfafi` installers about the 0.2.2 ceiling.
- **docs/SETUP.md § 8** — simplified to single-publisher walkthrough; legacy `cfafi` block kept as a historical footnote.

## Verified locally

- `uv build` produces `cultureflare-0.3.0-py3-none-any.whl` directly (no name-swap step). Wheel exposes both `cfafi` and `cultureflare` console scripts.
- 141 tests pass; markdownlint clean across 15 files.
- `python -m cfafi --version` → `cultureflare 0.3.0` (canonical fallback path from PR #25 review).

## Out of scope

- Deleting the legacy `pypi` / `testpypi` GitHub environments + the cfafi PyPI pending publishers. Harmless to leave; can clean up in a follow-up.
- Dropping the `cfafi` console-script alias. Tracked for the next major bump (v1.0).
- Renaming the Python module dir `cfafi/` → `cultureflare/`. Off the table per prior direction; both names work today via the aliases.
- Repo rename `agentculture/cfafi` → `agentculture/cultureflare`. Orthogonal; user's call when they want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)