### PR TITLE
fix(remote-login): close tunnel-ingress + service-token-policy gaps (#28)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@ All notable changes to this project will be documented here. The format
 is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0] - 2026-05-08
+
+
+### Added
+
+- `cultureflare remote-login setup --service URL`: required flag wiring tunnel public-hostname ingress on the remote-managed tunnel
+- `ensure_tunnel_config` / `get_tunnel_config` helpers for idempotent tunnel ingress configuration
+- `ensure_service_token_policy` / `find_service_token_policy` helpers that attach a `non_identity` policy admitting the service token to its Access app
+- `tunnel-config` and `service-token-policy` step records on `setup` / `teardown`; new `tunnel_config` and `service_token_policy` fields on `show`
+
+
+### Changed
+
+- `ensure_service_token` now returns a 4-tuple `(client_id, client_secret, created, token_id)` so callers can attach a non_identity policy without a second find
+- `setup()` now uses `strict=False` for the service-token step — re-running setup against an already-provisioned deployment skips the token (secret not rotated) instead of erroring; an idempotent re-run is now the supported repair path
+
+
+### Fixed
+
+- #28: provisioning a hostname via `remote-login setup` left the tunnel without an ingress rule (cloudflared returns 503) and left the service token without a non_identity policy (programmatic clients 302 to SSO). Both gaps are now closed by the same `setup` invocation.
+
 ## [0.4.0] - 2026-05-08
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.5.0] - 2026-05-08
 
-
 ### Added
 
 - `cultureflare remote-login setup --service URL`: required flag wiring tunnel public-hostname ingress on the remote-managed tunnel
@@ -14,12 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `ensure_service_token_policy` / `find_service_token_policy` helpers that attach a `non_identity` policy admitting the service token to its Access app
 - `tunnel-config` and `service-token-policy` step records on `setup` / `teardown`; new `tunnel_config` and `service_token_policy` fields on `show`
 
-
 ### Changed
 
 - `ensure_service_token` now returns a 4-tuple `(client_id, client_secret, created, token_id)` so callers can attach a non_identity policy without a second find
 - `setup()` now uses `strict=False` for the service-token step — re-running setup against an already-provisioned deployment skips the token (secret not rotated) instead of erroring; an idempotent re-run is now the supported repair path
-
 
 ### Fixed
 

--- a/cultureflare/_remote_login/__init__.py
+++ b/cultureflare/_remote_login/__init__.py
@@ -160,6 +160,66 @@ def _whoami() -> str:
         return "-"
 
 
+def _action(created: bool) -> str:
+    """Map ``created`` to the canonical step-record action verb."""
+    return "ensured" if created else "skipped"
+
+
+def _ensure_service_token_step(
+    *,
+    ctx: Context,
+    app_id: str,
+    with_service_token: bool,
+    steps: list[StepRecord],
+) -> tuple[str | None, str | None, str | None]:
+    """Run the optional service-token + non_identity-policy pair.
+
+    Returns ``(client_id, client_secret, policy_id)`` for the
+    ``SetupResult``. Each tuple element is None when the corresponding
+    resource wasn't requested or is not retrievable. Mutates ``steps``
+    in place so the orchestrator's step record list keeps its order.
+
+    Strict=False on the token ensure: re-running setup against a
+    deployment whose token already exists must be safe. The secret is
+    one-shot; re-runs return ``client_id`` with ``secret=None`` and a
+    "skipped (existing; secret not rotated)" step. Operators wanting a
+    fresh secret teardown first.
+    """
+    if not with_service_token:
+        return None, None, None
+
+    svc_cid, svc_secret, svc_created, svc_token_id = ensure_service_token(
+        account_id=ctx.account_id,
+        name=ctx.names.service_token_name,
+        strict=False,
+    )
+    svc_detail = f"client_id={svc_cid}"
+    if not svc_created:
+        svc_detail += " (existing; secret not rotated)"
+    steps.append(StepRecord(
+        name="service-token", action=_action(svc_created), detail=svc_detail,
+    ))
+
+    if not svc_token_id:
+        return svc_cid, svc_secret, None
+
+    # Non-identity policy admitting the token. Without it, requests
+    # carrying CF-Access-Client-Id/Secret are 302-redirected to SSO
+    # regardless of the existing email allow-policy.
+    svc_policy_id, svc_policy_created = ensure_service_token_policy(
+        account_id=ctx.account_id,
+        app_id=app_id,
+        token_id=svc_token_id,
+        name=ctx.names.service_token_policy_name,
+    )
+    steps.append(StepRecord(
+        name="service-token-policy",
+        action=_action(svc_policy_created),
+        detail=f"id={svc_policy_id}",
+    ))
+    return svc_cid, svc_secret, svc_policy_id
+
+
 def setup(
     *,
     ctx: Context,
@@ -212,8 +272,7 @@ def setup(
         account_id=ctx.account_id, name=ctx.names.tunnel_name,
     )
     steps.append(StepRecord(
-        name="tunnel",
-        action="ensured" if tunnel_created else "skipped",
+        name="tunnel", action=_action(tunnel_created),
         detail=f"{ctx.names.tunnel_name} (id={tunnel_id})",
     ))
     tunnel_token = get_tunnel_token(
@@ -231,8 +290,7 @@ def setup(
         service=ctx.service,
     )
     steps.append(StepRecord(
-        name="tunnel-config",
-        action="ensured" if tunnel_config_changed else "skipped",
+        name="tunnel-config", action=_action(tunnel_config_changed),
         detail=f"{ctx.hostname} → {ctx.service}",
     ))
 
@@ -242,8 +300,7 @@ def setup(
     )
     dns_target = f"{tunnel_id}.cfargotunnel.com"
     steps.append(StepRecord(
-        name="dns",
-        action="ensured" if dns_created else "skipped",
+        name="dns", action=_action(dns_created),
         detail=f"CNAME {ctx.hostname} → {dns_target}",
     ))
 
@@ -255,9 +312,7 @@ def setup(
         session_duration=session_duration,
     )
     steps.append(StepRecord(
-        name="access-app",
-        action="ensured" if app_created else "skipped",
-        detail=f"id={app_id}",
+        name="access-app", action=_action(app_created), detail=f"id={app_id}",
     ))
 
     # 5. Allow-policy.
@@ -267,50 +322,16 @@ def setup(
         emails=emails, domains=domains,
     )
     steps.append(StepRecord(
-        name="allow-policy",
-        action="ensured" if policy_created else "skipped",
+        name="allow-policy", action=_action(policy_created),
         detail=f"id={policy_id}",
     ))
 
-    # 6. Service token (optional).
-    # strict=False: re-running setup against a deployment whose token
-    # already exists must be safe. The secret is one-shot; re-runs return
-    # client_id with secret=None and the orchestrator records a "skipped"
-    # step. Operators wanting a fresh secret teardown first.
-    svc_cid: str | None = None
-    svc_secret: str | None = None
-    svc_token_id: str | None = None
-    svc_policy_id: str | None = None
-    if with_service_token:
-        svc_cid, svc_secret, svc_created, svc_token_id = ensure_service_token(
-            account_id=ctx.account_id,
-            name=ctx.names.service_token_name,
-            strict=False,
-        )
-        svc_detail = f"client_id={svc_cid}"
-        if not svc_created:
-            svc_detail += " (existing; secret not rotated)"
-        steps.append(StepRecord(
-            name="service-token",
-            action="ensured" if svc_created else "skipped",
-            detail=svc_detail,
-        ))
-
-    # 6b. Non-identity policy that admits the service token.
-    # Without it, requests carrying CF-Access-Client-Id/Secret are
-    # 302-redirected to SSO regardless of the existing email allow-policy.
-    if with_service_token and svc_token_id:
-        svc_policy_id, svc_policy_created = ensure_service_token_policy(
-            account_id=ctx.account_id,
-            app_id=app_id,
-            token_id=svc_token_id,
-            name=ctx.names.service_token_policy_name,
-        )
-        steps.append(StepRecord(
-            name="service-token-policy",
-            action="ensured" if svc_policy_created else "skipped",
-            detail=f"id={svc_policy_id}",
-        ))
+    # 6. Service token + non_identity policy (optional, paired).
+    svc_cid, svc_secret, svc_policy_id = _ensure_service_token_step(
+        ctx=ctx, app_id=app_id,
+        with_service_token=with_service_token,
+        steps=steps,
+    )
 
     sealed_in: dict[str, str] = {}
     if seal.enabled:

--- a/cultureflare/_remote_login/__init__.py
+++ b/cultureflare/_remote_login/__init__.py
@@ -16,7 +16,8 @@ from cultureflare._remote_login._access_app import (
 )
 from cultureflare._remote_login._access_org import find_org
 from cultureflare._remote_login._access_policy import (
-    delete_policy, ensure_allow_policy, find_policy,
+    delete_policy, ensure_allow_policy, ensure_service_token_policy,
+    find_policy, find_service_token_policy,
 )
 from cultureflare._remote_login._common import (
     Context, SetupResult, ShowResult, StepRecord, TeardownResult,
@@ -27,7 +28,8 @@ from cultureflare._remote_login._service_token import (
     delete_service_token, ensure_service_token, find_service_token,
 )
 from cultureflare._remote_login._tunnel import (
-    delete_tunnel, ensure_tunnel, find_tunnel, get_tunnel_token,
+    delete_tunnel, ensure_tunnel, ensure_tunnel_config,
+    find_tunnel, get_tunnel_config, get_tunnel_token,
 )
 from cultureflare._secrets import _shushu_sink
 from cultureflare.cli._errors import EXIT_USER_ERROR, CfafiError
@@ -175,6 +177,16 @@ def setup(
     """
     if seal is None:
         seal = derive_seal_plan(hostname=ctx.hostname, shushu_arg=None)
+    if not ctx.service:
+        raise CfafiError(
+            code=EXIT_USER_ERROR,
+            message="setup requires a local service URL for tunnel ingress",
+            remediation=(
+                "pass --service http://localhost:<port> on `cultureflare "
+                "remote-login setup` so cloudflared can route the public "
+                "hostname to your local process"
+            ),
+        )
     steps: list[StepRecord] = []
 
     # 1. Zero Trust org — verified, never created here.
@@ -207,6 +219,22 @@ def setup(
     tunnel_token = get_tunnel_token(
         account_id=ctx.account_id, tunnel_id=tunnel_id,
     )
+
+    # 2b. Tunnel ingress config — must follow tunnel creation.
+    # Without this, cloudflared registers connections then 503s every
+    # request because no ingress rule maps the public hostname to a
+    # local service. Idempotent: skipped when ingress already matches.
+    tunnel_config_changed = ensure_tunnel_config(
+        account_id=ctx.account_id,
+        tunnel_id=tunnel_id,
+        hostname=ctx.hostname,
+        service=ctx.service,
+    )
+    steps.append(StepRecord(
+        name="tunnel-config",
+        action="ensured" if tunnel_config_changed else "skipped",
+        detail=f"{ctx.hostname} → {ctx.service}",
+    ))
 
     # 3. DNS CNAME → tunnel.
     dns_id, dns_created = ensure_cname(
@@ -245,18 +273,43 @@ def setup(
     ))
 
     # 6. Service token (optional).
+    # strict=False: re-running setup against a deployment whose token
+    # already exists must be safe. The secret is one-shot; re-runs return
+    # client_id with secret=None and the orchestrator records a "skipped"
+    # step. Operators wanting a fresh secret teardown first.
     svc_cid: str | None = None
     svc_secret: str | None = None
+    svc_token_id: str | None = None
+    svc_policy_id: str | None = None
     if with_service_token:
-        svc_cid, svc_secret, svc_created = ensure_service_token(
+        svc_cid, svc_secret, svc_created, svc_token_id = ensure_service_token(
             account_id=ctx.account_id,
             name=ctx.names.service_token_name,
-            strict=True,
+            strict=False,
         )
+        svc_detail = f"client_id={svc_cid}"
+        if not svc_created:
+            svc_detail += " (existing; secret not rotated)"
         steps.append(StepRecord(
             name="service-token",
             action="ensured" if svc_created else "skipped",
-            detail=f"client_id={svc_cid}",
+            detail=svc_detail,
+        ))
+
+    # 6b. Non-identity policy that admits the service token.
+    # Without it, requests carrying CF-Access-Client-Id/Secret are
+    # 302-redirected to SSO regardless of the existing email allow-policy.
+    if with_service_token and svc_token_id:
+        svc_policy_id, svc_policy_created = ensure_service_token_policy(
+            account_id=ctx.account_id,
+            app_id=app_id,
+            token_id=svc_token_id,
+            name=ctx.names.service_token_policy_name,
+        )
+        steps.append(StepRecord(
+            name="service-token-policy",
+            action="ensured" if svc_policy_created else "skipped",
+            detail=f"id={svc_policy_id}",
         ))
 
     sealed_in: dict[str, str] = {}
@@ -277,6 +330,7 @@ def setup(
         tunnel_id=tunnel_id,
         tunnel_name=ctx.names.tunnel_name,
         tunnel_token=tunnel_token,
+        tunnel_service=ctx.service,
         dns_record_id=dns_id,
         dns_target=dns_target,
         access_app_id=app_id,
@@ -285,6 +339,7 @@ def setup(
         policy_domains=list(domains),
         service_token_client_id=svc_cid,
         service_token_client_secret=svc_secret,
+        service_token_policy_id=svc_policy_id,
         steps=steps,
         sealed_in=sealed_in,
     )
@@ -312,6 +367,13 @@ def show(*, ctx: Context, seal: SealPlan | None = None) -> ShowResult:
     tunnel = find_tunnel(
         account_id=ctx.account_id, name=ctx.names.tunnel_name,
     )
+    tunnel_config = (
+        get_tunnel_config(
+            account_id=ctx.account_id, tunnel_id=tunnel["id"],
+        )
+        if tunnel is not None
+        else None
+    )
     dns = find_cname(zone_id=ctx.zone_id, hostname=ctx.hostname)
 
     # Probe shushu unconditionally (independent of CF/ZT state) so that
@@ -323,8 +385,9 @@ def show(*, ctx: Context, seal: SealPlan | None = None) -> ShowResult:
     if org is None:
         return ShowResult(
             team_domain=None,
-            tunnel=tunnel, dns=dns,
-            access_app=None, policy=None, service_token=None,
+            tunnel=tunnel, tunnel_config=tunnel_config, dns=dns,
+            access_app=None, policy=None,
+            service_token=None, service_token_policy=None,
             sealed_in_status=sealed_status,
         )
     app = find_app(account_id=ctx.account_id, hostname=ctx.hostname)
@@ -340,14 +403,25 @@ def show(*, ctx: Context, seal: SealPlan | None = None) -> ShowResult:
     svc = find_service_token(
         account_id=ctx.account_id, name=ctx.names.service_token_name,
     )
+    svc_policy = (
+        find_service_token_policy(
+            account_id=ctx.account_id,
+            app_id=app["id"],
+            token_id=svc["id"],
+        )
+        if app is not None and svc is not None and svc.get("id")
+        else None
+    )
 
     return ShowResult(
         team_domain=org.get("auth_domain"),
         tunnel=tunnel,
+        tunnel_config=tunnel_config,
         dns=dns,
         access_app=app,
         policy=policy,
         service_token=svc,
+        service_token_policy=svc_policy,
         sealed_in_status=sealed_status,
     )
 
@@ -379,9 +453,28 @@ def teardown(
             name="service-token", action="deleted", detail=f"id={svc['id']}",
         ))
 
-    # 2. Allow-policy + 3. Access app.
+    # 2. Allow-policy + service-token policy + 3. Access app.
     app = find_app(account_id=ctx.account_id, hostname=ctx.hostname)
     if app is not None:
+        # Service-token policy: matched by include[].service_token.token_id.
+        # ``svc`` was captured BEFORE the token delete in step 1, so we
+        # still have the right id to look the policy up by even though
+        # the token itself is gone. Delete-app would cascade-delete any
+        # leftover policy too, but we surface the step explicitly.
+        if svc is not None:
+            svc_policy = find_service_token_policy(
+                account_id=ctx.account_id, app_id=app["id"],
+                token_id=svc["id"],
+            )
+            if svc_policy is not None:
+                delete_policy(
+                    account_id=ctx.account_id, app_id=app["id"],
+                    policy_id=svc_policy["id"],
+                )
+                steps.append(StepRecord(
+                    name="service-token-policy", action="deleted",
+                    detail=f"id={svc_policy['id']}",
+                ))
         policy = find_policy(
             account_id=ctx.account_id, app_id=app["id"],
             name=ctx.names.policy_name,

--- a/cultureflare/_remote_login/_access_policy.py
+++ b/cultureflare/_remote_login/_access_policy.py
@@ -63,3 +63,62 @@ def delete_policy(*, account_id: str, app_id: str, policy_id: str) -> None:
         "DELETE",
         f"/accounts/{account_id}/access/apps/{app_id}/policies/{policy_id}",
     )
+
+
+def find_service_token_policy(
+    *, account_id: str, app_id: str, token_id: str
+) -> dict | None:
+    """Return the non_identity policy admitting `token_id`, or None.
+
+    Matches by *behavior* not by name: we look for any policy on the app
+    whose ``decision == "non_identity"`` and whose ``include`` contains a
+    ``service_token`` rule referencing ``token_id``. This way, an
+    operator-renamed policy is still recognized as the one to skip.
+    """
+    for pol in _api.paginate(
+        f"/accounts/{account_id}/access/apps/{app_id}/policies"
+    ):
+        if pol.get("decision") != "non_identity":
+            continue
+        for rule in pol.get("include") or []:
+            svc = rule.get("service_token") or {}
+            if svc.get("token_id") == token_id:
+                return pol
+    return None
+
+
+def ensure_service_token_policy(
+    *,
+    account_id: str,
+    app_id: str,
+    token_id: str,
+    name: str,
+) -> tuple[str, bool]:
+    """Find or create a non_identity allow-policy for a service token.
+
+    Without such a policy, requests carrying ``CF-Access-Client-Id`` /
+    ``CF-Access-Client-Secret`` are 302-redirected to SSO instead of
+    being admitted (the meta JWT shows ``service_token_status: false``).
+    """
+    existing = find_service_token_policy(
+        account_id=account_id, app_id=app_id, token_id=token_id,
+    )
+    if existing is not None:
+        return existing["id"], False
+    # No explicit ``precedence``: CF rejects two policies on the same
+    # app sharing one (error 12130 "policy precedences must be unique").
+    # The existing email allow-policy already holds precedence 1 in
+    # most setups; let CF auto-assign rather than computing the next
+    # free integer (racy with concurrent edits).
+    response = _api.http_request(
+        "POST",
+        f"/accounts/{account_id}/access/apps/{app_id}/policies",
+        payload={
+            "name": name,
+            "decision": "non_identity",
+            "include": [
+                {"service_token": {"token_id": token_id}},
+            ],
+        },
+    )
+    return response["result"]["id"], True

--- a/cultureflare/_remote_login/_common.py
+++ b/cultureflare/_remote_login/_common.py
@@ -11,6 +11,7 @@ class Names:
     app_name: str
     service_token_name: str
     policy_name: str
+    service_token_policy_name: str
 
 
 def derive_names(
@@ -33,6 +34,7 @@ def derive_names(
         app_name=an,
         service_token_name=stn,
         policy_name=f"{an}-allow",
+        service_token_policy_name=f"{an}-svc-allow",
     )
 
 
@@ -44,6 +46,7 @@ class Context:
     zone_id: str
     hostname: str
     names: Names
+    service: str | None = None
 
 
 @dataclass
@@ -71,6 +74,10 @@ class SetupResult:
     service_token_client_secret: str | None
     steps: list[StepRecord]
     sealed_in: dict[str, str] = field(default_factory=dict)
+    # Added in #28: tunnel ingress route + non_identity service-token policy.
+    # Defaulted to None so older test fixtures keep compiling.
+    tunnel_service: str | None = None
+    service_token_policy_id: str | None = None
 
 
 @dataclass(frozen=True)
@@ -82,6 +89,9 @@ class ShowResult:
     policy: dict | None
     service_token: dict | None
     sealed_in_status: dict[str, dict | None] = field(default_factory=dict)
+    # Added in #28: see SetupResult note above.
+    tunnel_config: dict | None = None
+    service_token_policy: dict | None = None
 
 
 @dataclass

--- a/cultureflare/_remote_login/_render.py
+++ b/cultureflare/_remote_login/_render.py
@@ -165,11 +165,12 @@ def _row_tunnel(tunnel: dict | None) -> str:
 def _row_tunnel_config(config: dict | None) -> str:
     """Render the first ingress rule (the public-hostname route).
 
-    Empty/missing ingress is the gap from #28 — surface it explicitly.
+    Both ``config is None`` (no configuration object set yet) and an
+    explicit empty ``ingress`` list are the same operational gap from
+    #28: cloudflared registers connections then 503s every request.
+    Surface them with the same hint.
     """
-    if config is None:
-        return "- **tunnel-ingress:** (not found)"
-    rules = (config.get("config") or {}).get("ingress") or []
+    rules = ((config or {}).get("config") or {}).get("ingress") or []
     if not rules:
         return "- **tunnel-ingress:** (no rules — cloudflared will 503)"
     head = rules[0]

--- a/cultureflare/_remote_login/_render.py
+++ b/cultureflare/_remote_login/_render.py
@@ -23,6 +23,10 @@ def render_setup_markdown(result: SetupResult, *, hostname: str) -> str:
     lines.append(
         f"- **TUNNEL_TOKEN:** {_seal_or_value(result, 'tunnel_token', result.tunnel_token)}"
     )
+    if result.tunnel_service is not None:
+        lines.append(
+            f"- **TUNNEL_INGRESS:** {hostname} → {result.tunnel_service}"
+        )
     lines.append(
         f"- **DNS:** CNAME {hostname} → {result.dns_target} (proxied)"
     )
@@ -45,6 +49,10 @@ def render_setup_markdown(result: SetupResult, *, hostname: str) -> str:
                 f"- **SERVICE_TOKEN_CLIENT_SECRET:** "
                 f"{_seal_or_value(result, 'service_token_client_secret', result.service_token_client_secret)}"
             )
+        if result.service_token_policy_id is not None:
+            lines.append(
+                f"- **SERVICE_TOKEN_POLICY_ID:** {result.service_token_policy_id}"
+            )
     lines.append("")
     lines.append("## Steps")
     for i, step in enumerate(result.steps, start=1):
@@ -61,6 +69,7 @@ def render_setup_json(result: SetupResult, *, hostname: str) -> dict:
             "tunnel_name": result.tunnel_name,
             "tunnel_id": result.tunnel_id,
             "tunnel_token": result.tunnel_token,
+            "tunnel_service": result.tunnel_service,
             "dns": {
                 "record_id": result.dns_record_id,
                 "target": result.dns_target,
@@ -73,6 +82,7 @@ def render_setup_json(result: SetupResult, *, hostname: str) -> dict:
             },
             "service_token_client_id": result.service_token_client_id,
             "service_token_client_secret": result.service_token_client_secret,
+            "service_token_policy_id": result.service_token_policy_id,
             "sealed_in": dict(result.sealed_in),
             "steps": [
                 {"name": s.name, "action": s.action, "detail": s.detail}
@@ -87,6 +97,7 @@ def render_setup_dryrun_markdown(
     hostname: str,
     tunnel_name: str,
     app_name: str,
+    service: str,
     emails: list[str],
     domains: list[str],
     with_service_token: bool,
@@ -99,28 +110,46 @@ def render_setup_dryrun_markdown(
     lines.append("**Dry-run — no changes applied**")
     lines.append("")
     lines.append(f"## Plan for {hostname}")
-    lines.append("1. ensure Zero Trust org (existing required for v1)")
-    lines.append(f"2. ensure tunnel `{tunnel_name}`")
+    step = 0
+
+    def _step() -> int:
+        nonlocal step
+        step += 1
+        return step
+
+    lines.append(f"{_step()}. ensure Zero Trust org (existing required for v1)")
+    lines.append(f"{_step()}. ensure tunnel `{tunnel_name}`")
     lines.append(
-        f"3. ensure DNS CNAME {hostname} → <tunnel_id>.cfargotunnel.com (proxied)"
+        f"{_step()}. ensure tunnel ingress {hostname} → {service}"
     )
     lines.append(
-        f"4. ensure Access app `{app_name}` (session_duration={session_duration})"
+        f"{_step()}. ensure DNS CNAME {hostname} → "
+        "<tunnel_id>.cfargotunnel.com (proxied)"
+    )
+    lines.append(
+        f"{_step()}. ensure Access app `{app_name}` "
+        f"(session_duration={session_duration})"
     )
     policy_parts: list[str] = []
     if emails:
         policy_parts.append(f"allow [{', '.join(emails)}]")
     if domains:
         policy_parts.append(f"allow-domain [{', '.join(domains)}]")
-    lines.append(f"5. ensure allow-policy ({'; '.join(policy_parts)})")
+    lines.append(f"{_step()}. ensure allow-policy ({'; '.join(policy_parts)})")
     if with_service_token:
-        lines.append("6. ensure service-token (one-shot secret)")
+        lines.append(f"{_step()}. ensure service-token (one-shot secret)")
+        lines.append(
+            f"{_step()}. ensure non_identity service-token policy admitting it"
+        )
     if seal_tunnel_name is not None:
         u = seal_user or "<self>"
-        lines.append(f"7. seal tunnel_token into shushu/{u}/{seal_tunnel_name}")
+        lines.append(
+            f"{_step()}. seal tunnel_token into shushu/{u}/{seal_tunnel_name}"
+        )
         if with_service_token and seal_svc_name is not None:
             lines.append(
-                f"8. seal service-token client_secret into shushu/{u}/{seal_svc_name}"
+                f"{_step()}. seal service-token client_secret into "
+                f"shushu/{u}/{seal_svc_name}"
             )
     lines.append("")
     lines.append("Pass --apply to commit.")
@@ -131,6 +160,22 @@ def _row_tunnel(tunnel: dict | None) -> str:
     if tunnel is None:
         return "- **tunnel:** (not found)"
     return f"- **tunnel:** {tunnel.get('name')} (id={tunnel.get('id')})"
+
+
+def _row_tunnel_config(config: dict | None) -> str:
+    """Render the first ingress rule (the public-hostname route).
+
+    Empty/missing ingress is the gap from #28 — surface it explicitly.
+    """
+    if config is None:
+        return "- **tunnel-ingress:** (not found)"
+    rules = (config.get("config") or {}).get("ingress") or []
+    if not rules:
+        return "- **tunnel-ingress:** (no rules — cloudflared will 503)"
+    head = rules[0]
+    host = head.get("hostname") or "(any)"
+    svc = head.get("service") or "(none)"
+    return f"- **tunnel-ingress:** {host} → {svc}"
 
 
 def _row_dns(dns: dict | None, hostname: str) -> str:
@@ -164,6 +209,20 @@ def _row_service_token(svc: dict | None) -> str:
     )
 
 
+def _row_service_token_policy(svc_policy: dict | None) -> str:
+    """Render the non_identity policy admitting the service token.
+
+    Absence of this policy is the gap from #28 that makes service-token
+    auth fall through to SSO — surface it explicitly.
+    """
+    if svc_policy is None:
+        return (
+            "- **service-token-policy:** (not found — service token "
+            "headers will 302 to SSO)"
+        )
+    return f"- **service-token-policy:** id={svc_policy.get('id')}"
+
+
 def _row_sealed_status(key: str, status: dict | None) -> str:
     if status is None:
         return f"  - {key}: ?? (shushu not installed)"
@@ -189,10 +248,12 @@ def render_show_markdown(result: ShowResult, *, hostname: str) -> str:
         "",
         f"- **zero-trust-org:** {result.team_domain or '(not found)'}",
         _row_tunnel(result.tunnel),
+        _row_tunnel_config(result.tunnel_config),
         _row_dns(result.dns, hostname),
         _row_access_app(result.access_app),
         _row_policies(result.policy),
         _row_service_token(result.service_token),
+        _row_service_token_policy(result.service_token_policy),
     ]
     lines.extend(_rows_sealed_in_status(result.sealed_in_status))
     return "\n".join(lines) + "\n"
@@ -205,10 +266,12 @@ def render_show_json(result: ShowResult, *, hostname: str) -> dict:
             "hostname": hostname,
             "team_domain": result.team_domain,
             "tunnel": result.tunnel,
+            "tunnel_config": result.tunnel_config,
             "dns": result.dns,
             "access_app": result.access_app,
             "policy": result.policy,
             "service_token": result.service_token,
+            "service_token_policy": result.service_token_policy,
             "sealed_in_status": dict(result.sealed_in_status),
         },
     }

--- a/cultureflare/_remote_login/_service_token.py
+++ b/cultureflare/_remote_login/_service_token.py
@@ -21,17 +21,22 @@ def find_service_token(*, account_id: str, name: str) -> dict | None:
 
 def ensure_service_token(
     *, account_id: str, name: str, strict: bool
-) -> tuple[str, str | None, bool]:
+) -> tuple[str, str | None, bool, str | None]:
     """Find or create a service token.
 
-    Returns (client_id, client_secret_or_None, created).
+    Returns (client_id, client_secret_or_None, created, token_id).
+    The CF resource id (``token_id``) is distinct from the public
+    ``client_id`` — only the resource id can be referenced from a
+    non_identity policy's ``include[].service_token.token_id``.
 
     ``strict=True`` (used by setup with --with-service-token): if a
     token of this name already exists, raise — its secret can't be
     re-surfaced and the operator likely wanted a fresh one.
 
-    ``strict=False`` (used by show/teardown planners): return the
-    existing record with secret=None.
+    ``strict=False`` (used by show/teardown planners and by setup
+    after #28): return the existing record with secret=None and the
+    full token_id, so an idempotent re-run can attach a missing
+    non_identity policy without rotating the secret.
     """
     existing = find_service_token(account_id=account_id, name=name)
     if existing is not None:
@@ -48,7 +53,12 @@ def ensure_service_token(
                     "first"
                 ),
             )
-        return existing.get("client_id") or "", None, False
+        return (
+            existing.get("client_id") or "",
+            None,
+            False,
+            existing.get("id"),
+        )
 
     response = _api.http_request(
         "POST",
@@ -60,6 +70,7 @@ def ensure_service_token(
         result.get("client_id") or "",
         result.get("client_secret"),
         True,
+        result.get("id"),
     )
 
 

--- a/cultureflare/_remote_login/_tunnel.py
+++ b/cultureflare/_remote_login/_tunnel.py
@@ -34,6 +34,68 @@ def ensure_tunnel(*, account_id: str, name: str) -> tuple[str, bool]:
     return response["result"]["id"], True
 
 
+def get_tunnel_config(*, account_id: str, tunnel_id: str) -> dict | None:
+    """GET the remote-managed tunnel configuration.
+
+    Returns the ``result`` envelope (with keys like ``config``, ``version``)
+    or None if the tunnel has no configuration set yet.
+    """
+    response = _api.http_request(
+        "GET",
+        f"/accounts/{account_id}/cfd_tunnel/{tunnel_id}/configurations",
+    )
+    return response.get("result")
+
+
+def _ingress_matches(
+    config: dict | None, *, hostname: str, service: str
+) -> bool:
+    """True iff `config` already has the (hostname → service) + 404 catch-all."""
+    if not config:
+        return False
+    rules = (config.get("config") or {}).get("ingress") or []
+    if len(rules) < 2:
+        return False
+    head = rules[0]
+    tail = rules[-1]
+    head_match = (
+        head.get("hostname") == hostname
+        and head.get("service") == service
+    )
+    tail_match = tail.get("service") == "http_status:404"
+    return head_match and tail_match
+
+
+def ensure_tunnel_config(
+    *,
+    account_id: str,
+    tunnel_id: str,
+    hostname: str,
+    service: str,
+) -> bool:
+    """Set ingress for a remote-managed tunnel; idempotent.
+
+    Returns True if a PUT was made, False if existing config already
+    matches `(hostname → service)` + the `http_status:404` catch-all.
+    """
+    existing = get_tunnel_config(account_id=account_id, tunnel_id=tunnel_id)
+    if _ingress_matches(existing, hostname=hostname, service=service):
+        return False
+    _api.http_request(
+        "PUT",
+        f"/accounts/{account_id}/cfd_tunnel/{tunnel_id}/configurations",
+        payload={
+            "config": {
+                "ingress": [
+                    {"hostname": hostname, "service": service},
+                    {"service": "http_status:404"},
+                ],
+            },
+        },
+    )
+    return True
+
+
 def get_tunnel_token(*, account_id: str, tunnel_id: str) -> str:
     """Fetch the runtime token (passed to `cloudflared tunnel run --token`).
 

--- a/cultureflare/_remote_login/_tunnel.py
+++ b/cultureflare/_remote_login/_tunnel.py
@@ -76,22 +76,31 @@ def ensure_tunnel_config(
     """Set ingress for a remote-managed tunnel; idempotent.
 
     Returns True if a PUT was made, False if existing config already
-    matches `(hostname → service)` + the `http_status:404` catch-all.
+    matches ``(hostname → service)`` + the ``http_status:404`` catch-all.
+
+    The PUT preserves any other writable keys already present on the
+    tunnel's ``config`` object (e.g. ``warp-routing``, ``originRequest``)
+    by overlaying the new ``ingress`` rules on top of the existing
+    config rather than sending a fresh one. CF's `/configurations`
+    endpoint is replace-not-merge, so omitting a key resets it to
+    its default — which would silently drop operator-set
+    ``warp-routing`` toggles or origin TLS / connectTimeout overrides.
     """
     existing = get_tunnel_config(account_id=account_id, tunnel_id=tunnel_id)
     if _ingress_matches(existing, hostname=hostname, service=service):
         return False
+    existing_config = (existing or {}).get("config") or {}
+    new_config = {
+        **existing_config,
+        "ingress": [
+            {"hostname": hostname, "service": service},
+            {"service": "http_status:404"},
+        ],
+    }
     _api.http_request(
         "PUT",
         f"/accounts/{account_id}/cfd_tunnel/{tunnel_id}/configurations",
-        payload={
-            "config": {
-                "ingress": [
-                    {"hostname": hostname, "service": service},
-                    {"service": "http_status:404"},
-                ],
-            },
-        },
+        payload={"config": new_config},
     )
     return True
 

--- a/cultureflare/cli/_commands/remote_login.py
+++ b/cultureflare/cli/_commands/remote_login.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+from urllib.parse import urlparse
 
 from cultureflare._env import require_env
 from cultureflare._remote_login import setup, show, teardown
@@ -16,6 +17,26 @@ from cultureflare._remote_login._render import (
 )
 from cultureflare.cli._errors import EXIT_USER_ERROR, CfafiError
 from cultureflare.cli._output import emit_json, emit_result
+
+
+def _validate_service_url(value: str) -> str:
+    """Reject empty / scheme-less / host-less --service values.
+
+    We don't try to be exhaustive (cloudflared accepts ``unix:`` and
+    ``tcp://`` too), just catch the common shape mistakes that would
+    POST garbage into CF and produce a 503 the operator has to hunt for.
+    """
+    parsed = urlparse(value)
+    if not parsed.scheme or not parsed.netloc:
+        raise CfafiError(
+            code=EXIT_USER_ERROR,
+            message=f"--service must be scheme://host[:port], got {value!r}",
+            remediation=(
+                "use --service http://localhost:<port> "
+                "(or https://… / tcp://… for non-HTTP backends)"
+            ),
+        )
+    return value
 
 
 _SHUSHU_HELP = (
@@ -49,6 +70,7 @@ def _ctx_with_overrides(args: argparse.Namespace) -> Context:
     return Context(
         account_id=base.account_id, zone_id=base.zone_id,
         hostname=base.hostname, names=names,
+        service=getattr(args, "service", None),
     )
 
 
@@ -63,6 +85,7 @@ def _emit_setup_dryrun(
             "hostname": args.hostname,
             "tunnel_name": ctx.names.tunnel_name,
             "app_name": ctx.names.app_name,
+            "service": args.service,
             "with_service_token": args.with_service_token,
             "session_duration": args.session_duration,
             "emails": list(args.allow),
@@ -89,6 +112,7 @@ def _emit_setup_dryrun(
                 hostname=args.hostname,
                 tunnel_name=ctx.names.tunnel_name,
                 app_name=ctx.names.app_name,
+                service=args.service,
                 emails=list(args.allow),
                 domains=list(args.allow_domain),
                 with_service_token=args.with_service_token,
@@ -130,6 +154,7 @@ def cmd_setup(args: argparse.Namespace) -> None:
             message="at least one of --allow / --allow-domain is required",
             remediation="pass --allow user@example.com or --allow-domain @example.com",
         )
+    args.service = _validate_service_url(args.service)
     check_token_alive()
     ctx = _ctx_with_overrides(args)
     seal = derive_seal_plan(hostname=args.hostname, shushu_arg=args.shushu)
@@ -206,6 +231,14 @@ def register(sub: argparse._SubParsersAction) -> None:
     s.add_argument(
         "--allow-domain", action="append", default=[],
         help="Email-domain to allow, e.g. @example.com (repeatable).",
+    )
+    s.add_argument(
+        "--service", required=True,
+        help=(
+            "Local service URL the tunnel routes the public hostname to, "
+            "e.g. http://localhost:8080. Required: a missing ingress rule "
+            "is exactly the gap that makes cloudflared reply 503."
+        ),
     )
     s.add_argument("--tunnel-name", default=None,
                    help="Override the derived tunnel name.")

--- a/cultureflare/cli/_commands/remote_login.py
+++ b/cultureflare/cli/_commands/remote_login.py
@@ -20,11 +20,15 @@ from cultureflare.cli._output import emit_json, emit_result
 
 
 def _validate_service_url(value: str) -> str:
-    """Reject empty / scheme-less / host-less --service values.
+    """Reject empty / scheme-less / host-less ``--service`` values.
 
-    We don't try to be exhaustive (cloudflared accepts ``unix:`` and
-    ``tcp://`` too), just catch the common shape mistakes that would
-    POST garbage into CF and produce a 503 the operator has to hunt for.
+    Catches the common shape mistakes that would POST garbage into CF
+    and produce a 503 the operator has to hunt for. The check is
+    ``scheme://host[:port]`` — i.e. cloudflared targets that have a
+    netloc (``http://``, ``https://``, ``tcp://``). Schemes without
+    a netloc (``unix:/path``) aren't accepted here; if you need that
+    shape, set the tunnel ingress directly via the dashboard or API
+    and skip this CLI's ingress step.
     """
     parsed = urlparse(value)
     if not parsed.scheme or not parsed.netloc:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cultureflare"
-version = "0.4.0"
+version = "0.5.0"
 description = "CloudFlare Agent First Interface — agent-first CLI for CloudFlare management in the AgentCulture org."
 readme = "README.md"
 license = "MIT"

--- a/tests/test_cli_remote_login.py
+++ b/tests/test_cli_remote_login.py
@@ -40,6 +40,7 @@ def test_setup_dry_run_prints_plan_and_does_not_post(http_stub, capsys):
     rc = main([
         "remote-login", "setup",
         "--hostname", "irc.culture.dev",
+        "--service", "http://localhost:8080",
         "--allow", "me@example.com",
     ])
     out = capsys.readouterr().out
@@ -47,6 +48,7 @@ def test_setup_dry_run_prints_plan_and_does_not_post(http_stub, capsys):
     assert "Dry-run" in out
     assert "## Plan" in out
     assert "irc.culture.dev" in out
+    assert "http://localhost:8080" in out
     posts = [c for c in http_stub.calls if c[0] == "POST"]
     assert posts == []
 
@@ -57,8 +59,38 @@ def test_setup_requires_at_least_one_allow(http_stub, capsys):
     rc = main([
         "remote-login", "setup",
         "--hostname", "irc.culture.dev",
+        "--service", "http://localhost:8080",
     ])
     assert rc != 0
+
+
+def test_setup_requires_service(http_stub, capsys):
+    # argparse raises SystemExit at parse time; the structured error
+    # message still goes to stderr via _CfafiArgumentParser.error().
+    with pytest.raises(SystemExit) as exc:
+        main([
+            "remote-login", "setup",
+            "--hostname", "irc.culture.dev",
+            "--allow", "me@example.com",
+        ])
+    err = capsys.readouterr().err
+    assert exc.value.code != 0
+    assert "--service" in err
+
+
+def test_setup_rejects_invalid_service_url(http_stub, capsys):
+    http_stub.set("GET", "/user/tokens/verify", _verify_alive())
+    http_stub.set("GET", "/zones", _zones_one())
+    rc = main([
+        "remote-login", "setup",
+        "--hostname", "irc.culture.dev",
+        "--allow", "me@example.com",
+        "--service", "localhost:8080",  # missing scheme
+    ])
+    err = capsys.readouterr().err
+    assert rc != 0
+    assert "--service" in err
+    assert "scheme://host" in err
 
 
 def test_setup_preflight_blocks_when_token_inactive(http_stub, capsys):
@@ -66,6 +98,7 @@ def test_setup_preflight_blocks_when_token_inactive(http_stub, capsys):
     rc = main([
         "remote-login", "setup",
         "--hostname", "irc.culture.dev",
+        "--service", "http://localhost:8080",
         "--allow", "me@example.com",
     ])
     err = capsys.readouterr().err
@@ -120,14 +153,17 @@ def test_teardown_dry_run_does_not_delete(http_stub, capsys):
 
 def test_setup_argparse_accepts_no_shushu_flag(remote_login_parser):
     args = remote_login_parser.parse_args([
-        "remote-login", "setup", "--hostname", "app.example.com", "--allow", "x@y",
+        "remote-login", "setup", "--hostname", "app.example.com",
+        "--service", "http://localhost:8080", "--allow", "x@y",
     ])
     assert args.shushu is None
+    assert args.service == "http://localhost:8080"
 
 
 def test_setup_argparse_bare_shushu_yields_empty_string(remote_login_parser):
     args = remote_login_parser.parse_args([
         "remote-login", "setup", "--hostname", "app.example.com",
+        "--service", "http://localhost:8080",
         "--allow", "x@y", "--shushu",
     ])
     assert args.shushu == ""
@@ -136,6 +172,7 @@ def test_setup_argparse_bare_shushu_yields_empty_string(remote_login_parser):
 def test_setup_argparse_shushu_with_user(remote_login_parser):
     args = remote_login_parser.parse_args([
         "remote-login", "setup", "--hostname", "app.example.com",
+        "--service", "http://localhost:8080",
         "--allow", "x@y", "--shushu=alice",
     ])
     assert args.shushu == "alice"
@@ -176,6 +213,7 @@ def test_cmd_setup_dryrun_with_shushu_lists_seal_steps(capsys, monkeypatch):
 
     ns = argparse.Namespace(
         hostname="app.example.com", allow=["x@y"], allow_domain=[],
+        service="http://localhost:8080",
         with_service_token=True, session_duration="24h",
         tunnel_name=None, app_name=None, service_token_name=None,
         json=False, apply=False, shushu="alice",

--- a/tests/test_remote_login_access_policy.py
+++ b/tests/test_remote_login_access_policy.py
@@ -3,7 +3,8 @@
 import pytest
 
 from cultureflare._remote_login._access_policy import (
-    build_include, find_policy, ensure_allow_policy, delete_policy,
+    build_include, delete_policy, ensure_allow_policy,
+    ensure_service_token_policy, find_policy, find_service_token_policy,
 )
 from cultureflare.cli._errors import CfafiError, EXIT_USER_ERROR
 
@@ -97,6 +98,87 @@ def test_ensure_allow_policy_posts_when_absent(http_stub):
             {"email_domain": {"domain": "y.com"}},
         ],
     }
+
+
+# ---------------------------------------------------------------------------
+# Non-identity service-token policy (#28)
+# ---------------------------------------------------------------------------
+
+_POLICIES_PATH = "/accounts/acc-1/access/apps/app-1/policies"
+
+
+def test_find_service_token_policy_matches_by_token_id(http_stub):
+    http_stub.queue(_list_envelope(
+        {"id": "pol-email", "decision": "allow",
+         "include": [{"email": {"email": "x@y"}}]},
+        {"id": "pol-svc",
+         "decision": "non_identity",
+         "include": [{"service_token": {"token_id": "tok-1"}}]},
+    ))
+    p = find_service_token_policy(
+        account_id="acc-1", app_id="app-1", token_id="tok-1",
+    )
+    assert p["id"] == "pol-svc"
+
+
+def test_find_service_token_policy_ignores_non_non_identity(http_stub):
+    """An ``allow`` policy that happens to mention the token doesn't count."""
+    http_stub.queue(_list_envelope(
+        {"id": "pol-other",
+         "decision": "allow",
+         "include": [{"service_token": {"token_id": "tok-1"}}]},
+    ))
+    p = find_service_token_policy(
+        account_id="acc-1", app_id="app-1", token_id="tok-1",
+    )
+    assert p is None
+
+
+def test_find_service_token_policy_returns_none_when_token_id_differs(http_stub):
+    http_stub.queue(_list_envelope(
+        {"id": "pol-svc",
+         "decision": "non_identity",
+         "include": [{"service_token": {"token_id": "tok-other"}}]},
+    ))
+    p = find_service_token_policy(
+        account_id="acc-1", app_id="app-1", token_id="tok-1",
+    )
+    assert p is None
+
+
+def test_ensure_service_token_policy_returns_existing(http_stub):
+    http_stub.queue(_list_envelope(
+        {"id": "pol-svc",
+         "decision": "non_identity",
+         "include": [{"service_token": {"token_id": "tok-1"}}]},
+    ))
+    pid, created = ensure_service_token_policy(
+        account_id="acc-1", app_id="app-1",
+        token_id="tok-1", name="x.example.com-svc-allow",
+    )
+    assert pid == "pol-svc"
+    assert created is False
+    assert [c for c in http_stub.calls if c[0] == "POST"] == []
+
+
+def test_ensure_service_token_policy_posts_when_absent(http_stub):
+    http_stub.queue(_list_envelope())
+    http_stub.set("POST", _POLICIES_PATH, {
+        "success": True, "errors": [], "messages": [],
+        "result": {"id": "pol-svc-new"},
+    })
+    pid, created = ensure_service_token_policy(
+        account_id="acc-1", app_id="app-1",
+        token_id="tok-1", name="x.example.com-svc-allow",
+    )
+    assert pid == "pol-svc-new"
+    assert created is True
+    posts = [c for c in http_stub.calls if c[0] == "POST"]
+    assert len(posts) == 1
+    payload = posts[0][2]
+    assert payload["decision"] == "non_identity"
+    assert payload["include"] == [{"service_token": {"token_id": "tok-1"}}]
+    assert payload["name"] == "x.example.com-svc-allow"
 
 
 def test_delete_policy_calls_delete(http_stub):

--- a/tests/test_remote_login_orchestrator.py
+++ b/tests/test_remote_login_orchestrator.py
@@ -17,6 +17,7 @@ def _ctx(hostname="irc.culture.dev"):
         zone_id="zid-1",
         hostname=hostname,
         names=derive_names(hostname=hostname),
+        service="http://localhost:8080",
     )
 
 
@@ -26,6 +27,7 @@ def _ctx_for(hostname):
         zone_id="zid-1",
         hostname=hostname,
         names=derive_names(hostname=hostname),
+        service="http://localhost:8080",
     )
 
 
@@ -61,6 +63,19 @@ def _program_setup_happy_path(
     http_stub.set(
         "GET", f"/accounts/{account_id}/cfd_tunnel/{tunnel_id}/token",
         {"success": True, "errors": [], "messages": [], "result": "TUN-TOK"},
+    )
+    http_stub.set(
+        "GET", f"/accounts/{account_id}/cfd_tunnel/{tunnel_id}/configurations",
+        {"success": True, "errors": [], "messages": [],
+         "result": {"config": {"ingress": []}}},
+    )
+    http_stub.set(
+        "PUT", f"/accounts/{account_id}/cfd_tunnel/{tunnel_id}/configurations",
+        {"success": True, "errors": [], "messages": [],
+         "result": {"config": {"ingress": [
+             {"hostname": hostname, "service": "http://localhost:8080"},
+             {"service": "http_status:404"},
+         ]}}},
     )
     http_stub.set("GET", f"/zones/{zone_id}/dns_records", {
         "success": True, "errors": [], "messages": [],
@@ -144,10 +159,27 @@ def test_setup_runs_all_six_steps_in_order_when_nothing_exists(http_stub):
     assert result.policy_id == "pol-1"
     assert result.service_token_client_id == "CID"
     assert result.service_token_client_secret == "SEC"
+    assert result.tunnel_service == "http://localhost:8080"
+    assert result.service_token_policy_id is not None
     assert [s.name for s in result.steps] == [
-        "zero-trust-org", "tunnel", "dns", "access-app",
-        "allow-policy", "service-token",
+        "zero-trust-org", "tunnel", "tunnel-config", "dns", "access-app",
+        "allow-policy", "service-token", "service-token-policy",
     ]
+    # The non_identity policy POST must reference the token's *resource id*,
+    # not the (different) public client_id — otherwise CF accepts the
+    # policy but service-token requests still fall through to SSO.
+    posts = [c for c in http_stub.calls if c[0] == "POST"
+             and c[1] == "/accounts/acc-1/access/apps/app-1/policies"]
+    decisions = [(p[2] or {}).get("decision") for p in posts]
+    assert "non_identity" in decisions
+    non_identity_post = next(
+        p for p in posts if (p[2] or {}).get("decision") == "non_identity"
+    )
+    include = (non_identity_post[2] or {}).get("include") or []
+    assert any(
+        (rule.get("service_token") or {}).get("token_id") == "st-1"
+        for rule in include
+    )
 
 
 def test_setup_skips_service_token_step_when_not_requested(http_stub):
@@ -160,6 +192,16 @@ def test_setup_skips_service_token_step_when_not_requested(http_stub):
     http_stub.set(
         "GET", "/accounts/acc-1/cfd_tunnel/tun-1/token",
         {"success": True, "errors": [], "messages": [], "result": "TUN-TOK"},
+    )
+    http_stub.set(
+        "GET", "/accounts/acc-1/cfd_tunnel/tun-1/configurations",
+        {"success": True, "errors": [], "messages": [],
+         "result": {"config": {"ingress": []}}},
+    )
+    http_stub.set(
+        "PUT", "/accounts/acc-1/cfd_tunnel/tun-1/configurations",
+        {"success": True, "errors": [], "messages": [],
+         "result": {"config": {"ingress": []}}},
     )
     http_stub.set("GET", "/zones/zid-1/dns_records", _empty_list())
     http_stub.set("POST", "/zones/zid-1/dns_records",
@@ -210,6 +252,14 @@ def _program_show_happy_path(
         _list_envelope({"id": tunnel_id, "name": tunnel_name}),
     )
     http_stub.set(
+        "GET", f"/accounts/{account_id}/cfd_tunnel/{tunnel_id}/configurations",
+        {"success": True, "errors": [], "messages": [],
+         "result": {"config": {"ingress": [
+             {"hostname": hostname, "service": "http://localhost:8080"},
+             {"service": "http_status:404"},
+         ]}}},
+    )
+    http_stub.set(
         "GET", f"/zones/{zone_id}/dns_records",
         _list_envelope({
             "id": "rec-1", "type": "CNAME", "name": hostname,
@@ -239,6 +289,11 @@ def test_show_reports_partial_state(http_stub):
     http_stub.set(
         "GET", "/accounts/acc-1/cfd_tunnel",
         _list_envelope({"id": "tun-1", "name": "irc-culture-dev"}),
+    )
+    http_stub.set(
+        "GET", "/accounts/acc-1/cfd_tunnel/tun-1/configurations",
+        {"success": True, "errors": [], "messages": [],
+         "result": {"config": {"ingress": []}}},
     )
     http_stub.set("GET", "/zones/zid-1/dns_records", _empty_list())
     http_stub.set("GET", "/accounts/acc-1/access/apps", _empty_list())
@@ -285,11 +340,23 @@ def _program_teardown_happy_path(
     )
     http_stub.set(
         "GET", f"/accounts/{account_id}/access/apps/{app_id}/policies",
-        _list_envelope({"id": policy_id, "name": policy_name}),
+        _list_envelope(
+            {"id": policy_id, "name": policy_name},
+            {
+                "id": "pol-svc",
+                "name": f"{hostname}-svc-allow",
+                "decision": "non_identity",
+                "include": [{"service_token": {"token_id": svc_id}}],
+            },
+        ),
     )
     http_stub.set(
         "DELETE", f"/accounts/{account_id}/access/apps/{app_id}/policies/{policy_id}",
         {"success": True, "errors": [], "messages": [], "result": {"id": policy_id}},
+    )
+    http_stub.set(
+        "DELETE", f"/accounts/{account_id}/access/apps/{app_id}/policies/pol-svc",
+        {"success": True, "errors": [], "messages": [], "result": {"id": "pol-svc"}},
     )
     http_stub.set(
         "DELETE", f"/accounts/{account_id}/access/apps/{app_id}",
@@ -322,7 +389,8 @@ def test_teardown_reverses_setup_skipping_zt_org(http_stub):
     result = teardown(ctx=_ctx(), keep_tunnel=False)
     assert isinstance(result, TeardownResult)
     assert [s.name for s in result.steps] == [
-        "service-token", "allow-policy", "access-app", "dns", "tunnel",
+        "service-token", "service-token-policy",
+        "allow-policy", "access-app", "dns", "tunnel",
     ]
     delete_paths = [c[1] for c in http_stub.calls if c[0] == "DELETE"]
     assert all("organizations" not in p for p in delete_paths)

--- a/tests/test_remote_login_render.py
+++ b/tests/test_remote_login_render.py
@@ -350,6 +350,24 @@ def test_show_markdown_flags_missing_tunnel_ingress():
     assert "503" in md  # remediation hint in the (no rules) message
 
 
+def test_show_markdown_treats_none_config_as_no_rules():
+    """get_tunnel_config returns None when no config is set yet — same gap."""
+    show = ShowResult(
+        team_domain="ac.cloudflareaccess.com",
+        tunnel={"id": "tun-1", "name": "irc-culture-dev"},
+        tunnel_config=None,
+        dns=None, access_app=None, policy=None,
+        service_token=None, service_token_policy=None,
+    )
+    md = render_show_markdown(show, hostname="irc.culture.dev")
+    assert "**tunnel-ingress:** (no rules — cloudflared will 503)" in md
+    # The misleading "(not found)" must NOT appear on the ingress line.
+    ingress_line = next(
+        line for line in md.splitlines() if "tunnel-ingress" in line
+    )
+    assert "(not found)" not in ingress_line
+
+
 def test_show_markdown_renders_tunnel_ingress_when_present():
     show = ShowResult(
         team_domain="ac.cloudflareaccess.com",

--- a/tests/test_remote_login_render.py
+++ b/tests/test_remote_login_render.py
@@ -74,10 +74,12 @@ def test_render_setup_dryrun_markdown_shows_plan_and_no_secrets():
         app_name="irc.culture.dev",
         emails=["me@example.com"],
         domains=[],
+        service="http://localhost:8080",
         with_service_token=True,
         session_duration="24h",
     )
     assert "Dry-run" in md
+    assert "http://localhost:8080" in md
     assert "## Plan" in md
     assert "TUN-TOK" not in md
     assert "tunnel" in md.lower()
@@ -306,6 +308,7 @@ def test_dryrun_markdown_lists_seal_steps_when_shushu_set():
         tunnel_name="app-example-com",
         app_name="app.example.com",
         emails=["x@y"], domains=[],
+        service="http://localhost:8080",
         with_service_token=True,
         session_duration="24h",
         seal_user="alice",
@@ -323,6 +326,7 @@ def test_dryrun_markdown_omits_seal_when_shushu_unset():
         tunnel_name="app-example-com",
         app_name="app.example.com",
         emails=["x@y"], domains=[],
+        service="http://localhost:8080",
         with_service_token=True,
         session_duration="24h",
         seal_user=None,
@@ -330,6 +334,93 @@ def test_dryrun_markdown_omits_seal_when_shushu_unset():
         seal_svc_name=None,
     )
     assert "seal" not in md.lower()
+
+
+def test_show_markdown_flags_missing_tunnel_ingress():
+    """The exact gap from #28: tunnel exists but config has no ingress."""
+    show = ShowResult(
+        team_domain="ac.cloudflareaccess.com",
+        tunnel={"id": "tun-1", "name": "irc-culture-dev"},
+        tunnel_config={"config": {"ingress": []}},
+        dns=None, access_app=None, policy=None,
+        service_token=None, service_token_policy=None,
+    )
+    md = render_show_markdown(show, hostname="irc.culture.dev")
+    assert "**tunnel-ingress:** (no rules" in md
+    assert "503" in md  # remediation hint in the (no rules) message
+
+
+def test_show_markdown_renders_tunnel_ingress_when_present():
+    show = ShowResult(
+        team_domain="ac.cloudflareaccess.com",
+        tunnel={"id": "tun-1", "name": "irc-culture-dev"},
+        tunnel_config={"config": {"ingress": [
+            {"hostname": "irc.culture.dev", "service": "http://localhost:8080"},
+            {"service": "http_status:404"},
+        ]}},
+        dns=None, access_app=None, policy=None,
+        service_token=None, service_token_policy=None,
+    )
+    md = render_show_markdown(show, hostname="irc.culture.dev")
+    assert (
+        "**tunnel-ingress:** irc.culture.dev → http://localhost:8080" in md
+    )
+
+
+def test_show_markdown_flags_missing_service_token_policy():
+    """The other half of #28: token exists but no non_identity policy."""
+    show = ShowResult(
+        team_domain="ac.cloudflareaccess.com",
+        tunnel=None, tunnel_config=None, dns=None,
+        access_app={"id": "app-1"},
+        policy={"id": "pol-1"},
+        service_token={"id": "st-1", "name": "irc-svc", "client_id": "cid"},
+        service_token_policy=None,
+    )
+    md = render_show_markdown(show, hostname="irc.culture.dev")
+    assert "**service-token-policy:** (not found" in md
+    assert "302" in md  # remediation hint
+
+
+def test_show_json_includes_new_fields():
+    show = ShowResult(
+        team_domain="ac.cloudflareaccess.com",
+        tunnel={"id": "tun-1"},
+        tunnel_config={"config": {"ingress": [
+            {"hostname": "irc.culture.dev", "service": "http://localhost:8080"},
+        ]}},
+        dns=None, access_app={"id": "app-1"},
+        policy={"id": "pol-1"},
+        service_token={"id": "st-1"},
+        service_token_policy={"id": "pol-svc"},
+    )
+    env = render_show_json(show, hostname="irc.culture.dev")
+    r = env["result"]
+    assert r["tunnel_config"]["config"]["ingress"][0]["service"] == \
+        "http://localhost:8080"
+    assert r["service_token_policy"] == {"id": "pol-svc"}
+
+
+def test_setup_markdown_renders_tunnel_ingress_and_svc_policy():
+    result = SetupResult(
+        team_domain="ac.cloudflareaccess.com",
+        tunnel_id="tun-1", tunnel_name="irc-culture-dev",
+        tunnel_token="TUN-TOK",
+        tunnel_service="http://localhost:8765",
+        dns_record_id="rec-1",
+        dns_target="tun-1.cfargotunnel.com",
+        access_app_id="app-1",
+        policy_id="pol-1",
+        policy_emails=["me@example.com"],
+        policy_domains=[],
+        service_token_client_id="CID",
+        service_token_client_secret="SEC",
+        service_token_policy_id="pol-svc",
+        steps=[],
+    )
+    md = render_setup_markdown(result, hostname="irc.culture.dev")
+    assert "**TUNNEL_INGRESS:** irc.culture.dev → http://localhost:8765" in md
+    assert "**SERVICE_TOKEN_POLICY_ID:** pol-svc" in md
 
 
 def test_show_json_includes_sealed_in_status():

--- a/tests/test_remote_login_service_token.py
+++ b/tests/test_remote_login_service_token.py
@@ -44,16 +44,18 @@ def test_ensure_service_token_raises_when_existing_with_strict(http_stub):
 
 def test_ensure_service_token_returns_existing_with_no_secret_when_lax(http_stub):
     # strict=False means: caller (e.g. teardown's planner) accepts
-    # 'no secret available'. setup() will pass strict=True.
+    # 'no secret available'. Returns the resource id so an idempotent
+    # re-run can still attach a non_identity policy.
     http_stub.queue(_list_envelope(
         {"id": "st-b", "name": "irc-svc", "client_id": "cid-b"},
     ))
-    cid, secret, created = ensure_service_token(
+    cid, secret, created, token_id = ensure_service_token(
         account_id="acc-1", name="irc-svc", strict=False,
     )
     assert cid == "cid-b"
     assert secret is None
     assert created is False
+    assert token_id == "st-b"
 
 
 def test_ensure_service_token_posts_when_absent(http_stub):
@@ -65,12 +67,13 @@ def test_ensure_service_token_posts_when_absent(http_stub):
             "client_id": "cid-new", "client_secret": "secret-shhh",
         },
     })
-    cid, secret, created = ensure_service_token(
+    cid, secret, created, token_id = ensure_service_token(
         account_id="acc-1", name="irc-svc", strict=True,
     )
     assert cid == "cid-new"
     assert secret == "secret-shhh"
     assert created is True
+    assert token_id == "st-new"
     posts = [c for c in http_stub.calls if c[0] == "POST"]
     assert posts[0][2] == {"name": "irc-svc"}
 

--- a/tests/test_remote_login_tunnel.py
+++ b/tests/test_remote_login_tunnel.py
@@ -3,7 +3,8 @@
 import pytest
 
 from cultureflare._remote_login._tunnel import (
-    find_tunnel, ensure_tunnel, get_tunnel_token, delete_tunnel,
+    delete_tunnel, ensure_tunnel, ensure_tunnel_config,
+    find_tunnel, get_tunnel_config, get_tunnel_token,
 )
 
 
@@ -79,3 +80,91 @@ def test_delete_tunnel_passes_force_true(http_stub):
     assert method == "DELETE"
     assert path == "/accounts/acc-1/cfd_tunnel/tun-b"
     assert query.get("force") == "true"
+
+
+# ---------------------------------------------------------------------------
+# Tunnel ingress configuration (#28)
+# ---------------------------------------------------------------------------
+
+_TUNNEL_CFG_PATH = "/accounts/acc-1/cfd_tunnel/tun-b/configurations"
+
+
+def _config_envelope(ingress):
+    return {
+        "success": True, "errors": [], "messages": [],
+        "result": {"config": {"ingress": ingress}},
+    }
+
+
+def test_get_tunnel_config_returns_result_envelope(http_stub):
+    http_stub.set("GET", _TUNNEL_CFG_PATH, _config_envelope([
+        {"hostname": "x.example.com", "service": "http://localhost:80"},
+        {"service": "http_status:404"},
+    ]))
+    cfg = get_tunnel_config(account_id="acc-1", tunnel_id="tun-b")
+    assert cfg is not None
+    rules = cfg["config"]["ingress"]
+    assert rules[0]["hostname"] == "x.example.com"
+
+
+def test_ensure_tunnel_config_skips_when_ingress_already_matches(http_stub):
+    http_stub.set("GET", _TUNNEL_CFG_PATH, _config_envelope([
+        {"hostname": "x.example.com", "service": "http://localhost:8080"},
+        {"service": "http_status:404"},
+    ]))
+    changed = ensure_tunnel_config(
+        account_id="acc-1", tunnel_id="tun-b",
+        hostname="x.example.com", service="http://localhost:8080",
+    )
+    assert changed is False
+    assert [c[0] for c in http_stub.calls] == ["GET"]
+
+
+def test_ensure_tunnel_config_puts_when_no_ingress(http_stub):
+    """The exact bug from issue #28 — tunnel created but no ingress rule."""
+    http_stub.set("GET", _TUNNEL_CFG_PATH, _config_envelope([]))
+    http_stub.set("PUT", _TUNNEL_CFG_PATH, _config_envelope([
+        {"hostname": "x.example.com", "service": "http://localhost:8080"},
+        {"service": "http_status:404"},
+    ]))
+    changed = ensure_tunnel_config(
+        account_id="acc-1", tunnel_id="tun-b",
+        hostname="x.example.com", service="http://localhost:8080",
+    )
+    assert changed is True
+    puts = [c for c in http_stub.calls if c[0] == "PUT"]
+    assert len(puts) == 1
+    payload = puts[0][2]
+    rules = payload["config"]["ingress"]
+    assert rules[0] == {"hostname": "x.example.com", "service": "http://localhost:8080"}
+    assert rules[-1] == {"service": "http_status:404"}
+
+
+def test_ensure_tunnel_config_overwrites_stale_ingress(http_stub):
+    """Existing ingress points at the wrong service — overwrite."""
+    http_stub.set("GET", _TUNNEL_CFG_PATH, _config_envelope([
+        {"hostname": "x.example.com", "service": "http://localhost:9999"},
+        {"service": "http_status:404"},
+    ]))
+    http_stub.set("PUT", _TUNNEL_CFG_PATH, _config_envelope([
+        {"hostname": "x.example.com", "service": "http://localhost:8080"},
+        {"service": "http_status:404"},
+    ]))
+    changed = ensure_tunnel_config(
+        account_id="acc-1", tunnel_id="tun-b",
+        hostname="x.example.com", service="http://localhost:8080",
+    )
+    assert changed is True
+
+
+def test_ensure_tunnel_config_overwrites_when_hostname_mismatch(http_stub):
+    http_stub.set("GET", _TUNNEL_CFG_PATH, _config_envelope([
+        {"hostname": "old.example.com", "service": "http://localhost:8080"},
+        {"service": "http_status:404"},
+    ]))
+    http_stub.set("PUT", _TUNNEL_CFG_PATH, _config_envelope([]))
+    changed = ensure_tunnel_config(
+        account_id="acc-1", tunnel_id="tun-b",
+        hostname="x.example.com", service="http://localhost:8080",
+    )
+    assert changed is True

--- a/tests/test_remote_login_tunnel.py
+++ b/tests/test_remote_login_tunnel.py
@@ -157,6 +157,40 @@ def test_ensure_tunnel_config_overwrites_stale_ingress(http_stub):
     assert changed is True
 
 
+def test_ensure_tunnel_config_preserves_other_config_keys(http_stub):
+    """Don't clobber operator-set warp-routing / originRequest etc.
+
+    The PUT endpoint is replace-not-merge — omitting a key resets it.
+    Bug #28 follow-up from qodo review on PR #30.
+    """
+    http_stub.set("GET", _TUNNEL_CFG_PATH, {
+        "success": True, "errors": [], "messages": [],
+        "result": {
+            "version": 7,
+            "config": {
+                "ingress": [{"service": "http_status:404"}],
+                "warp-routing": {"enabled": True},
+                "originRequest": {"connectTimeout": 30},
+            },
+        },
+    })
+    http_stub.set("PUT", _TUNNEL_CFG_PATH, _config_envelope([]))
+    ensure_tunnel_config(
+        account_id="acc-1", tunnel_id="tun-b",
+        hostname="x.example.com", service="http://localhost:8080",
+    )
+    puts = [c for c in http_stub.calls if c[0] == "PUT"]
+    payload = puts[0][2]
+    cfg = payload["config"]
+    # New ingress applied
+    assert cfg["ingress"][0] == {
+        "hostname": "x.example.com", "service": "http://localhost:8080",
+    }
+    # Other keys preserved verbatim
+    assert cfg["warp-routing"] == {"enabled": True}
+    assert cfg["originRequest"] == {"connectTimeout": 30}
+
+
 def test_ensure_tunnel_config_overwrites_when_hostname_mismatch(http_stub):
     http_stub.set("GET", _TUNNEL_CFG_PATH, _config_envelope([
         {"hostname": "old.example.com", "service": "http://localhost:8080"},

--- a/uv.lock
+++ b/uv.lock
@@ -183,7 +183,7 @@ wheels = [
 
 [[package]]
 name = "cultureflare"
-version = "0.4.0"
+version = "0.5.0"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary

- Adds `ensure_tunnel_config` (PUT `/cfd_tunnel/{id}/configurations`) and `ensure_service_token_policy` (POST a `non_identity` policy admitting the service token) to `cultureflare._remote_login`. Both are idempotent (find-or-skip).
- Wires both into `cultureflare remote-login setup`, gated by a new **required** `--service URL` flag for tunnel ingress.
- Mirrors the new resources in `show` (with explicit \"will 503\" / \"will 302 to SSO\" hints when missing) and `teardown` (deletes the non_identity policy before the Access app).
- Closes #28.

## Why

Filed by irc-lens in #28: provisioning a hostname via `setup` left the tunnel without an ingress rule (cloudflared returns 503) and left the service token without a non_identity policy (programmatic clients 302 to SSO). The env file looked complete but the deployment was unusable.

## Verified live against a local domain

The same PR was used to repair the live broken deployment as the end-to-end verification:

\`\`\`
$ cultureflare remote-login show --hostname [domain]   # before
- **tunnel-ingress:** (no rules — cloudflared will 503)
- **service-token-policy:** (not found — service token headers will 302 to SSO)

$ cultureflare remote-login setup --hostname [domain] \
    --service http://localhost:8765 --allow [emai] \
    --with-service-token --apply
…
8. ✓ ensured service-token-policy (id=27f7f966-3767-41f3-8a42-e219c53bcbc9)

$ cultureflare remote-login show --hostname [domain]   # after
- **tunnel-ingress:** [domain] → http://localhost:8765
- **service-token-policy:** id=27f7f966-3767-41f3-8a42-e219c53bcbc9
\`\`\`

The existing service-token secret is **not rotated** (irc-lens keeps using its current `cd186b7d…access` client_id and the secret it already has on its host). irc-lens's own `pytest -m cloudflare` round-trip is the final step on their side.

## Notable design notes

- `ensure_service_token` now returns a 4-tuple `(client_id, client_secret, created, token_id)` so the orchestrator can attach the non_identity policy without a second `find_service_token` (which doesn't see the just-created token under the test stub).
- `setup`'s service-token step uses `strict=False` — re-running setup against an existing deployment must not error (the secret is one-shot; teardown first if you want a fresh one). This makes \"setup as repair\" a supported path.
- The non_identity policy POST does **not** set `precedence` — CF rejects two policies on the same app sharing one (error 12130). Let CF auto-assign rather than racing to compute the next free integer. Discovered live during the verify step.

## Test plan

- [x] 229 pytest tests passing locally (was 200; added 29 covering the new helpers and orchestrator wiring).
- [x] `cultureflare remote-login setup --service http://localhost:[port] --apply` against the live [domain] succeeded; `show` reports both gaps closed.
- [x] No-auth `curl [domain]` correctly 302s to the Access SSO login (Access still gating; previously it would 503 from cloudflared *after* SSO admit).
- [ ] irc-lens runs `pytest -m cloudflare` against the existing tunnel + lens to confirm the full service-token round-trip.

## Follow-ups

- Bash sibling scripts under `.claude/skills/cultureflare-write/scripts/` (`cf-tunnel-config-set.sh`, `cf-access-svc-token-policy-create.sh`) for agents that load the skill but not the Python CLI. Deferred to a follow-up since the Python CLI is sufficient for the live fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)