### PR TITLE
feat(skills): cf-dns-delete + cf-redirect-delete primitives (#40)

### DIFF
--- a/.claude/skills/cultureflare-write/SKILL.md
+++ b/.claude/skills/cultureflare-write/SKILL.md
@@ -118,6 +118,8 @@ Every write operation in this skill follows the same shape:
 | Add a redirect | `bash .claude/skills/cultureflare-write/scripts/cf-redirect-create.sh ...` |
 | Delete one Pages deployment | `bash .claude/skills/cultureflare-write/scripts/cf-pages-deployment-delete.sh ...` |
 | Bulk-delete all deployments in a Pages project | `bash .claude/skills/cultureflare-write/scripts/cf-pages-deployments-purge.sh ...` (two-phase, see §3.3) |
+| Delete a DNS record | `bash .claude/skills/cultureflare-write/scripts/cf-dns-delete.sh ...` |
+| Delete one redirect rule | `bash .claude/skills/cultureflare-write/scripts/cf-redirect-delete.sh ...` |
 
 Full flag reference for each script follows below.
 
@@ -170,6 +172,46 @@ the redirect won't fire. Use `cultureflare dns create` / `cf-dns-create.sh`
 (below) to add the apex and `www` records first, then create the
 redirect.
 
+### cf-redirect-delete.sh
+
+Deletes a **single** Single Redirect rule from a zone's
+`http_request_dynamic_redirect` ruleset — the rule whose expression
+matches `FROM_HOST`. A zone's redirect ruleset can hold many rules
+(e.g. `www`→apex plus several subdomain 301s); this removes one and
+leaves the rest untouched. It never deletes the whole ruleset.
+
+```sh
+# Dry-run (resolves the rule, prints what it would DELETE):
+bash .claude/skills/cultureflare-write/scripts/cf-redirect-delete.sh \
+  culture.dev agex.culture.dev
+
+# Apply for real:
+bash .claude/skills/cultureflare-write/scripts/cf-redirect-delete.sh \
+  culture.dev agex.culture.dev --apply
+```
+
+`ZONE` is the zone whose ruleset holds the rule (e.g. `culture.dev`),
+which is **not** the same as `FROM_HOST` when `FROM_HOST` is a
+subdomain (`agex.culture.dev`). Both are explicit positionals — nothing
+is inferred. The rule is matched on the anchored token
+`http.host eq "FROM_HOST"`, so a wildcard `www` rule or a different
+subdomain's rule is never caught by accident.
+
+Flags:
+
+- `--apply` — actually DELETE. Without it, the script is a dry-run.
+- `--json` — raw CloudFlare response envelope (the updated ruleset on
+  apply, a simulated body in dry-run).
+
+Exit codes: `0` success (dry-run or apply), `1` zone / ruleset / rule
+not found or ambiguous match or API error, `2` usage error.
+
+Idempotent teardown: if no rule matches `FROM_HOST` (already removed),
+the script exits 1 with "nothing to delete" rather than mutating
+anything. Uses the same `Zone · Single Redirect · Edit` scope as
+`cf-redirect-create.sh` — CF's "Edit" permission covers DELETE, so no
+token upgrade is needed.
+
 ### cf-dns-create.sh / cultureflare dns create
 
 Creates a DNS record in a zone. Same safety model as
@@ -213,6 +255,41 @@ Idempotency key: **type + name + content**. Two A records at the
 same name with different IPs are allowed (CF supports round-robin);
 two records with identical type+name+content are refused as
 duplicates.
+
+### cf-dns-delete.sh
+
+Deletes a DNS record from a zone, resolved by record **name**. Same
+safety model as the create scripts: dry-run by default, `--apply` to
+commit. Refuses ambiguous matches instead of guessing.
+
+```sh
+# Dry-run:
+bash .claude/skills/cultureflare-write/scripts/cf-dns-delete.sh \
+  culture.dev agex.culture.dev
+
+# Apply for real:
+bash .claude/skills/cultureflare-write/scripts/cf-dns-delete.sh \
+  culture.dev agex.culture.dev --apply
+```
+
+`ZONE` is the zone the record lives in (e.g. `culture.dev`); `NAME` is
+the fully-qualified record name (e.g. `agex.culture.dev`). If a name
+resolves to more than one record (e.g. an A + AAAA pair, or
+round-robin A records), the script lists the candidates and exits 1 —
+narrow the match with `--type` and/or `--content`.
+
+Flags:
+
+- `--type=TYPE` — narrow to a record type (`A`, `AAAA`, `CNAME`, `TXT`,
+  `MX`, `NS`, `SRV`, `CAA`).
+- `--content=VALUE` — narrow to records with this exact content.
+- `--apply` — actually DELETE. Without it, the script is a dry-run.
+- `--json` — raw CloudFlare response envelope (or simulated body in
+  dry-run).
+
+Exit codes: `0` success, `1` zone not found / no match / ambiguous
+match / API error, `2` usage error. Uses the same `Zone · DNS · Edit`
+scope as `cf-dns-create.sh` — DELETE needs no extra token scope.
 
 ### cf-pages-project-create.sh
 
@@ -663,11 +740,12 @@ downstream jq pipelines.
   deletes every deployment but leaves the zero-deployment project
   behind. A future `cf-pages-project-delete.sh` will land as a
   separate, smaller PR.
-- **Workers / DNS / zone deletion.** Still Phase 3 territory; new
+- **Workers / zone deletion.** Still Phase 3 territory; new
   `cf-*-delete.sh` scripts can follow the same dry-run-by-default
-  pattern. Whether to re-use the manifest gate depends on blast
-  radius — a single DNS record rarely warrants it; bulk route
-  deletion probably does.
+  pattern. (DNS-record deletion now exists — `cf-dns-delete.sh`; and
+  single redirect-rule deletion — `cf-redirect-delete.sh`.) Whether to
+  re-use the manifest gate depends on blast radius — a single DNS
+  record rarely warrants it; bulk route deletion probably does.
 - **Account-wide rulesets.** This skill only creates zone-level
   rulesets. Account-level rulesets (applied across many zones) are
   out of scope.

--- a/.claude/skills/cultureflare-write/references/cf-api-gotchas.md
+++ b/.claude/skills/cultureflare-write/references/cf-api-gotchas.md
@@ -135,3 +135,25 @@ permissions problem, which makes it easy to chase the wrong rabbit.
 for any zone-level Edit permission (Single Redirect, DNS, Workers
 Routes). `docs/SETUP.md` §1.5 lists every scope in one place so a
 fresh token covers the whole surface.
+
+## 7. Rulesets list omits the `rules` array
+
+**Symptom.** `GET /zones/:id/rulesets` returns each ruleset's
+metadata (id, phase, kind, version) but **no `rules`**. Iterating
+`.result[].rules` to find a specific rule yields nothing, so a
+delete-by-host lookup silently finds zero matches.
+
+**Root cause.** The list endpoint is a summary view. The `rules`
+array only comes back from the per-ruleset detail GET
+`GET /zones/:id/rulesets/:ruleset_id`.
+
+**Guard.** `cf-redirect-delete.sh`
+([scripts/cf-redirect-delete.sh](../scripts/cf-redirect-delete.sh))
+resolves the `http_request_dynamic_redirect` ruleset id from the list,
+then does a second `cf_api` (single-object) GET on the detail endpoint
+to enumerate `.result.rules` before selecting the rule to delete.
+Delete a single rule via
+`DELETE /zones/:id/rulesets/:ruleset_id/rules/:rule_id` (returns the
+updated ruleset) — **never** `DELETE …/rulesets/:ruleset_id`, which
+drops every rule in the phase (e.g. the `www`→apex and other subdomain
+redirects sharing that ruleset).

--- a/.claude/skills/cultureflare-write/scripts/cf-dns-delete.sh
+++ b/.claude/skills/cultureflare-write/scripts/cf-dns-delete.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+# Delete a DNS record from a CloudFlare zone.
+#
+# Usage:
+#   cf-dns-delete.sh ZONE NAME [--type=TYPE] [--content=VALUE] [--apply] [--json]
+#
+# Default is DRY-RUN: resolves the zone, finds the matching record(s),
+# refuses if the match is ambiguous, prints the DELETE URL it would
+# hit, and exits 0 WITHOUT mutating anything. Pass --apply to actually
+# DELETE.
+#
+# The record is resolved by NAME (a fully-qualified record name such as
+# agex.culture.dev), narrowed server-side with the optional --type /
+# --content filters. The zone is an explicit positional so the blast
+# radius is obvious and never inferred — this is the zone whose record
+# you are deleting (e.g. culture.dev for the agex.culture.dev record).
+#
+# Flags:
+#   --type=TYPE      narrow the match to a record type (A, AAAA, CNAME, ...)
+#   --content=VALUE  narrow the match to records with this exact content
+#   --apply          actually DELETE (without it, this is a dry-run)
+#   --json           raw CloudFlare response envelope (or simulated body in dry-run)
+#
+# Exits 1 on: zone not found, no matching record (already gone),
+#   ambiguous match (>1 record — narrow with --type / --content),
+#   API error. Exits 2 on usage error.
+
+set -euo pipefail
+shopt -s inherit_errexit
+
+mode=md
+apply=0
+type_filter=""
+content_filter=""
+positional=()
+
+for arg in "$@"; do
+  case "$arg" in
+    --json)       mode=json ;;
+    --apply)      apply=1 ;;
+    --type=*)     type_filter="${arg#*=}" ;;
+    --content=*)  content_filter="${arg#*=}" ;;
+    -h|--help)
+      # Skip line 1 (shebang), strip `# ?`, stop at the first non-comment line.
+      awk 'NR==1{next} /^#/{sub(/^# ?/, ""); print; next} {exit}' "$0"
+      exit 0
+      ;;
+    -*)
+      echo "ERROR: unknown flag: $arg" >&2
+      exit 2
+      ;;
+    *)
+      positional+=("$arg")
+      ;;
+  esac
+done
+
+if (( ${#positional[@]} != 2 )); then
+  echo "ERROR: expected ZONE and NAME positional args, got ${#positional[@]}" >&2
+  echo "usage: cf-dns-delete.sh ZONE NAME [--type=TYPE] [--content=VALUE] [--apply] [--json]" >&2
+  exit 2
+fi
+zone_name="${positional[0]}"
+record_name="${positional[1]}"
+
+# Validate ZONE and NAME early — both interpolate into URLs and the
+# match summary. Same hostname shape used by cf-redirect-create.sh /
+# cf-dns-create.sh. Anything outside it is rejected before any API call.
+host_re='^[a-zA-Z0-9][a-zA-Z0-9.-]*$'
+for h in "$zone_name" "$record_name"; do
+  if [[ ! "$h" =~ $host_re ]]; then
+    echo "ERROR: invalid hostname: $h" >&2
+    exit 2
+  fi
+done
+
+# If --type given, validate against the same set cf-dns-create.sh accepts.
+if [[ -n "$type_filter" ]]; then
+  case "$type_filter" in
+    A|AAAA|CNAME|TXT|MX|NS|SRV|CAA) ;;
+    *)
+      echo "ERROR: unsupported record type: $type_filter (allowed: A AAAA CNAME TXT MX NS SRV CAA)" >&2
+      exit 2
+      ;;
+  esac
+fi
+
+# shellcheck source=../../cloudflare/scripts/_lib.sh
+source "$(dirname "${BASH_SOURCE[0]}")/_lib.sh"
+
+# Resolve ZONE to a zone ID.
+zones_json=$(cf_api_paginated /zones)
+# shellcheck disable=SC2016  # single-quoted jq filter
+zone_id=$(printf '%s' "$zones_json" | jq -r --arg name "$zone_name" \
+  '[.result[] | select(.name == $name) | .id] | .[0] // ""')
+
+if [[ -z "$zone_id" ]]; then
+  echo "ERROR: zone $zone_name not found in this account" >&2
+  exit 1
+fi
+
+# Build the list query. Every user-supplied value that lands in the
+# query string is URL-encoded, even the allowlist-validated type, to
+# stay consistent with the repo-wide "encode everything from outside"
+# convention. `match=all` is only meaningful with multiple filters but
+# is harmless with one.
+name_encoded=$(jq -rn --arg v "$record_name" '$v|@uri')
+query="name=$name_encoded&match=all"
+if [[ -n "$type_filter" ]]; then
+  type_encoded=$(jq -rn --arg v "$type_filter" '$v|@uri')
+  query="$query&type=$type_encoded"
+fi
+if [[ -n "$content_filter" ]]; then
+  content_encoded=$(jq -rn --arg v "$content_filter" '$v|@uri')
+  query="$query&content=$content_encoded"
+fi
+
+records_json=$(cf_api_paginated "/zones/$zone_id/dns_records?$query")
+
+# shellcheck disable=SC2016  # single-quoted jq filter
+matches_json=$(printf '%s' "$records_json" | jq '
+  [.result[] | {id, type, name, content, proxied}]
+')
+match_count=$(printf '%s' "$matches_json" | jq 'length')
+
+# Compose a human-readable selector for error messages.
+selector="$record_name"
+[[ -n "$type_filter" ]]    && selector="$selector type=$type_filter"
+[[ -n "$content_filter" ]] && selector="$selector content=$content_filter"
+
+if (( match_count == 0 )); then
+  echo "ERROR: no DNS record matching '$selector' on zone $zone_name (nothing to delete)" >&2
+  exit 1
+fi
+if (( match_count > 1 )); then
+  echo "ERROR: ambiguous match on zone $zone_name: '$selector' matches $match_count records" >&2
+  printf '%s\n' "$matches_json" | jq -r '.[] | "  - \(.id)  \(.type)  \(.content)"' >&2
+  echo "       narrow with --type=TYPE and/or --content=VALUE." >&2
+  exit 1
+fi
+
+record_id=$(printf '%s' "$matches_json" | jq -r '.[0].id')
+record_type=$(printf '%s' "$matches_json" | jq -r '.[0].type')
+record_content=$(printf '%s' "$matches_json" | jq -r '.[0].content')
+record_proxied=$(printf '%s' "$matches_json" | jq -r '.[0].proxied')
+
+delete_path="/zones/$zone_id/dns_records/$record_id"
+
+render_summary_kv() {
+  printf -- '- **zone:** %s (id=%s)\n' "$zone_name" "$zone_id"
+  printf -- '- **type:** %s\n' "$record_type"
+  printf -- '- **name:** %s\n' "$record_name"
+  printf -- '- **content:** %s\n' "$record_content"
+  printf -- '- **proxied:** %s\n' "$record_proxied"
+  printf -- '- **record_id:** %s\n' "$record_id"
+  return 0
+}
+
+if (( apply == 0 )); then
+  if [[ "$mode" == "json" ]]; then
+    # shellcheck disable=SC2016  # single-quoted jq filter
+    jq -n \
+      --arg zone_id "$zone_id" \
+      --arg record_id "$record_id" \
+      --arg delete_path "$delete_path" \
+      '{success: true, errors: [], messages: ["dry-run: no changes applied"],
+        result: {dry_run: true, zone_id: $zone_id, record_id: $record_id,
+                 would_delete: $delete_path}}'
+    exit 0
+  fi
+  printf '**Dry-run — no changes applied**\n\n'
+  render_summary_kv
+  # shellcheck disable=SC2016  # literal backticks wrap markdown inline code
+  printf '\n**would DELETE** `%s`\n' "$delete_path"
+  exit 0
+fi
+
+# Apply path.
+response=$(cf_api "$delete_path" -X DELETE)
+
+if [[ "$mode" == "json" ]]; then
+  printf '%s\n' "$response"
+  exit 0
+fi
+
+printf '**DNS record deleted**\n\n'
+render_summary_kv

--- a/.claude/skills/cultureflare-write/scripts/cf-dns-delete.sh
+++ b/.claude/skills/cultureflare-write/scripts/cf-dns-delete.sh
@@ -46,7 +46,7 @@ for arg in "$@"; do
       exit 0
       ;;
     -*)
-      echo "ERROR: unknown flag: $arg" >&2
+      printf '%s\n' "ERROR: unknown flag: $arg" >&2
       exit 2
       ;;
     *)
@@ -56,8 +56,8 @@ for arg in "$@"; do
 done
 
 if (( ${#positional[@]} != 2 )); then
-  echo "ERROR: expected ZONE and NAME positional args, got ${#positional[@]}" >&2
-  echo "usage: cf-dns-delete.sh ZONE NAME [--type=TYPE] [--content=VALUE] [--apply] [--json]" >&2
+  printf '%s\n' "ERROR: expected ZONE and NAME positional args, got ${#positional[@]}" >&2
+  printf '%s\n' "usage: cf-dns-delete.sh ZONE NAME [--type=TYPE] [--content=VALUE] [--apply] [--json]" >&2
   exit 2
 fi
 zone_name="${positional[0]}"
@@ -69,7 +69,7 @@ record_name="${positional[1]}"
 host_re='^[a-zA-Z0-9][a-zA-Z0-9.-]*$'
 for h in "$zone_name" "$record_name"; do
   if [[ ! "$h" =~ $host_re ]]; then
-    echo "ERROR: invalid hostname: $h" >&2
+    printf '%s\n' "ERROR: invalid hostname: $h" >&2
     exit 2
   fi
 done
@@ -79,7 +79,7 @@ if [[ -n "$type_filter" ]]; then
   case "$type_filter" in
     A|AAAA|CNAME|TXT|MX|NS|SRV|CAA) ;;
     *)
-      echo "ERROR: unsupported record type: $type_filter (allowed: A AAAA CNAME TXT MX NS SRV CAA)" >&2
+      printf '%s\n' "ERROR: unsupported record type: $type_filter (allowed: A AAAA CNAME TXT MX NS SRV CAA)" >&2
       exit 2
       ;;
   esac
@@ -95,7 +95,7 @@ zone_id=$(printf '%s' "$zones_json" | jq -r --arg name "$zone_name" \
   '[.result[] | select(.name == $name) | .id] | .[0] // ""')
 
 if [[ -z "$zone_id" ]]; then
-  echo "ERROR: zone $zone_name not found in this account" >&2
+  printf '%s\n' "ERROR: zone $zone_name not found in this account" >&2
   exit 1
 fi
 
@@ -129,13 +129,13 @@ selector="$record_name"
 [[ -n "$content_filter" ]] && selector="$selector content=$content_filter"
 
 if (( match_count == 0 )); then
-  echo "ERROR: no DNS record matching '$selector' on zone $zone_name (nothing to delete)" >&2
+  printf '%s\n' "ERROR: no DNS record matching '$selector' on zone $zone_name (nothing to delete)" >&2
   exit 1
 fi
 if (( match_count > 1 )); then
-  echo "ERROR: ambiguous match on zone $zone_name: '$selector' matches $match_count records" >&2
+  printf '%s\n' "ERROR: ambiguous match on zone $zone_name: '$selector' matches $match_count records" >&2
   printf '%s\n' "$matches_json" | jq -r '.[] | "  - \(.id)  \(.type)  \(.content)"' >&2
-  echo "       narrow with --type=TYPE and/or --content=VALUE." >&2
+  printf '%s\n' "       narrow with --type=TYPE and/or --content=VALUE." >&2
   exit 1
 fi
 

--- a/.claude/skills/cultureflare-write/scripts/cf-redirect-delete.sh
+++ b/.claude/skills/cultureflare-write/scripts/cf-redirect-delete.sh
@@ -1,0 +1,190 @@
+#!/usr/bin/env bash
+# Delete a single Single Redirect rule from a zone's
+# http_request_dynamic_redirect ruleset.
+#
+# Usage:
+#   cf-redirect-delete.sh ZONE FROM_HOST [--apply] [--json]
+#
+# Default is DRY-RUN: resolves the zone, finds the dynamic-redirect
+# ruleset, locates the one rule whose expression matches FROM_HOST,
+# refuses if the match is ambiguous, prints the DELETE URL it would
+# hit, and exits 0 WITHOUT mutating anything. Pass --apply to actually
+# DELETE.
+#
+# This deletes ONE RULE, not the whole ruleset. A zone's redirect
+# ruleset can hold many rules (e.g. www -> apex, several subdomain
+# 301s); removing one leaves the rest untouched. CF's per-rule
+# endpoint is DELETE /zones/:zone/rulesets/:ruleset/rules/:rule, which
+# returns the updated ruleset.
+#
+# ZONE is the zone whose ruleset holds the rule (e.g. culture.dev),
+# which is NOT the same as FROM_HOST when FROM_HOST is a subdomain
+# (e.g. agex.culture.dev). Both are explicit so nothing is inferred.
+#
+# Flags:
+#   --apply   actually DELETE (without it, this is a dry-run)
+#   --json    raw CloudFlare response envelope (or simulated body in dry-run)
+#
+# Exits 1 on: zone not found, no redirect ruleset on the zone, no rule
+#   matching FROM_HOST (already gone), ambiguous match (>1 rule),
+#   API error. Exits 2 on usage error.
+
+set -euo pipefail
+shopt -s inherit_errexit
+
+mode=md
+apply=0
+positional=()
+
+for arg in "$@"; do
+  case "$arg" in
+    --json)   mode=json ;;
+    --apply)  apply=1 ;;
+    -h|--help)
+      awk 'NR==1{next} /^#/{sub(/^# ?/, ""); print; next} {exit}' "$0"
+      exit 0
+      ;;
+    -*)
+      echo "ERROR: unknown flag: $arg" >&2
+      exit 2
+      ;;
+    *)
+      positional+=("$arg")
+      ;;
+  esac
+done
+
+if (( ${#positional[@]} != 2 )); then
+  echo "ERROR: expected ZONE and FROM_HOST positional args, got ${#positional[@]}" >&2
+  echo "usage: cf-redirect-delete.sh ZONE FROM_HOST [--apply] [--json]" >&2
+  exit 2
+fi
+zone_name="${positional[0]}"
+from_host="${positional[1]}"
+
+# Validate hostnames early — FROM_HOST is spliced into a jq match token
+# below, and ZONE goes into the lookup. Same shape as the sibling scripts.
+host_re='^[a-zA-Z0-9][a-zA-Z0-9.-]*$'
+for h in "$zone_name" "$from_host"; do
+  if [[ ! "$h" =~ $host_re ]]; then
+    echo "ERROR: invalid hostname: $h" >&2
+    exit 2
+  fi
+done
+
+# shellcheck source=../../cloudflare/scripts/_lib.sh
+source "$(dirname "${BASH_SOURCE[0]}")/_lib.sh"
+
+# Resolve ZONE to a zone ID.
+zones_json=$(cf_api_paginated /zones)
+# shellcheck disable=SC2016  # single-quoted jq filter
+zone_id=$(printf '%s' "$zones_json" | jq -r --arg name "$zone_name" \
+  '[.result[] | select(.name == $name) | .id] | .[0] // ""')
+
+if [[ -z "$zone_id" ]]; then
+  echo "ERROR: zone $zone_name not found in this account" >&2
+  exit 1
+fi
+
+# Find the zone-level dynamic-redirect ruleset. Same selector as
+# cf-redirect-create.sh's idempotency check.
+rulesets_json=$(cf_api_paginated "/zones/$zone_id/rulesets")
+# shellcheck disable=SC2016  # single-quoted jq filter
+ruleset_id=$(printf '%s' "$rulesets_json" | jq -r '
+  [
+    .result[]
+    | select(.phase == "http_request_dynamic_redirect")
+    | select(.kind == "zone")
+    | .id
+  ] | .[0] // ""
+')
+
+if [[ -z "$ruleset_id" ]]; then
+  echo "ERROR: no redirect ruleset (http_request_dynamic_redirect) on zone $zone_name (nothing to delete)" >&2
+  exit 1
+fi
+
+# The rulesets LIST endpoint omits the rules array; fetch the ruleset
+# DETAIL to enumerate rules. Single-object GET, so cf_api not _paginated.
+ruleset_detail=$(cf_api "/zones/$zone_id/rulesets/$ruleset_id")
+
+# Match rules whose expression contains the exact quoted host token
+# `http.host eq "FROM_HOST"`. The surrounding quotes anchor the match:
+# searching for `"agex.culture.dev"` will not hit `"notagex.culture.dev"`
+# (preceded by a non-quote) nor the www wildcard rule (which has no
+# `http.host eq "..."` clause). cf-redirect-create.sh emits exactly this
+# clause (plus an optional `or (http.host eq "www.FROM_HOST")`), so a
+# --www-created rule is matched by its apex host too.
+# shellcheck disable=SC2016  # single-quoted jq filter
+matches_json=$(printf '%s' "$ruleset_detail" | jq --arg h "$from_host" '
+  [
+    .result.rules[]
+    | select(.expression | contains("http.host eq \"" + $h + "\""))
+    | {id, expression,
+       target: (.action_parameters.from_value.target_url.expression
+                // .action_parameters.from_value.target_url // "—"),
+       status_code: (.action_parameters.from_value.status_code // "—")}
+  ]
+')
+match_count=$(printf '%s' "$matches_json" | jq 'length')
+
+if (( match_count == 0 )); then
+  echo "ERROR: no redirect rule for host '$from_host' in zone $zone_name's ruleset (nothing to delete)" >&2
+  exit 1
+fi
+if (( match_count > 1 )); then
+  echo "ERROR: ambiguous match in zone $zone_name: host '$from_host' matches $match_count rules" >&2
+  printf '%s\n' "$matches_json" | jq -r '.[] | "  - \(.id)  \(.expression)"' >&2
+  exit 1
+fi
+
+rule_id=$(printf '%s' "$matches_json" | jq -r '.[0].id')
+rule_expression=$(printf '%s' "$matches_json" | jq -r '.[0].expression')
+rule_target=$(printf '%s' "$matches_json" | jq -r '.[0].target')
+rule_status=$(printf '%s' "$matches_json" | jq -r '.[0].status_code')
+
+delete_path="/zones/$zone_id/rulesets/$ruleset_id/rules/$rule_id"
+
+render_summary_kv() {
+  printf -- '- **zone:** %s (id=%s)\n' "$zone_name" "$zone_id"
+  printf -- '- **from:** %s\n' "$from_host"
+  printf -- '- **ruleset_id:** %s\n' "$ruleset_id"
+  printf -- '- **rule_id:** %s\n' "$rule_id"
+  printf -- '- **expression:** %s\n' "$rule_expression"
+  printf -- '- **target:** %s\n' "$rule_target"
+  printf -- '- **status:** %s\n' "$rule_status"
+  return 0
+}
+
+if (( apply == 0 )); then
+  if [[ "$mode" == "json" ]]; then
+    # shellcheck disable=SC2016  # single-quoted jq filter
+    jq -n \
+      --arg zone_id "$zone_id" \
+      --arg ruleset_id "$ruleset_id" \
+      --arg rule_id "$rule_id" \
+      --arg delete_path "$delete_path" \
+      '{success: true, errors: [], messages: ["dry-run: no changes applied"],
+        result: {dry_run: true, zone_id: $zone_id, ruleset_id: $ruleset_id,
+                 rule_id: $rule_id, would_delete: $delete_path}}'
+    exit 0
+  fi
+  printf '**Dry-run — no changes applied**\n\n'
+  render_summary_kv
+  # shellcheck disable=SC2016  # literal backticks wrap markdown inline code
+  printf '\n**would DELETE** `%s`\n' "$delete_path"
+  exit 0
+fi
+
+# Apply path. CF returns the UPDATED ruleset (minus the deleted rule).
+response=$(cf_api "$delete_path" -X DELETE)
+
+if [[ "$mode" == "json" ]]; then
+  printf '%s\n' "$response"
+  exit 0
+fi
+
+remaining=$(printf '%s' "$response" | jq -r '.result.rules | length // 0' 2>/dev/null || echo '?')
+printf '**Redirect rule deleted**\n\n'
+render_summary_kv
+printf -- '- **remaining rules in ruleset:** %s\n' "$remaining"

--- a/.claude/skills/cultureflare-write/scripts/cf-redirect-delete.sh
+++ b/.claude/skills/cultureflare-write/scripts/cf-redirect-delete.sh
@@ -45,7 +45,7 @@ for arg in "$@"; do
       exit 0
       ;;
     -*)
-      echo "ERROR: unknown flag: $arg" >&2
+      printf '%s\n' "ERROR: unknown flag: $arg" >&2
       exit 2
       ;;
     *)
@@ -55,8 +55,8 @@ for arg in "$@"; do
 done
 
 if (( ${#positional[@]} != 2 )); then
-  echo "ERROR: expected ZONE and FROM_HOST positional args, got ${#positional[@]}" >&2
-  echo "usage: cf-redirect-delete.sh ZONE FROM_HOST [--apply] [--json]" >&2
+  printf '%s\n' "ERROR: expected ZONE and FROM_HOST positional args, got ${#positional[@]}" >&2
+  printf '%s\n' "usage: cf-redirect-delete.sh ZONE FROM_HOST [--apply] [--json]" >&2
   exit 2
 fi
 zone_name="${positional[0]}"
@@ -67,7 +67,7 @@ from_host="${positional[1]}"
 host_re='^[a-zA-Z0-9][a-zA-Z0-9.-]*$'
 for h in "$zone_name" "$from_host"; do
   if [[ ! "$h" =~ $host_re ]]; then
-    echo "ERROR: invalid hostname: $h" >&2
+    printf '%s\n' "ERROR: invalid hostname: $h" >&2
     exit 2
   fi
 done
@@ -82,7 +82,7 @@ zone_id=$(printf '%s' "$zones_json" | jq -r --arg name "$zone_name" \
   '[.result[] | select(.name == $name) | .id] | .[0] // ""')
 
 if [[ -z "$zone_id" ]]; then
-  echo "ERROR: zone $zone_name not found in this account" >&2
+  printf '%s\n' "ERROR: zone $zone_name not found in this account" >&2
   exit 1
 fi
 
@@ -100,7 +100,7 @@ ruleset_id=$(printf '%s' "$rulesets_json" | jq -r '
 ')
 
 if [[ -z "$ruleset_id" ]]; then
-  echo "ERROR: no redirect ruleset (http_request_dynamic_redirect) on zone $zone_name (nothing to delete)" >&2
+  printf '%s\n' "ERROR: no redirect ruleset (http_request_dynamic_redirect) on zone $zone_name (nothing to delete)" >&2
   exit 1
 fi
 
@@ -118,7 +118,7 @@ ruleset_detail=$(cf_api "/zones/$zone_id/rulesets/$ruleset_id")
 # shellcheck disable=SC2016  # single-quoted jq filter
 matches_json=$(printf '%s' "$ruleset_detail" | jq --arg h "$from_host" '
   [
-    .result.rules[]
+    (.result.rules // [])[]
     | select(.expression | contains("http.host eq \"" + $h + "\""))
     | {id, expression,
        target: (.action_parameters.from_value.target_url.expression
@@ -129,11 +129,11 @@ matches_json=$(printf '%s' "$ruleset_detail" | jq --arg h "$from_host" '
 match_count=$(printf '%s' "$matches_json" | jq 'length')
 
 if (( match_count == 0 )); then
-  echo "ERROR: no redirect rule for host '$from_host' in zone $zone_name's ruleset (nothing to delete)" >&2
+  printf '%s\n' "ERROR: no redirect rule for host '$from_host' in zone $zone_name's ruleset (nothing to delete)" >&2
   exit 1
 fi
 if (( match_count > 1 )); then
-  echo "ERROR: ambiguous match in zone $zone_name: host '$from_host' matches $match_count rules" >&2
+  printf '%s\n' "ERROR: ambiguous match in zone $zone_name: host '$from_host' matches $match_count rules" >&2
   printf '%s\n' "$matches_json" | jq -r '.[] | "  - \(.id)  \(.expression)"' >&2
   exit 1
 fi
@@ -184,7 +184,7 @@ if [[ "$mode" == "json" ]]; then
   exit 0
 fi
 
-remaining=$(printf '%s' "$response" | jq -r '.result.rules | length // 0' 2>/dev/null || echo '?')
+remaining=$(printf '%s' "$response" | jq -r '.result.rules | length // 0' 2>/dev/null || printf '%s' '?')
 printf '**Redirect rule deleted**\n\n'
 render_summary_kv
 printf -- '- **remaining rules in ruleset:** %s\n' "$remaining"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented here. The format
 is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.0] - 2026-05-26
+
+### Added
+
+- cf-dns-delete.sh — delete a DNS record by name (dry-run by default, --apply to commit; refuses ambiguous matches; --type/--content narrowing).
+- cf-redirect-delete.sh — delete a single Single Redirect rule from a zone's http_request_dynamic_redirect ruleset by matching FROM_HOST, preserving the other rules in the ruleset.
+- Tests + fixtures for both new delete primitives, and a cf-api-gotchas entry documenting that the rulesets list omits the rules array (detail GET required).
+
+### Changed
+
+- cultureflare-write SKILL.md: documented the two delete scripts and removed DNS deletion from the "does NOT do yet" list.
+
 ## [0.8.0] - 2026-05-15
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - cultureflare-write SKILL.md: documented the two delete scripts and removed DNS deletion from the "does NOT do yet" list.
 
+### Fixed
+
+- cf-redirect-delete.sh: guard the rule enumeration against a null/missing `rules` array (`(.result.rules // [])[]`) so a malformed ruleset-detail response yields the controlled "nothing to delete" exit 1 instead of a `jq` "Cannot iterate over null" crash under `set -e`.
+- cf-dns-delete.sh / cf-redirect-delete.sh: use `printf` instead of `echo` for all variable-bearing error/usage output (PR compliance 631479 — portable across shells).
+
 ## [0.8.0] - 2026-05-15
 
 ### Added

--- a/cultureflare/__init__.py
+++ b/cultureflare/__init__.py
@@ -8,7 +8,7 @@ from importlib.metadata import PackageNotFoundError, version as _pkg_version
 # version is rewritten to "0.3.0.devN" by the publish workflow) report
 # their actual version here. The legacy `cfafi` wheel (frozen at 0.2.2)
 # is the second-tier fallback for anyone still on the old install.
-__version__ = "0.8.0"
+__version__ = "0.9.0"
 
 try:
     __version__ = _pkg_version("cultureflare")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cultureflare"
-version = "0.8.0"
+version = "0.9.0"
 description = "CloudFlare Agent First Interface — agent-first CLI for CloudFlare management in the AgentCulture org."
 readme = "README.md"
 license = "MIT"

--- a/tests/bats/cf-dns-delete.bats
+++ b/tests/bats/cf-dns-delete.bats
@@ -1,0 +1,137 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+setup() {
+  cf_bats_setup
+  WRITE_SCRIPTS="$SKILL_DIR/../cfafi-write/scripts"
+}
+
+# Helper — asserts curl was NEVER invoked with `-X DELETE`.
+_assert_no_delete() {
+  if grep -qF -- '-X	DELETE' "$BATS_TEST_TMPDIR/curl.log" 2>/dev/null; then
+    echo "expected no DELETE, but curl.log contains one:" >&2
+    cat "$BATS_TEST_TMPDIR/curl.log" >&2
+    return 1
+  fi
+  return 0
+}
+
+# --- usage errors ---
+
+@test "cf-dns-delete exits 2 when positional args missing" {
+  run bash "$WRITE_SCRIPTS/cf-dns-delete.sh" culture.dev
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"expected ZONE and NAME"* ]]
+}
+
+@test "cf-dns-delete exits 2 on unknown flag" {
+  run bash "$WRITE_SCRIPTS/cf-dns-delete.sh" culture.dev agex.culture.dev --bogus
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"unknown flag"* ]]
+}
+
+@test "cf-dns-delete exits 2 on invalid hostname" {
+  run bash "$WRITE_SCRIPTS/cf-dns-delete.sh" culture.dev 'bad name!'
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"invalid hostname"* ]]
+}
+
+@test "cf-dns-delete exits 2 on unsupported --type" {
+  run bash "$WRITE_SCRIPTS/cf-dns-delete.sh" culture.dev agex.culture.dev --type=BOGUS
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"unsupported record type"* ]]
+}
+
+# --- resolution errors ---
+
+@test "cf-dns-delete exits 1 when the zone is not in the account" {
+  cf_mock "/zones?per_page" "zones_with_agentculture.json"
+  run bash "$WRITE_SCRIPTS/cf-dns-delete.sh" nosuch.dev agex.nosuch.dev --apply
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"zone nosuch.dev not found"* ]]
+  _assert_no_delete
+}
+
+@test "cf-dns-delete exits 1 when no record matches (nothing to delete)" {
+  cf_mock "/zones?per_page"   "zones_with_agentculture.json"
+  cf_mock "/dns_records?"     "dns_records_empty.json"
+  run bash "$WRITE_SCRIPTS/cf-dns-delete.sh" culture.dev agex.culture.dev --apply
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"no DNS record matching"* ]]
+  [[ "$output" == *"nothing to delete"* ]]
+  _assert_no_delete
+}
+
+@test "cf-dns-delete exits 1 on an ambiguous match and lists candidates" {
+  cf_mock "/zones?per_page"   "zones_with_agentculture.json"
+  cf_mock "/dns_records?"     "dns_records.json"
+  run bash "$WRITE_SCRIPTS/cf-dns-delete.sh" culture.dev culture.dev
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"ambiguous match"* ]]
+  [[ "$output" == *"narrow with --type"* ]]
+  _assert_no_delete
+}
+
+# --- dry-run (default, no --apply) ---
+
+@test "cf-dns-delete dry-run prints banner, resolved record, and would-DELETE path" {
+  cf_mock "/zones?per_page"   "zones_with_agentculture.json"
+  cf_mock "/dns_records?"     "dns_records_agex_cname.json"
+  run bash "$WRITE_SCRIPTS/cf-dns-delete.sh" culture.dev agex.culture.dev
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"**Dry-run — no changes applied**"* ]]
+  [[ "$output" == *"zone-id-culture-dev-bbbbbbbbbbbbbbbbbbbb"* ]]
+  [[ "$output" == *"**type:** CNAME"* ]]
+  [[ "$output" == *"dns-rec-agex-cname-000000000000000a"* ]]
+  [[ "$output" == *"**would DELETE**"* ]]
+  [[ "$output" == *"/dns_records/dns-rec-agex-cname-000000000000000a"* ]]
+  _assert_no_delete
+}
+
+@test "cf-dns-delete --json dry-run emits a synthetic envelope" {
+  cf_mock "/zones?per_page"   "zones_with_agentculture.json"
+  cf_mock "/dns_records?"     "dns_records_agex_cname.json"
+  run bash "$WRITE_SCRIPTS/cf-dns-delete.sh" culture.dev agex.culture.dev --json
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.success == true'
+  echo "$output" | jq -e '.result.dry_run == true'
+  echo "$output" | jq -e '.result.record_id == "dns-rec-agex-cname-000000000000000a"'
+  echo "$output" | jq -e '.result.would_delete | endswith("/dns_records/dns-rec-agex-cname-000000000000000a")'
+  [[ "$output" != *"Dry-run — no changes applied"* ]]
+  _assert_no_delete
+}
+
+# --- apply path ---
+
+@test "cf-dns-delete --apply DELETEs the resolved record id" {
+  cf_mock "/zones?per_page" "zones_with_agentculture.json"
+  cf_mock "/dns_records?"   "dns_records_agex_cname.json"
+  cf_mock "/dns_records/dns-rec-agex-cname-000000000000000a" "dns_record_delete_ok.json"
+  run bash "$WRITE_SCRIPTS/cf-dns-delete.sh" culture.dev agex.culture.dev --apply
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"**DNS record deleted**"* ]]
+  cf_assert_called "-X	DELETE"
+  cf_assert_called "/zones/zone-id-culture-dev-bbbbbbbbbbbbbbbbbbbb/dns_records/dns-rec-agex-cname-000000000000000a"
+}
+
+@test "cf-dns-delete --apply --json passes the CF response envelope through" {
+  cf_mock "/zones?per_page" "zones_with_agentculture.json"
+  cf_mock "/dns_records?"   "dns_records_agex_cname.json"
+  cf_mock "/dns_records/dns-rec-agex-cname-000000000000000a" "dns_record_delete_ok.json"
+  run bash "$WRITE_SCRIPTS/cf-dns-delete.sh" culture.dev agex.culture.dev --apply --json
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.success == true'
+  echo "$output" | jq -e '.result.id == "dns-rec-agex-cname-000000000000000a"'
+  [[ "$output" != *"DNS record deleted"* ]]
+}
+
+# --- name resolution uses pagination ---
+
+@test "cf-dns-delete resolves the zone via paginated /zones" {
+  cf_mock "/zones?per_page" "zones_with_agentculture.json"
+  cf_mock "/dns_records?"   "dns_records_agex_cname.json"
+  run bash "$WRITE_SCRIPTS/cf-dns-delete.sh" culture.dev agex.culture.dev
+  [ "$status" -eq 0 ]
+  cf_assert_called "/zones?per_page=50&page=1"
+}

--- a/tests/bats/cf-redirect-delete.bats
+++ b/tests/bats/cf-redirect-delete.bats
@@ -69,6 +69,18 @@ _assert_no_delete() {
   _assert_no_delete
 }
 
+@test "cf-redirect-delete exits 1 cleanly when the ruleset detail has no rules array (null guard)" {
+  cf_mock "/zones?per_page"    "zones_with_agentculture.json"
+  cf_mock "/rulesets?per_page" "rulesets_culture_dev.json"
+  cf_mock "/rulesets/redirect-ruleset-id-culturedev-0001" "ruleset_detail_no_rules.json"
+  run bash "$WRITE_SCRIPTS/cf-redirect-delete.sh" culture.dev agex.culture.dev --apply
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"no redirect rule for host 'agex.culture.dev'"* ]]
+  # The null guard must produce the controlled message, not a jq crash.
+  [[ "$output" != *"Cannot iterate over null"* ]]
+  _assert_no_delete
+}
+
 @test "cf-redirect-delete exits 1 on an ambiguous match and lists candidates" {
   cf_mock "/zones?per_page"    "zones_with_agentculture.json"
   cf_mock "/rulesets?per_page" "rulesets_culture_dev.json"

--- a/tests/bats/cf-redirect-delete.bats
+++ b/tests/bats/cf-redirect-delete.bats
@@ -1,0 +1,155 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+setup() {
+  cf_bats_setup
+  WRITE_SCRIPTS="$SKILL_DIR/../cfafi-write/scripts"
+  # The ruleset-detail GET (/rulesets/<id>) and the per-rule DELETE
+  # (/rulesets/<id>/rules/<rid>) share the /rulesets/<id> prefix; the
+  # stub's longest-substring-wins policy routes the DELETE to its own
+  # fixture as long as the rule-path mock is registered.
+}
+
+_assert_no_delete() {
+  if grep -qF -- '-X	DELETE' "$BATS_TEST_TMPDIR/curl.log" 2>/dev/null; then
+    echo "expected no DELETE, but curl.log contains one:" >&2
+    cat "$BATS_TEST_TMPDIR/curl.log" >&2
+    return 1
+  fi
+  return 0
+}
+
+# --- usage errors ---
+
+@test "cf-redirect-delete exits 2 when positional args missing" {
+  run bash "$WRITE_SCRIPTS/cf-redirect-delete.sh" culture.dev
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"expected ZONE and FROM_HOST"* ]]
+}
+
+@test "cf-redirect-delete exits 2 on unknown flag" {
+  run bash "$WRITE_SCRIPTS/cf-redirect-delete.sh" culture.dev agex.culture.dev --bogus
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"unknown flag"* ]]
+}
+
+@test "cf-redirect-delete exits 2 on invalid hostname" {
+  run bash "$WRITE_SCRIPTS/cf-redirect-delete.sh" culture.dev 'has"quote'
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"invalid hostname"* ]]
+}
+
+# --- resolution errors ---
+
+@test "cf-redirect-delete exits 1 when the zone is not in the account" {
+  cf_mock "/zones?per_page" "zones_with_agentculture.json"
+  run bash "$WRITE_SCRIPTS/cf-redirect-delete.sh" nosuch.dev agex.nosuch.dev --apply
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"zone nosuch.dev not found"* ]]
+  _assert_no_delete
+}
+
+@test "cf-redirect-delete exits 1 when the zone has no redirect ruleset" {
+  cf_mock "/zones?per_page"    "zones_with_agentculture.json"
+  cf_mock "/rulesets?per_page" "rulesets_empty.json"
+  run bash "$WRITE_SCRIPTS/cf-redirect-delete.sh" culture.dev agex.culture.dev --apply
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"no redirect ruleset"* ]]
+  _assert_no_delete
+}
+
+@test "cf-redirect-delete exits 1 when no rule matches the host (nothing to delete)" {
+  cf_mock "/zones?per_page"    "zones_with_agentculture.json"
+  cf_mock "/rulesets?per_page" "rulesets_culture_dev.json"
+  cf_mock "/rulesets/redirect-ruleset-id-culturedev-0001" "ruleset_detail_culture_dev.json"
+  run bash "$WRITE_SCRIPTS/cf-redirect-delete.sh" culture.dev nope.culture.dev --apply
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"no redirect rule for host 'nope.culture.dev'"* ]]
+  _assert_no_delete
+}
+
+@test "cf-redirect-delete exits 1 on an ambiguous match and lists candidates" {
+  cf_mock "/zones?per_page"    "zones_with_agentculture.json"
+  cf_mock "/rulesets?per_page" "rulesets_culture_dev.json"
+  cf_mock "/rulesets/redirect-ruleset-id-culturedev-0001" "ruleset_detail_dup_agex.json"
+  run bash "$WRITE_SCRIPTS/cf-redirect-delete.sh" culture.dev agex.culture.dev
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"ambiguous match"* ]]
+  [[ "$output" == *"rule-agex-dup-a"* ]]
+  [[ "$output" == *"rule-agex-dup-b"* ]]
+  _assert_no_delete
+}
+
+# --- dry-run (default, no --apply) ---
+
+@test "cf-redirect-delete dry-run prints the matched rule and would-DELETE path" {
+  cf_mock "/zones?per_page"    "zones_with_agentculture.json"
+  cf_mock "/rulesets?per_page" "rulesets_culture_dev.json"
+  cf_mock "/rulesets/redirect-ruleset-id-culturedev-0001" "ruleset_detail_culture_dev.json"
+  run bash "$WRITE_SCRIPTS/cf-redirect-delete.sh" culture.dev agex.culture.dev
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"**Dry-run — no changes applied**"* ]]
+  [[ "$output" == *"rule-agex-0001"* ]]
+  [[ "$output" == *'(http.host eq "agex.culture.dev")'* ]]
+  [[ "$output" == *"culture.dev/agex"* ]]
+  [[ "$output" == *"**status:** 301"* ]]
+  [[ "$output" == *"**would DELETE**"* ]]
+  [[ "$output" == *"/rulesets/redirect-ruleset-id-culturedev-0001/rules/rule-agex-0001"* ]]
+  _assert_no_delete
+}
+
+@test "cf-redirect-delete --json dry-run emits a synthetic envelope" {
+  cf_mock "/zones?per_page"    "zones_with_agentculture.json"
+  cf_mock "/rulesets?per_page" "rulesets_culture_dev.json"
+  cf_mock "/rulesets/redirect-ruleset-id-culturedev-0001" "ruleset_detail_culture_dev.json"
+  run bash "$WRITE_SCRIPTS/cf-redirect-delete.sh" culture.dev agex.culture.dev --json
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.success == true'
+  echo "$output" | jq -e '.result.dry_run == true'
+  echo "$output" | jq -e '.result.rule_id == "rule-agex-0001"'
+  echo "$output" | jq -e '.result.ruleset_id == "redirect-ruleset-id-culturedev-0001"'
+  echo "$output" | jq -e '.result.would_delete | endswith("/rulesets/redirect-ruleset-id-culturedev-0001/rules/rule-agex-0001")'
+  _assert_no_delete
+}
+
+# --- apply path ---
+
+@test "cf-redirect-delete --apply DELETEs only the matched rule and preserves the others" {
+  cf_mock "/zones?per_page"    "zones_with_agentculture.json"
+  cf_mock "/rulesets?per_page" "rulesets_culture_dev.json"
+  cf_mock "/rulesets/redirect-ruleset-id-culturedev-0001" "ruleset_detail_culture_dev.json"
+  cf_mock "/rulesets/redirect-ruleset-id-culturedev-0001/rules/rule-agex-0001" "ruleset_rule_delete_ok.json"
+  run bash "$WRITE_SCRIPTS/cf-redirect-delete.sh" culture.dev agex.culture.dev --apply
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"**Redirect rule deleted**"* ]]
+  [[ "$output" == *"**remaining rules in ruleset:** 2"* ]]
+  cf_assert_called "-X	DELETE"
+  cf_assert_called "/rulesets/redirect-ruleset-id-culturedev-0001/rules/rule-agex-0001"
+  # Preservation: the other two rules must never appear in a request path.
+  ! grep -qF -- "/rules/rule-www-0002" "$BATS_TEST_TMPDIR/curl.log"
+  ! grep -qF -- "/rules/rule-citation-0003" "$BATS_TEST_TMPDIR/curl.log"
+}
+
+@test "cf-redirect-delete --apply --json passes the CF response envelope through" {
+  cf_mock "/zones?per_page"    "zones_with_agentculture.json"
+  cf_mock "/rulesets?per_page" "rulesets_culture_dev.json"
+  cf_mock "/rulesets/redirect-ruleset-id-culturedev-0001" "ruleset_detail_culture_dev.json"
+  cf_mock "/rulesets/redirect-ruleset-id-culturedev-0001/rules/rule-agex-0001" "ruleset_rule_delete_ok.json"
+  run bash "$WRITE_SCRIPTS/cf-redirect-delete.sh" culture.dev agex.culture.dev --apply --json
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.success == true'
+  echo "$output" | jq -e '.result.rules | length == 2'
+  [[ "$output" != *"Redirect rule deleted"* ]]
+}
+
+# --- zone lookup uses pagination ---
+
+@test "cf-redirect-delete resolves the zone via paginated /zones" {
+  cf_mock "/zones?per_page"    "zones_with_agentculture.json"
+  cf_mock "/rulesets?per_page" "rulesets_culture_dev.json"
+  cf_mock "/rulesets/redirect-ruleset-id-culturedev-0001" "ruleset_detail_culture_dev.json"
+  run bash "$WRITE_SCRIPTS/cf-redirect-delete.sh" culture.dev agex.culture.dev
+  [ "$status" -eq 0 ]
+  cf_assert_called "/zones?per_page=50&page=1"
+}

--- a/tests/fixtures/dns_record_delete_ok.json
+++ b/tests/fixtures/dns_record_delete_ok.json
@@ -1,0 +1,8 @@
+{
+  "success": true,
+  "errors": [],
+  "messages": [],
+  "result": {
+    "id": "dns-rec-agex-cname-000000000000000a"
+  }
+}

--- a/tests/fixtures/dns_records_agex_cname.json
+++ b/tests/fixtures/dns_records_agex_cname.json
@@ -1,0 +1,19 @@
+{
+  "success": true,
+  "errors": [],
+  "messages": [],
+  "result": [
+    {
+      "id": "dns-rec-agex-cname-000000000000000a",
+      "type": "CNAME",
+      "name": "agex.culture.dev",
+      "content": "culture.dev",
+      "proxiable": true,
+      "proxied": true,
+      "ttl": 1,
+      "created_on": "2026-04-20T23:16:41.540273Z",
+      "modified_on": "2026-04-20T23:16:41.540273Z"
+    }
+  ],
+  "result_info": {"page": 1, "per_page": 100, "total_pages": 1, "count": 1, "total_count": 1}
+}

--- a/tests/fixtures/ruleset_detail_culture_dev.json
+++ b/tests/fixtures/ruleset_detail_culture_dev.json
@@ -1,0 +1,62 @@
+{
+  "success": true,
+  "errors": [],
+  "messages": [],
+  "result": {
+    "id": "redirect-ruleset-id-culturedev-0001",
+    "name": "default",
+    "description": "",
+    "kind": "zone",
+    "phase": "http_request_dynamic_redirect",
+    "source": "firewall_custom",
+    "version": "3",
+    "last_updated": "2026-04-20T23:27:07.254911Z",
+    "rules": [
+      {
+        "id": "rule-agex-0001",
+        "version": "1",
+        "action": "redirect",
+        "description": "agex.culture.dev 301",
+        "expression": "(http.host eq \"agex.culture.dev\")",
+        "enabled": true,
+        "action_parameters": {
+          "from_value": {
+            "target_url": {"expression": "concat(\"https://culture.dev/agex\", http.request.uri.path)"},
+            "status_code": 301,
+            "preserve_query_string": true
+          }
+        }
+      },
+      {
+        "id": "rule-www-0002",
+        "version": "1",
+        "action": "redirect",
+        "description": "www.culture.dev -> apex",
+        "expression": "(http.request.full_uri wildcard r\"https://www.culture.dev/*\")",
+        "enabled": true,
+        "action_parameters": {
+          "from_value": {
+            "target_url": {"expression": "wildcard_replace(http.request.full_uri, r\"https://www.culture.dev/*\", r\"https://culture.dev/${1}\")"},
+            "status_code": 301,
+            "preserve_query_string": true
+          }
+        }
+      },
+      {
+        "id": "rule-citation-0003",
+        "version": "1",
+        "action": "redirect",
+        "description": "citation-cli.culture.dev 301",
+        "expression": "(http.host eq \"citation-cli.culture.dev\")",
+        "enabled": true,
+        "action_parameters": {
+          "from_value": {
+            "target_url": {"expression": "concat(\"https://culture.dev/citation-cli\", http.request.uri.path)"},
+            "status_code": 301,
+            "preserve_query_string": true
+          }
+        }
+      }
+    ]
+  }
+}

--- a/tests/fixtures/ruleset_detail_dup_agex.json
+++ b/tests/fixtures/ruleset_detail_dup_agex.json
@@ -1,0 +1,35 @@
+{
+  "success": true,
+  "errors": [],
+  "messages": [],
+  "result": {
+    "id": "redirect-ruleset-id-culturedev-0001",
+    "name": "default",
+    "kind": "zone",
+    "phase": "http_request_dynamic_redirect",
+    "rules": [
+      {
+        "id": "rule-agex-dup-a",
+        "action": "redirect",
+        "expression": "(http.host eq \"agex.culture.dev\")",
+        "action_parameters": {
+          "from_value": {
+            "target_url": {"expression": "concat(\"https://culture.dev/agex\", http.request.uri.path)"},
+            "status_code": 301
+          }
+        }
+      },
+      {
+        "id": "rule-agex-dup-b",
+        "action": "redirect",
+        "expression": "(http.host eq \"agex.culture.dev\") or (http.host eq \"www.agex.culture.dev\")",
+        "action_parameters": {
+          "from_value": {
+            "target_url": {"expression": "concat(\"https://culture.dev/agex\", http.request.uri.path)"},
+            "status_code": 302
+          }
+        }
+      }
+    ]
+  }
+}

--- a/tests/fixtures/ruleset_detail_no_rules.json
+++ b/tests/fixtures/ruleset_detail_no_rules.json
@@ -1,0 +1,11 @@
+{
+  "success": true,
+  "errors": [],
+  "messages": [],
+  "result": {
+    "id": "redirect-ruleset-id-culturedev-0001",
+    "name": "default",
+    "kind": "zone",
+    "phase": "http_request_dynamic_redirect"
+  }
+}

--- a/tests/fixtures/ruleset_rule_delete_ok.json
+++ b/tests/fixtures/ruleset_rule_delete_ok.json
@@ -1,0 +1,47 @@
+{
+  "success": true,
+  "errors": [],
+  "messages": [],
+  "result": {
+    "id": "redirect-ruleset-id-culturedev-0001",
+    "name": "default",
+    "description": "",
+    "kind": "zone",
+    "phase": "http_request_dynamic_redirect",
+    "source": "firewall_custom",
+    "version": "4",
+    "last_updated": "2026-05-26T00:00:00.000000Z",
+    "rules": [
+      {
+        "id": "rule-www-0002",
+        "version": "1",
+        "action": "redirect",
+        "description": "www.culture.dev -> apex",
+        "expression": "(http.request.full_uri wildcard r\"https://www.culture.dev/*\")",
+        "enabled": true,
+        "action_parameters": {
+          "from_value": {
+            "target_url": {"expression": "wildcard_replace(http.request.full_uri, r\"https://www.culture.dev/*\", r\"https://culture.dev/${1}\")"},
+            "status_code": 301,
+            "preserve_query_string": true
+          }
+        }
+      },
+      {
+        "id": "rule-citation-0003",
+        "version": "1",
+        "action": "redirect",
+        "description": "citation-cli.culture.dev 301",
+        "expression": "(http.host eq \"citation-cli.culture.dev\")",
+        "enabled": true,
+        "action_parameters": {
+          "from_value": {
+            "target_url": {"expression": "concat(\"https://culture.dev/citation-cli\", http.request.uri.path)"},
+            "status_code": 301,
+            "preserve_query_string": true
+          }
+        }
+      }
+    ]
+  }
+}

--- a/tests/fixtures/rulesets_culture_dev.json
+++ b/tests/fixtures/rulesets_culture_dev.json
@@ -1,0 +1,18 @@
+{
+  "success": true,
+  "errors": [],
+  "messages": [],
+  "result": [
+    {
+      "id": "redirect-ruleset-id-culturedev-0001",
+      "name": "default",
+      "description": "",
+      "kind": "zone",
+      "phase": "http_request_dynamic_redirect",
+      "source": "firewall_custom",
+      "version": "3",
+      "last_updated": "2026-04-20T23:27:07.254911Z"
+    }
+  ],
+  "result_info": {"page": 1, "per_page": 20, "total_pages": 1, "count": 1, "total_count": 1}
+}


### PR DESCRIPTION
## What

Closes #40 — adds the two delete primitives needed to remove the
`agex.culture.dev` subdomain (DNS record + 301 redirect rule). The live
teardown runs **after merge** (see below), per the issue's
"confirm-before-merging" tradeoff (full removal is the site owner's
preference).

### New scripts (`.claude/skills/cultureflare-write/scripts/`)

- **`cf-dns-delete.sh ZONE NAME [--type=TYPE] [--content=VALUE] [--apply] [--json]`**
  — resolves a DNS record by name and DELETEs it. Dry-run by default;
  refuses ambiguous matches (lists candidates, asks for
  `--type`/`--content`).
- **`cf-redirect-delete.sh ZONE FROM_HOST [--apply] [--json]`** — deletes
  a **single** Single Redirect rule from a zone's
  `http_request_dynamic_redirect` ruleset, matched on the anchored token
  `http.host eq "FROM_HOST"`. **Preserves the other rules** in the
  ruleset — it uses `DELETE …/rulesets/:id/rules/:rid`, never the
  whole-ruleset endpoint.

Both follow the established `cf-redirect-create.sh` safety model:
dry-run by default, `--apply` to commit, `--json` passthrough, name→ID
resolution, exit codes `0`/`1`/`2`. No token-scope upgrade — DELETE
reuses the same `DNS · Edit` / `Single Redirect · Edit` scopes as the
create scripts.

### Tests & docs

- `tests/bats/cf-dns-delete.bats` + `tests/bats/cf-redirect-delete.bats`
  (24 tests): dry-run, apply, `--json`, idempotency (nothing-to-delete),
  ambiguous-match refusal, name resolution, and a **preservation
  assertion** that the `www` and `citation-cli` rules never appear in a
  DELETE path.
- 6 new fixtures.
- `cultureflare-write/SKILL.md`: flag-reference blocks + scripts-table
  rows; §5 "does NOT do yet" updated.
- `cf-api-gotchas.md` §7: the rulesets list omits the `rules` array (a
  detail GET is required to enumerate them).
- Version `0.8.0` → `0.9.0`.

### Live dry-run (against real CF, read-only) resolves exactly the #40 targets

- `cf-dns-delete` → record `ead2eb5cc1986a995f7881135025fd40`
  (CNAME `agex.culture.dev`)
- `cf-redirect-delete` → rule `8b13fc41f8cd45dab520e0f0da859d7a` in
  ruleset `3f66f64b547048ab9d2445aec5291140`

## Teardown (after merge)

Live `--apply` runs from merged `main`, DNS first so the host stops
resolving before the orphaned rule is removed:

```sh
bash .claude/skills/cultureflare-write/scripts/cf-dns-delete.sh      culture.dev agex.culture.dev --apply
bash .claude/skills/cultureflare-write/scripts/cf-redirect-delete.sh culture.dev agex.culture.dev --apply
```

Then verify the issue's acceptance criteria: `agex.culture.dev` →
NXDOMAIN, `https://culture.dev/agex/` still `200`, and the
`www.culture.dev` / `citation-cli.culture.dev` redirects intact.

## Local gates

shellcheck ✓ · markdownlint ✓ · bats 255/255 ✓ · doctest-align ✓

- cultureflare (Claude)
