### PR TITLE
feat(skills): vendor devague workflow trio — think / spec-to-plan / assign-to-workforce (#39)

### DIFF
--- a/.claude/skills/assign-to-workforce/SKILL.md
+++ b/.claude/skills/assign-to-workforce/SKILL.md
@@ -1,0 +1,242 @@
+---
+name: assign-to-workforce
+type: command
+description: >
+  Fan out a converged devague plan's dependency waves to parallel agents in
+  isolated git worktrees, one agent per task per wave, with TDD-gated merges
+  by the main agent. Human gates: the exported spec, the implementation split
+  plan (task map + per-task agent/model proposal + go/no-go), and the final PR.
+  The devague CLI stays deterministic and non-orchestrating (#20) — it only
+  *describes* the graph via `devague plan waves`; the operator (main agent)
+  performs the fan-out. Use when the user says "assign to workforce",
+  "fan out the plan", "parallel subagents", or after /spec-to-plan exports a
+  plan. Authored and maintained in agentculture/devague (origin = devague);
+  steward pulls this skill from here and broadcasts it to the AgentCulture
+  mesh — it is NOT vendored from steward like the other skills here.
+---
+
+# assign-to-workforce — fan out a converged plan's waves to parallel agents
+
+The skill is named **`assign-to-workforce`**; the product/CLI it reads is the
+**`devague plan waves`** command. (The prior leg — turning a spec into a plan —
+is the sibling **`/spec-to-plan`** skill.)
+
+`assign-to-workforce` takes a **converged devague plan** and fans out its
+dependency waves to parallel agents (subagents, teammate agents, or generalist
+agents) — one agent per task per wave — each working in an **isolated git
+worktree**. The main agent merges each completed worktree gated by TDD. The
+human owns exactly three gates: the exported spec, the implementation split
+plan, and the final PR.
+
+The devague CLI is **never orchestrated by devague itself** — `devague plan
+waves` describes the dependency graph (#20); it does not spawn agents, manage
+worktrees, mark tasks done, or pick a backend. The fan-out is the *operator's*
+job — this skill and the main agent perform it.
+
+## How to run
+
+The entry point is `scripts/assign-to-workforce.sh`. Invoke it from the
+repository whose plan you are implementing (plans persist under `.devague/`
+in the current directory):
+
+```bash
+bash .claude/skills/assign-to-workforce/scripts/assign-to-workforce.sh split-plan [--plan <slug>]
+bash .claude/skills/assign-to-workforce/scripts/assign-to-workforce.sh waves    [--plan <slug>] [--json]
+bash .claude/skills/assign-to-workforce/scripts/assign-to-workforce.sh help
+```
+
+It resolves the CLI portably — an installed `devague` on `PATH` (the normal
+case), falling back to `uv run devague` when you are inside the devague
+checkout, else an install hint. The `split-plan` subcommand reads
+`devague plan waves --json` and renders the human-facing implementation split
+plan: task map, proposed per-task agent + model assignment, and the go/no-go
+question. The `waves` subcommand forwards to `devague plan waves` verbatim.
+
+### Usage
+
+| Subcommand | What it does |
+|------------|--------------|
+| `split-plan [--plan S]` | Read `devague plan waves` and print the implementation split plan — task map with per-task agent + model proposal — ready for human go/no-go review. |
+| `waves [--plan S] [--json]` | Forward to `devague plan waves [--json]`. Read-only; lists wave batches. On a converged plan exits 0 listing the waves. |
+| `help` | Print usage. |
+
+## The full flow
+
+The flow has three human gates and one automated TDD merge loop.
+
+### Human gate 1 — the exported spec
+
+The plan is seeded from a converged frame (`devague plan new --frame <slug>`).
+The human reviewed and approved the spec when it was exported by the `/think`
+skill. No re-approval needed here — the spec gate is already closed.
+
+### Human gate 2 — the implementation split plan
+
+Before any task is assigned, the main agent presents the **implementation split
+plan** for human go/no-go. This is the only gate the human owns at the
+implementation stage (per task, the TDD gate is the main agent's).
+
+The split plan contains:
+
+1. **Task map** — every task id, its one-line summary, acceptance criteria, and
+   the wave it belongs to (from `devague plan waves`).
+2. **Per-task agent + model proposal** — for each task: the proposed agent type
+   (subagent / teammate / generalist), the proposed model (e.g. a cheaper/faster
+   model for a well-scoped task), and the scope justification (why this task is
+   safe to delegate).
+3. **Go/no-go question** — explicit human decision: "Approve this split and
+   assign the plan to the workforce, or edit it first?"
+
+The human may edit any row (agent type, model, scope) before approving. The
+plan is model-agnostic — devague does not pick a backend (#20).
+
+Run `split-plan` to print the proposed table:
+
+```bash
+bash .claude/skills/assign-to-workforce/scripts/assign-to-workforce.sh split-plan
+```
+
+Do not proceed to fan-out until the human approves the split plan.
+
+### Fan-out — one agent per task per wave in isolated worktrees
+
+Once the human approves, the main agent fans out each wave in order:
+
+1. **Create an isolated git worktree** for each task in the current wave:
+
+   ```bash
+   git worktree add ../worktrees/agent-<task-id> -b agent/<task-id>
+   ```
+
+2. **Spawn a task agent** inside that worktree (using the approved model from
+   the split plan), with:
+   - The task id, summary, and acceptance criteria as its brief.
+   - Instruction to work **test-first** (TDD): write the failing test(s) that
+     match the acceptance criteria before implementing.
+   - Instruction to commit its work to the worktree branch.
+
+3. **Same-wave tasks run in parallel** (within-wave tasks have no
+   inter-task dependency; the dependency graph guarantees this). Same-file
+   overlap surfaces as a merge conflict at reconcile time, not a live race —
+   isolated worktrees prevent clobbering.
+
+4. **Wait for all tasks in the wave to complete** before starting the next wave.
+
+### TDD-gated merge — main agent, no human per task
+
+For each completed task worktree, the main agent:
+
+1. **Runs the task's tests before merge** (on the main branch): baseline must
+   pass (or the relevant tests must be absent — the task adds them).
+2. **Merges the worktree branch** into the main branch:
+
+   ```bash
+   git merge --no-ff agent/<task-id>
+   ```
+
+3. **Runs the task's tests after merge**: they must pass. If they do not, the
+   merge is reverted and the task agent is given the failure output to fix.
+4. **Removes the worktree** once the merge is accepted:
+
+   ```bash
+   git worktree remove ../worktrees/agent-<task-id>
+   ```
+
+The human does **not** review individual task merges. Per-task acceptance is
+the main agent's responsibility — the TDD gate (tests pass before AND after
+merge) plus the task's acceptance criteria. This mirrors the non-authoritative
+working state pattern of the Human Review Loop (#17): per-task merge records
+are uncommitted working state; the authoritative human gate is the final PR.
+
+Advance to the next wave only after all tasks in the current wave are merged
+and their tests pass.
+
+### Human gate 3 — the final PR
+
+Once all waves are merged and the full test suite passes, the main agent opens
+a PR via the `cicd` skill (`devex pr open`). The human reviews and merges. This
+is the last and only remaining human gate.
+
+## Hard rules (do not violate)
+
+These protect the human-gate contract and the TDD guarantee.
+
+- **Present the split plan before any fan-out.** Never spawn a task agent
+  without prior human approval of the implementation split plan (gate 2). The
+  split plan is the human's only implementation-stage decision.
+- **One worktree per task.** Never run two tasks in the same worktree — file
+  contention is managed by isolation, not by trust in the dependency graph.
+  The dependency graph guarantees *logical* independence within a wave, not
+  *file* disjointness. Conflicts surface at merge time.
+- **Tests before AND after merge — no exceptions.** The TDD gate must pass on
+  both sides. A merge that makes tests pass only after (not before) means the
+  baseline was already broken — fix the baseline first.
+- **Human does not gate per-task merges.** The TDD contract replaces the
+  human here. Do not pause for human approval between wave tasks.
+- **devague CLI is not orchestrated.** `devague plan waves` is read-only
+  scheduling metadata (#20). Never run `devague plan` commands inside a task
+  worktree to "mark a task done" or modify plan state from a subagent.
+- **Three gates only.** The human's gates are: (1) the exported spec, (2) the
+  implementation split plan, (3) the final PR. No silent fourth gate.
+- **No LLM calls in the devague CLI.** The CLI is deterministic. This skill
+  adds orchestration convention, not CLI behavior.
+
+## Output contract
+
+The `split-plan` subcommand prints to **stdout** and exits 0 when a converged
+plan is found. On error (no plan, cyclic graph) it exits non-zero with a
+`hint:` line on stderr. The `waves` subcommand forwards the CLI's own output
+contract (stdout, `--json` for structured output, exit 0 on success).
+
+## Worked example
+
+Picking up after `/spec-to-plan` exported a plan for the frame `my-feature`:
+
+```bash
+a() { bash .claude/skills/assign-to-workforce/scripts/assign-to-workforce.sh "$@"; }
+
+# 1. Inspect the waves
+a waves
+
+# 2. Present the implementation split plan for human review
+a split-plan
+
+# --- HUMAN: review the table, edit agent/model assignments if needed,
+#     then say "approved" to proceed ---
+
+# 3. Fan out wave 1 (t1, t2, t3 are independent — run in parallel)
+git worktree add ../worktrees/agent-t1 -b agent/t1
+git worktree add ../worktrees/agent-t2 -b agent/t2
+git worktree add ../worktrees/agent-t3 -b agent/t3
+# ... spawn task agents in each worktree, await completion ...
+
+# 4. TDD-gated merge for each wave-1 task (no human per task)
+git merge --no-ff agent/t1   # tests pass before + after
+git worktree remove ../worktrees/agent-t1
+git merge --no-ff agent/t2
+git worktree remove ../worktrees/agent-t2
+git merge --no-ff agent/t3
+git worktree remove ../worktrees/agent-t3
+
+# 5. Advance to wave 2 (t4 depends on t1–t3 being merged)
+git worktree add ../worktrees/agent-t4 -b agent/t4
+# ... spawn, await, merge with TDD gate, remove worktree ...
+
+# 6. Open the final PR (human gate 3)
+bash .claude/skills/cicd/scripts/workflow.sh open
+```
+
+The exported plan-md from `devague plan export` is the standing brief for
+each task agent — its task id, summary, acceptance criteria, and the targets
+it covers are already in that file.
+
+## Provenance
+
+This is a **first-party** skill — its origin is `agentculture/devague`, where
+the devague agent maintains it alongside the tools it operates (dogfooding),
+next to its siblings `/think` and `/spec-to-plan`. It is the *third* skill in
+that outbound family, covering the implementation leg after a plan converges.
+The flow runs the *opposite* direction of the vendored steward skills: steward
+pulls this **from** devague and broadcasts it to the rest of the AgentCulture
+mesh. The `cite, don't import` policy still holds: downstream repos copy it,
+they don't symlink or depend on it. See `docs/skill-sources.md`.

--- a/.claude/skills/assign-to-workforce/scripts/assign-to-workforce.sh
+++ b/.claude/skills/assign-to-workforce/scripts/assign-to-workforce.sh
@@ -1,0 +1,213 @@
+#!/usr/bin/env bash
+# assign-to-workforce.sh — fan out devague plan waves to parallel agents.
+#
+# The skill is named `assign-to-workforce`; it reads `devague plan waves`
+# (scheduling metadata produced by the /spec-to-plan skill) and renders the
+# implementation split plan: task map + per-task agent/model proposal + a
+# go/no-go prompt for the human. The actual fan-out (worktree creation,
+# spawning, TDD-gated merges) is performed by the operator/main agent once
+# the human approves the split plan.
+#
+# The devague CLI is non-orchestrating (#20): `devague plan waves` describes
+# the dependency graph; it does not spawn agents, manage worktrees, or pick
+# a backend. This wrapper is the operator-facing helper.
+#
+# Origin: authored and maintained in agentculture/devague. steward pulls this
+# skill from here and broadcasts it to the rest of the AgentCulture mesh, so
+# it is written to run anywhere — portable bash, no devague-checkout assumptions.
+#
+# Plans persist under .devague/ in the current directory, so run from the repo
+# you are implementing.
+
+set -euo pipefail
+
+# ── resolve the devague CLI (mesh-first, then local-dev fallback) ───────────
+DEVAGUE=()
+resolve_devague() {
+    if command -v devague >/dev/null 2>&1; then
+        DEVAGUE=(devague)            # installed tool — the normal mesh case
+        return 0
+    fi
+    # Local-dev fallback: inside the devague checkout, run via uv.
+    local dir="$PWD"
+    while [ -n "$dir" ] && [ "$dir" != "/" ]; do
+        if [ -f "$dir/pyproject.toml" ] \
+            && grep -q '^name = "devague"' "$dir/pyproject.toml" 2>/dev/null; then
+            if command -v uv >/dev/null 2>&1; then
+                DEVAGUE=(uv run devague)
+                return 0
+            fi
+            break
+        fi
+        dir=$(dirname "$dir")
+    done
+    cat >&2 <<'EOF'
+error: devague CLI not found.
+hint: install it with `uv tool install devague` (or `pipx install devague`),
+      or run from inside the devague checkout with `uv` available.
+      https://github.com/agentculture/devague
+EOF
+    return 1
+}
+
+usage() {
+    cat <<'EOF'
+assign-to-workforce.sh — fan out devague plan waves to parallel agents.
+
+Usage:
+  assign-to-workforce.sh split-plan [--plan <slug>]   print the implementation split plan
+  assign-to-workforce.sh waves      [--plan <slug>] [--json]   list dependency waves
+  assign-to-workforce.sh help                         this help
+
+Commands:
+  split-plan   Read `devague plan waves --json` and render the human-facing
+               implementation split plan: task map + per-task agent/model
+               proposal + go/no-go. Present this to the human before any
+               fan-out; do not proceed without approval.
+  waves        Forward `devague plan waves` (and any extra flags) verbatim.
+               On a converged plan exits 0 and lists the dependency waves.
+
+Plans persist under .devague/ in the current directory — run from the repo
+you are implementing. Results go to stdout, diagnostics to stderr.
+
+Human gates (three only):
+  1. The exported spec (already closed by the /think leg).
+  2. This implementation split plan (go/no-go to assign to workforce).
+  3. The final PR (opened by the main agent via `cicd` / `devex pr open`).
+
+The devague CLI is non-orchestrating (#20): `devague plan waves` describes
+the graph; the operator performs the fan-out. One worktree per task; TDD
+gates every merge (tests pass before AND after merge); no human per task.
+EOF
+}
+
+# ── split-plan: render the implementation split plan for human review ────────
+cmd_split_plan() {
+    local extra_args=()
+    # Forward any --plan flag so waves targets the right plan.
+    while [ $# -gt 0 ]; do
+        extra_args+=("$1")
+        shift
+    done
+
+    local waves_json tmp_err waves_rc old_exit_trap
+    # Clean up the temp file on any exit path — including a signal after its
+    # creation — WITHOUT permanently changing the script's process-global EXIT
+    # handling. Capture any prior EXIT trap BEFORE mktemp (that capture forks a
+    # subshell, so doing it first keeps it out of the untracked-file window),
+    # then install our cleanup trap on the line immediately after mktemp, and
+    # restore the prior trap once the file is safely gone (#30; PR #31 review;
+    # devague#32).
+    old_exit_trap="$(trap -p EXIT)"
+    tmp_err="$(mktemp)"
+    trap 'rm -f "$tmp_err"' EXIT
+    set +e
+    waves_json="$("${DEVAGUE[@]}" plan waves --json "${extra_args[@]}" 2>"$tmp_err")"
+    waves_rc=$?
+    set -e
+    local waves_err
+    waves_err="$(cat "$tmp_err")"
+    rm -f "$tmp_err"
+    trap - EXIT
+    eval "${old_exit_trap}"  # empty string is a no-op; re-installs a prior trap if any
+
+    if [ "$waves_rc" -ne 0 ]; then
+        printf '%s\n' "$waves_err" >&2
+        return "$waves_rc"
+    fi
+
+    DEVAGUE_WAVES_JSON="$waves_json" python3 - <<'PY'
+import json
+import os
+import sys
+
+raw = os.environ.get("DEVAGUE_WAVES_JSON", "").strip()
+if not raw:
+    print("error: no waves output from devague plan waves", file=sys.stderr)
+    print("hint: ensure a converged plan exists (devague plan converge)", file=sys.stderr)
+    sys.exit(1)
+
+try:
+    data = json.loads(raw)
+except json.JSONDecodeError as exc:
+    print(f"error: could not parse waves JSON: {exc}", file=sys.stderr)
+    sys.exit(1)
+
+plan_slug = data.get("plan", "(unknown)")
+waves = data.get("waves") or []
+
+print(f"Implementation split plan — plan: {plan_slug}")
+print()
+print("Dependency waves (from `devague plan waves`):")
+for i, wave in enumerate(waves, 1):
+    tasks = ", ".join(wave)
+    print(f"  Wave {i}: [{tasks}]")
+
+print()
+print("Task assignments (proposed — edit before approving):")
+print()
+
+headers = ("Task", "Wave", "Summary", "Agent type", "Model", "Scope note")
+rows = []
+for i, wave in enumerate(waves, 1):
+    for task_id in wave:
+        rows.append((
+            task_id,
+            str(i),
+            "(see plan export for summary + acceptance criteria)",
+            "subagent",
+            "cheaper/faster",
+            "TDD-scoped task; isolated worktree; tests gate merge",
+        ))
+
+col_widths = [max(len(h), max((len(r[j]) for r in rows), default=0))
+              for j, h in enumerate(headers)]
+
+def row_str(cells):
+    return "| " + " | ".join(c.ljust(w) for c, w in zip(cells, col_widths)) + " |"
+
+sep = "| " + " | ".join("-" * w for w in col_widths) + " |"
+print(row_str(headers))
+print(sep)
+for row in rows:
+    print(row_str(row))
+
+print()
+print("Go/no-go: review the table above, edit agent type / model / scope as needed,")
+print("then confirm: \"Approved — assign to workforce\" or \"Edit first\".")
+print()
+print("Once approved, fan out wave by wave:")
+print("  1. Create one git worktree per task in the wave.")
+print("  2. Spawn a task agent per worktree (brief = task summary + acceptance criteria).")
+print("  3. Await all tasks in the wave; then TDD-gate each merge (tests before + after).")
+print("  4. Advance to the next wave.")
+print("  5. Open the final PR (human gate 3) after all waves merge and tests pass.")
+PY
+}
+
+main() {
+    case "${1:-help}" in
+        help | -h | --help)
+            usage
+            return 0
+            ;;
+        split-plan)
+            shift
+            resolve_devague
+            cmd_split_plan "$@"
+            ;;
+        waves)
+            shift
+            resolve_devague
+            exec "${DEVAGUE[@]}" plan waves "$@"
+            ;;
+        *)
+            printf 'error: unknown subcommand: %s\n' "$1" >&2
+            # shellcheck disable=SC2016  # backticks are literal text, not a subshell
+            printf 'hint: run `assign-to-workforce.sh help` for usage\n' >&2
+            return 1
+            ;;
+    esac
+}
+
+main "$@"

--- a/.claude/skills/assign-to-workforce/scripts/assign-to-workforce.sh
+++ b/.claude/skills/assign-to-workforce/scripts/assign-to-workforce.sh
@@ -30,8 +30,8 @@ resolve_devague() {
     fi
     # Local-dev fallback: inside the devague checkout, run via uv.
     local dir="$PWD"
-    while [ -n "$dir" ] && [ "$dir" != "/" ]; do
-        if [ -f "$dir/pyproject.toml" ] \
+    while [[ -n "$dir" && "$dir" != "/" ]]; do
+        if [[ -f "$dir/pyproject.toml" ]] \
             && grep -q '^name = "devague"' "$dir/pyproject.toml" 2>/dev/null; then
             if command -v uv >/dev/null 2>&1; then
                 DEVAGUE=(uv run devague)
@@ -83,12 +83,8 @@ EOF
 
 # ── split-plan: render the implementation split plan for human review ────────
 cmd_split_plan() {
-    local extra_args=()
-    # Forward any --plan flag so waves targets the right plan.
-    while [ $# -gt 0 ]; do
-        extra_args+=("$1")
-        shift
-    done
+    # Forward any --plan flag (and any other args) so waves targets the right plan.
+    local extra_args=("$@")
 
     local waves_json tmp_err waves_rc old_exit_trap
     # Clean up the temp file on any exit path — including a signal after its
@@ -111,7 +107,7 @@ cmd_split_plan() {
     trap - EXIT
     eval "${old_exit_trap}"  # empty string is a no-op; re-installs a prior trap if any
 
-    if [ "$waves_rc" -ne 0 ]; then
+    if [[ "$waves_rc" -ne 0 ]]; then
         printf '%s\n' "$waves_err" >&2
         return "$waves_rc"
     fi
@@ -186,7 +182,8 @@ PY
 }
 
 main() {
-    case "${1:-help}" in
+    local sub="${1:-help}"
+    case "$sub" in
         help | -h | --help)
             usage
             return 0
@@ -202,7 +199,7 @@ main() {
             exec "${DEVAGUE[@]}" plan waves "$@"
             ;;
         *)
-            printf 'error: unknown subcommand: %s\n' "$1" >&2
+            printf 'error: unknown subcommand: %s\n' "$sub" >&2
             # shellcheck disable=SC2016  # backticks are literal text, not a subshell
             printf 'hint: run `assign-to-workforce.sh help` for usage\n' >&2
             return 1

--- a/.claude/skills/spec-to-plan/SKILL.md
+++ b/.claude/skills/spec-to-plan/SKILL.md
@@ -1,0 +1,230 @@
+---
+name: spec-to-plan
+type: command
+description: >
+  Turn a converged devague spec into a buildable plan by working forwards (the
+  spec→plan leg; drives the `devague plan` CLI group). Seed a plan from a
+  converged frame, add tasks that collectively cover every coverage target (the
+  frame's confirmed claims + honesty conditions), give each task acceptance
+  criteria and an honest dependency order, park genuine unknowns as first-class
+  risks, and export a plan only once it *converges*. Use when the user says
+  "spec to plan", "stp", "turn this spec into a plan", "plan this spec", "make a
+  build plan", or after the /think skill exports a spec. Authored and maintained
+  in agentculture/devague (origin = devague); steward pulls this skill from here
+  and broadcasts it to the AgentCulture mesh — it is NOT vendored from steward
+  like the other skills here.
+---
+
+# spec-to-plan — work a converged spec forwards into a buildable plan
+
+The skill is named **`spec-to-plan`**; the product/CLI it drives is the
+**`devague plan`** command group. (The prior leg — turning a vague idea into a
+spec — is the sibling **`/think`** skill.) It is the **forward** peer of the
+working-backwards spec engine: where `/think` converges on *what* to build,
+`/spec-to-plan` converges on *how* to build it.
+
+A plan is seeded from a **converged frame** and tracks **tasks** against the
+spec's **coverage targets**. The CLI is **deterministic and move-driven** — you
+(the agent) choose the next move; the CLI tracks state and tells you what's still
+missing. Run `devague plan learn` for the method and `devague plan explain
+<move>` for any single move.
+
+## How to run
+
+The entry point is `scripts/spec-to-plan.sh`. Invoke it from the repository you
+are speccing (plans persist under `.devague/` in the current directory, alongside
+the frames they derive from):
+
+```bash
+bash .claude/skills/spec-to-plan/scripts/spec-to-plan.sh <move> [args...]
+bash .claude/skills/spec-to-plan/scripts/spec-to-plan.sh status
+```
+
+It resolves the CLI portably — an installed `devague` on `PATH` (the normal
+case), falling back to `uv run devague` inside the devague checkout, else an
+install hint. Every move — including `status` — is forwarded verbatim as
+`devague plan <move>`, so you can equally call the CLI directly
+(`devague plan <move> …`).
+
+### Moves
+
+| Move | What it does |
+|------|--------------|
+| `new --frame <slug>` | Seed a plan from a **converged** frame. Derives the coverage targets (`c*`/`h*`) the plan must satisfy. Refuses an unconverged frame. |
+| `task "<summary>"` | Add a task. `--accept "<crit>"`, `--dep <tN>`, `--covers <c*/h*>` (each repeatable); `--origin llm` lands it `proposed`. |
+| `accept <tN> "<crit>"` | Add an acceptance criterion to a task. |
+| `depend <tN> --on <tM>` | Record that task `tN` depends on `tM`. |
+| `cover <tN> --target <c*/h*>` | Mark a task as covering a coverage target. |
+| `confirm <tN>` / `reject <tN>` | Resolve a task. **User-only decision.** |
+| `risk "<text>" --kind <kind>` | Record a first-class plan risk (`--task <tN>` to attach). |
+| `converge` | Evaluate the gate against the **live** source frame; list remaining gaps. |
+| `export` | Write the buildable plan to `docs/plans/` — only after `converge` passes. |
+| `waves` | Emit deterministic dependency waves (`{plan, waves}`) — scheduling metadata only, *not* orchestration. Read-only, works on an in-progress plan; refuses a cyclic/dangling graph. Devague describes the graph; an operator decides how to run it (#20). |
+| `status` | Read-only: where the plan stands + the recommended next move, re-checked against the live frame (`--json` too). |
+| `show` / `list` | Render a plan / list plans (`--json` for raw state). |
+| `learn` / `explain <move>` | Teach the method / explain one move. |
+
+Risk kinds (shared with the frame engine): `unknown_nonblocking`,
+`unknown_blocking`, `out_of_scope`, `follow_up`.
+
+### `status` — the next-move verb
+
+`status` is a first-class, **read-only** CLI verb (`devague plan status`,
+internalised from this wrapper in 0.11.0 — issue
+[#30](https://github.com/agentculture/devague/issues/30)). It composes
+`devague plan list` + `devague plan converge` and prints where the current plan
+stands, the remaining gaps, and the recommended next move derived from the first
+gap. Like `converge`/`export` it re-checks the **live** source frame (so frame
+drift surfaces as an error), but it never mutates state. Pass `--json` for the
+structured payload (`{plan, total, ready_for_plan, blockers, warnings,
+parked_items, required_next_moves}`).
+
+```text
+plan: my-feature    (1 plan total)
+convergence: NOT passed — 2 gap(s):
+  - coverage target c5 (boundary) has no confirmed task
+  - task t2 has no acceptance criteria
+
+recommended next move (first gap):
+  cover c5: devague plan task "<summary>" --covers c5 --accept "<...>"
+```
+
+Run it whenever you're unsure what to do next.
+
+## Hard rules (do not violate)
+
+These are the point of the method — convergence must mean something.
+
+- **Seed from a converged spec only.** `plan new` refuses a frame that hasn't
+  converged. The plan's coverage targets *are* the spec's confirmed claims and
+  honesty conditions — there is nothing honest to plan against until the spec
+  converges.
+- **LLM proposals stay proposed.** A task captured with `--origin llm` lands as
+  `proposed`. **Never `confirm` your own proposal.** Confirmation is a user-only
+  decision — surface the proposed task and let the user confirm or reject it.
+- **Cover every target; criteria on every task.** The gate requires every
+  coverage target to be covered by a confirmed task, and every confirmed task to
+  carry at least one acceptance criterion. Don't hand-wave a task as "done-ish."
+- **Keep the graph honest.** Dependencies must reference real tasks and form an
+  acyclic graph; the gate rejects dangling deps and cycles.
+- **Park real unknowns as risks; don't paper over them.** A genuinely unknown
+  decision is an `unknown_blocking` risk — it holds back convergence, by design.
+- **Converge against the live frame.** `converge`/`export` re-load the source
+  frame every time. If the frame was deleted or has regressed below convergence,
+  they refuse — re-converge the spec (in `/think`) first.
+
+## Coaching toward small, file-disjoint, TDD-gated tasks
+
+When authoring a plan that will be built via parallel execution (fanned out to
+multiple agents via the downstream `/assign-to-workforce` skill), prefer the
+following discipline to maximize parallelism and minimize merge friction:
+
+### Small and crisply scoped
+
+Each task should be **small enough for a simpler or cheaper model to build
+test-first** without re-deriving the full design. If a task spans multiple files
+or architectural layers, split it — narrow scope forces you to write sharp
+acceptance criteria and keeps waves wide.
+
+### File disjoint
+
+**Prefer tasks that touch non-overlapping files.** When two same-wave tasks
+modify the same file, merge collision becomes inevitable. The dependency graph
+alone *does not* guarantee file disjointness — it only sequences task *content*
+dependencies; same-wave tasks with overlapping file-writes must be split across
+waves or given explicit dependencies.
+
+Check `devague plan waves` output: if a wave is wide but all tasks touch
+`src/core.py`, the wave is *formally* parallel but *operationally* serialized at
+merge. Reorder task boundaries so wide waves operate on disjoint file sets.
+
+### TDD acceptance criteria on every task
+
+Every confirmed task must carry **at least one acceptance criterion**, phrased as
+a testable condition (not a vague outcome). For example:
+
+- Bad: "Implement the parser"
+- Better: "Parser accepts a valid spec file and rejects malformed YAML without
+  data loss"
+
+Acceptance criteria are **the contract** between the main agent (who merges) and
+the subagent (who builds). A test suite derived from these criteria validates
+each task's output *before* merge, independent of model capability. This is not
+optional: `devague plan converge` warns (non-blocking) when a confirmed task
+lacks criteria.
+
+### The key invariant: parallel = serial
+
+**A plan built in parallel must yield identical results to building it serially.**
+This is guaranteed only if:
+
+1. Same-wave tasks have no inter-task dependencies (checked by `waves`).
+2. Same-wave tasks touch disjoint files (you must verify; the CLI does not).
+3. Each task's acceptance criteria are sharp enough that a subagent's output
+   passes them independent of whether it was built in isolation or alongside
+   other tasks.
+
+The TDD gate — tests pass before *and* after the merge — is the main agent's
+proof that parallelism didn't break correctness.
+
+### How to route tasks to the workforce
+
+Once your plan converges, `devague plan waves` emits the dependency-graph as
+**scheduling metadata** (ordered batches of task IDs). This feeds directly into
+the `/assign-to-workforce` skill, which:
+
+1. Displays the plan, waves, and suggested per-task subagent/model pairing.
+2. Waits for the human to approve the implementation split plan (or edit
+   assignments).
+3. Fans out approved waves to isolated subagent worktrees (one per task per
+   wave).
+4. Returns control to the main agent, which TDD-gates each merge before moving
+   to the next wave.
+
+Plan for workforce execution early: narrow task scope, write crisp acceptance
+criteria, and strive for wide waves with disjoint files.
+
+## Output contract
+
+Results go to **stdout**, diagnostics and errors to **stderr** — a strict split
+you can rely on when parsing. Pass `--json` to any move for a structured payload.
+Exit code `0` on success, non-zero on user error (with a `hint:` line). Plans
+live under `.devague/plans/` in the current directory; the exported plan-md lands
+in `docs/plans/`.
+
+## Worked example
+
+Picking up after `/think` exported a spec for the frame `my-feature`:
+
+```bash
+p() { bash .claude/skills/spec-to-plan/scripts/spec-to-plan.sh "$@"; }
+
+p new --frame my-feature        # seeds the plan + its coverage targets
+p show                          # see the c*/h* targets you must cover
+
+p task "Build the core engine" --accept "engine has a convergence gate" \
+    --covers c1 --covers c3
+p task "Pressure-test honesty conditions" --dep t1 --covers h1 --covers h2 \
+    --accept "every honesty condition maps to a test"
+
+# Park a genuine unknown instead of guessing:
+p risk "exact rollout sequencing" --kind unknown_nonblocking
+
+p status        # what's left + the next move
+p converge      # gate; resolve any listed gaps
+p export        # writes docs/plans/my-feature.md once converged
+```
+
+The exported plan-md is a buildable artifact: topologically ordered tasks, each
+with acceptance criteria and the spec targets it covers. It feeds directly into
+implementation (or `superpowers:writing-plans`).
+
+## Provenance
+
+This is a **first-party** skill — its origin is `agentculture/devague`, where the
+devague agent maintains it alongside the tool it operates (dogfooding), next to
+its sibling `/think`. It is the *inverse* of the other skills under
+`.claude/skills/`, which devague vendors **from** steward. When ready, steward
+pulls it **from** devague and broadcasts it to the rest of the AgentCulture mesh.
+The `cite, don't import` policy still holds: downstream repos copy it, they don't
+symlink or depend on it. See `docs/skill-sources.md`.

--- a/.claude/skills/spec-to-plan/scripts/spec-to-plan.sh
+++ b/.claude/skills/spec-to-plan/scripts/spec-to-plan.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# spec-to-plan.sh — drive devague's spec→plan engine (the /spec-to-plan skill).
+#
+# The skill is named `spec-to-plan`; the product/CLI it drives is `devague` (the
+# idea→spec half lives in the sibling /think skill). This wrapper forwards every
+# move to `devague plan <move>` verbatim — including the `status` verb the CLI
+# internalised in 0.11.0 (devague#30/#31), which reads the plan convergence gate
+# and names the recommended next move. It is the forward leg: seed a plan from a
+# *converged* frame, then work it into a buildable plan.
+#
+# Origin: authored and maintained in agentculture/devague. steward pulls this
+# skill from here and broadcasts it to the rest of the AgentCulture mesh, so it
+# is written to run anywhere — portable bash, no devague-checkout assumptions.
+#
+# Plans persist under .devague/ in the current directory (alongside frames), so
+# run from the repo you are speccing.
+
+set -euo pipefail
+
+# ── resolve the devague CLI (mesh-first, then local-dev fallback) ───────────
+DEVAGUE=()
+resolve_devague() {
+    if command -v devague >/dev/null 2>&1; then
+        DEVAGUE=(devague)            # installed tool — the normal mesh case
+        return 0
+    fi
+    # Local-dev fallback: inside the devague checkout, run via uv.
+    local dir="$PWD"
+    while [ -n "$dir" ] && [ "$dir" != "/" ]; do
+        if [ -f "$dir/pyproject.toml" ] \
+            && grep -q '^name = "devague"' "$dir/pyproject.toml" 2>/dev/null; then
+            if command -v uv >/dev/null 2>&1; then
+                DEVAGUE=(uv run devague)
+                return 0
+            fi
+            break
+        fi
+        dir=$(dirname "$dir")
+    done
+    cat >&2 <<'EOF'
+error: devague CLI not found.
+hint: install it with `uv tool install devague` (or `pipx install devague`),
+      or run from inside the devague checkout with `uv` available.
+      https://github.com/agentculture/devague
+EOF
+    return 1
+}
+
+usage() {
+    cat <<'EOF'
+spec-to-plan.sh — drive devague's spec→plan engine (the /spec-to-plan skill).
+
+Usage:
+  spec-to-plan.sh <move> [args...]   forward a `devague plan` move
+  spec-to-plan.sh status [--plan S]  where the plan stands + the next move
+  spec-to-plan.sh help               this help
+
+Moves (forwarded to `devague plan`; run `devague plan learn` for the method):
+  new          start a plan from a CONVERGED frame (--frame <slug>)
+  task         add a task (--accept / --dep / --covers, --origin user|llm)
+  accept       add an acceptance criterion to a task
+  depend       record that a task depends on another (--on)
+  cover        mark a task as covering a coverage target (c*/h*)
+  confirm      confirm a task                          (USER-only decision)
+  reject       reject a task
+  risk         record a first-class plan risk
+  converge     check whether the plan can export
+  export       write the buildable plan (only after converge passes)
+  waves        emit deterministic dependency waves (scheduling metadata, not orchestration)
+  status       where the plan stands + the recommended next move
+  show / list  render a plan / list plans
+  learn        teach the method   |   explain <move>  explain one move
+
+Plans persist under .devague/ in the current directory — run from the repo you
+are speccing. Results go to stdout, diagnostics to stderr; pass --json to any
+move for structured output.
+
+Note: every move — including `status` — is forwarded verbatim as `devague plan
+<move>`, so new plan moves work without editing this script. (`status` was
+internalised into the CLI in devague 0.11.0; it is no longer wrapper-only.)
+
+Prior leg: a plan is seeded from a converged frame produced by the /think skill.
+EOF
+}
+
+main() {
+    case "${1:-help}" in
+        help | -h | --help)
+            usage
+            return 0
+            ;;
+        *)
+            # Forward every move to `devague plan <move>` verbatim — including the
+            # internalised `status` verb (`devague plan status`) — so the CLI's own
+            # parser owns the plan surface.
+            resolve_devague
+            exec "${DEVAGUE[@]}" plan "$@"
+            ;;
+    esac
+}
+
+main "$@"

--- a/.claude/skills/spec-to-plan/scripts/spec-to-plan.sh
+++ b/.claude/skills/spec-to-plan/scripts/spec-to-plan.sh
@@ -26,8 +26,8 @@ resolve_devague() {
     fi
     # Local-dev fallback: inside the devague checkout, run via uv.
     local dir="$PWD"
-    while [ -n "$dir" ] && [ "$dir" != "/" ]; do
-        if [ -f "$dir/pyproject.toml" ] \
+    while [[ -n "$dir" && "$dir" != "/" ]]; do
+        if [[ -f "$dir/pyproject.toml" ]] \
             && grep -q '^name = "devague"' "$dir/pyproject.toml" 2>/dev/null; then
             if command -v uv >/dev/null 2>&1; then
                 DEVAGUE=(uv run devague)

--- a/.claude/skills/think/SKILL.md
+++ b/.claude/skills/think/SKILL.md
@@ -1,0 +1,201 @@
+---
+name: think
+type: command
+description: >
+  Think a vague feature idea into a buildable spec by working backwards (the
+  idea→spec leg; drives the `devague` CLI). Start from the announcement
+  ("pretend it shipped"), capture and classify claims, interrogate them with
+  honesty conditions and hard questions, park open vagueness as a first-class
+  object, and export a spec only once the frame *converges*. Use when the user
+  says "think this through", "spec this", "work backwards", "turn this idea into
+  a spec", "announcement frame", or "devague", or when a feature request is too
+  vague to build yet. Once a spec exports, hand off to the sibling /spec-to-plan
+  skill to turn it into a plan. Authored and maintained in agentculture/devague
+  (origin = devague); steward pulls this skill from here and broadcasts it to the
+  AgentCulture mesh — it is NOT vendored from steward like the other skills here.
+---
+
+# think — work an idea backwards into a buildable spec
+
+The skill is named **`think`**; the product/CLI it drives is **`devague`**. (The
+forward leg — turning a converged spec into a plan — is the sibling
+**`/spec-to-plan`** skill, which drives `devague plan`.)
+
+`think` turns a vague feature idea into a buildable spec by **working
+backwards**: you start from the announcement you'd make if it had already
+shipped, then build an **Announcement Frame** by capturing claims, pressure
+-testing them, parking what's still genuinely unknown, and only exporting once
+the frame converges.
+
+The CLI is **deterministic and move-driven** — it is *not* a wizard. There is no
+fixed sequence of prompts. **You (the agent) choose the next move; the CLI just
+tracks state and tells you what's still missing.** Run `devague learn` for the
+canonical ten-stage arc and `devague explain <move>` for any single move.
+
+This skill is the operator: a portable wrapper that resolves the CLI and
+forwards every move verbatim — including `status`, the read-only verb that reads
+the convergence gate and tells you the recommended next move.
+
+## How to run
+
+The entry point is `scripts/think.sh`. Invoke it from the repository you are
+speccing (frames persist under `.devague/` in the current directory):
+
+```bash
+bash .claude/skills/think/scripts/think.sh <move> [args...]
+bash .claude/skills/think/scripts/think.sh status
+```
+
+It resolves the CLI portably — an installed `devague` on `PATH` (the normal
+case), falling back to `uv run devague` when you are inside the devague checkout.
+If neither resolves it prints an install hint (`uv tool install devague`). Every
+move — including `status` — is forwarded verbatim, so you can equally call the
+CLI directly (`devague <move> …`) when it is installed; the wrapper exists only
+for portable resolution.
+
+### Moves
+
+| Move | What it does |
+|------|--------------|
+| `new "<announcement>"` | Start a frame from the announcement (the first move). Seeds an auto-confirmed `announcement` claim. |
+| `capture --kind <kind> "<text>"` | Record + classify a claim. `--origin llm` lands it as `proposed`. |
+| `interrogate <id> --honesty "…"` | Attach an honesty condition (what must be true). Also `--hard-question`, `--risk`, `--contradicts`, `--blocking`. |
+| `confirm <id> [<id>…]` / `reject <id> [<id>…]` | Resolve one or more claims (`c*`) / honesty conditions (`h*`) in one **transactional** call. **User-only decision.** Also `confirm --from-review <file>` to apply an edited review artifact. |
+| `review` | List every **proposed** (unconfirmed) claim + honesty condition with ids (`--json` too); writes a non-authoritative artifact to `.devague/reviews/<slug>.md`. Un-gated; never mutates. |
+| `question "<text>"` | Record / list / `--resolve` a pending user decision as durable working state in `.devague/questions/<slug>.md`. |
+| `park "<text>" --kind <kind>` | Move uncertainty into first-class open vagueness instead of forcing an answer. |
+| `converge` | Evaluate the gate; list remaining gaps. |
+| `export` | Write the buildable spec to `docs/specs/` — only after `converge` passes. |
+| `status` | Read-only: where the frame stands + the recommended next move (`--json` too). |
+| `show` / `list` | Render a frame / list frames (`--json` for raw state). |
+| `learn` / `explain <move>` | Teach the method / explain one move. |
+
+Claim kinds: `announcement`, `audience`, `after_state`, `before_state`,
+`why_it_matters`, `boundary`, `success_signal`, `open_question`, `non_goal`,
+`requirement`, `assumption`, `decision`. Vagueness kinds: `unknown_nonblocking`,
+`unknown_blocking`, `out_of_scope`, `follow_up`.
+
+These are exactly the kinds the **shipped CLI enforces** (`CLAIM_KINDS` /
+`VAGUENESS_KINDS` in `devague/frame.py`) — the skill documents the surface as
+built, so every command here passes the CLI's `choices=` validation. `requirement`
+is spec-affecting (needs a confirmed honesty condition); `non_goal` / `decision`
+are descriptive; an unconfirmed `assumption` is a convergence *warning*, not a
+blocker. The formal entity model, the `(state × origin)` vocabulary, and the
+per-move input/output/transition/error contract are documented in
+[`docs/spec-contract.md`](../../../docs/spec-contract.md) (issue
+[#5](https://github.com/agentculture/devague/issues/5)); for the authoritative
+live shape of any move, run it with `--json` (or `devague learn --json` /
+`devague explain <move>`).
+
+### `status` — the next-move verb
+
+`status` is a first-class, **read-only** CLI verb (`devague status`, internalised
+from this wrapper in 0.11.0 — issue
+[#30](https://github.com/agentculture/devague/issues/30)). It composes
+`list` + `converge` and prints where the current frame stands, the remaining
+gaps, and the recommended next move; it never mutates state (the
+`drafting`↔`converged` transition stays in `converge`). It reports
+`ready_for_spec`, lists the `blockers` and `warnings`, and shows
+`required_next_moves[0]` as the recommended move. Pass `--json` for the same
+fields as a structured payload (`{frame, total, ready_for_spec, blockers,
+warnings, parked_items, required_next_moves}`).
+
+```text
+frame: my-feature    (1 frame total)
+convergence: NOT passed — 2 gap(s):
+  - missing a 'boundary' / non-goal claim
+  - claim c2 has no confirmed honesty condition
+
+recommended next move (first gap):
+  devague capture --kind boundary "<text>"
+```
+
+Run it whenever you're unsure what to do next.
+
+## Hard rules (do not violate)
+
+These are the point of the method — convergence must mean something.
+
+- **LLM proposals stay proposed.** A claim captured with `--origin llm`, and any
+  honesty condition you (the agent) propose, lands as `proposed`. **Never
+  `confirm` your own proposal.** Confirmation is a user-only decision — surface
+  the proposal and let the user confirm or reject it. Proposed content must not
+  silently become an authoritative requirement.
+- **Honesty conditions route through the user.** Propose them freely with
+  `interrogate --honesty`; the user owns whether they hold.
+- **Converge, don't vibe.** `export` is gated on `converge` passing. Never claim
+  the frame is ready on a hunch — run `converge` (or `status`) and resolve every
+  listed gap. The gate requires confirmed `announcement` / `audience` /
+  `after_state`, a `before_state` or `why_it_matters`, a `boundary`, a
+  `success_signal`, a confirmed honesty condition on every spec-affecting claim,
+  and no unresolved blocking vagueness or hard question.
+- **Park real unknowns; don't paper over them.** If something is genuinely
+  unknown, `park` it (blocking or non-blocking) rather than fabricating an
+  answer. Blocking vagueness holds back convergence — by design.
+
+## Output contract
+
+Results go to **stdout**, diagnostics and errors to **stderr** — a strict split
+you can rely on when parsing. Pass `--json` to any move for a structured payload
+on the same stream. Exit code `0` on success, non-zero on user error (with a
+`hint:` line). Frames live under `.devague/` in the current directory.
+
+## Worked example
+
+A short end-to-end session (the kind you'd run to spec a feature like
+[devague#5](https://github.com/agentculture/devague/issues/5)):
+
+```bash
+d() { bash .claude/skills/think/scripts/think.sh "$@"; }
+
+d new "Devague ships a documented spec contract"
+d capture --kind audience "devague + the assisting LLM"
+d capture --kind after_state "a vague idea becomes a buildable, pressure-tested spec"
+d capture --kind why_it_matters "specs converge on evidence, not vibes"
+d capture --kind boundary "not a full PRD generator; no fixed wizard"
+d capture --kind success_signal "a frame exports only after the gate passes"
+
+# Pressure-test a claim, then let the USER confirm the condition:
+d interrogate c1 --honesty "the contract round-trips: save -> load -> identical frame"
+# ...user reviews and runs: d confirm h1
+
+# Park a genuine unknown instead of guessing:
+d park "exact JSON schema versioning policy" --kind unknown_nonblocking
+
+d status        # what's left + the next move
+d converge      # gate; resolve any listed gaps
+d export        # writes docs/specs/<slug>.md once converged
+```
+
+The exported spec-md is a buildable artifact.
+
+## After export — commit, then hand off
+
+Once `export` writes the spec **and the user has reviewed it**, close the
+idea→spec leg cleanly before moving on:
+
+1. **Commit the spec.** Commit the exported `docs/specs/<slug>.md` (along with
+   the `.devague/<slug>.json` frame state and any review artifact under
+   `docs/reviews/`) so the converged frame is durable in history, not just on
+   disk. Use a focused message, e.g. `git commit -m "spec: <slug> (devague
+   /think)"`. The frame and the spec are the evidence trail for every confirmed
+   claim — keep them together. (Per the repo's standing convention this normally
+   becomes a branch + PR via the `cicd` skill; commit-only is fine when the user
+   asks for it.)
+2. **Hand off to `/spec-to-plan`.** The forward leg is the sibling skill:
+   `devague plan new --frame <slug>` seeds a plan from the converged frame and
+   works it forward into a buildable plan (it can equally feed
+   `superpowers:writing-plans` or a normal implementation PR).
+
+Don't pause for a "what next?" menu after a reviewed export — the standing flow
+is **commit, then `/spec-to-plan`**.
+
+## Provenance
+
+This is a **first-party** skill — its origin is `agentculture/devague`, where the
+devague agent maintains it alongside the tool it operates (dogfooding). It is the
+*inverse* of the other skills under `.claude/skills/`, which devague vendors
+**from** steward. When this skill is ready, steward pulls it **from** devague and
+broadcasts it to the rest of the AgentCulture mesh. The `cite, don't import`
+policy still holds: downstream repos copy it, they don't symlink or depend on it.
+See `docs/skill-sources.md`.

--- a/.claude/skills/think/scripts/think.sh
+++ b/.claude/skills/think/scripts/think.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# think.sh — drive devague's working-backwards idea→spec engine (the /think skill).
+#
+# The skill is named `think`; the product/CLI it drives is `devague` (the spec→plan
+# half lives in the sibling /spec-to-plan skill, which drives `devague plan`).
+# devague turns a vague feature idea into a buildable spec by working backwards.
+# This wrapper is the agent-facing operator for the deterministic devague CLI:
+# it resolves the CLI portably and forwards every move verbatim — including the
+# `status` verb the CLI internalised in 0.11.0 (devague#30/#31), which reads the
+# convergence gate and names the recommended next move.
+#
+# Origin: authored and maintained in agentculture/devague. steward pulls this
+# skill from here and broadcasts it to the rest of the AgentCulture mesh, so it
+# is written to run anywhere — portable bash, no devague-checkout assumptions.
+#
+# Frames persist under .devague/ in the current directory, so run from the repo
+# you are speccing.
+
+set -euo pipefail
+
+# ── resolve the devague CLI (mesh-first, then local-dev fallback) ───────────
+DEVAGUE=()
+resolve_devague() {
+    if command -v devague >/dev/null 2>&1; then
+        DEVAGUE=(devague)            # installed tool — the normal mesh case
+        return 0
+    fi
+    # Local-dev fallback: inside the devague checkout, run via uv.
+    local dir="$PWD"
+    while [ -n "$dir" ] && [ "$dir" != "/" ]; do
+        if [ -f "$dir/pyproject.toml" ] \
+            && grep -q '^name = "devague"' "$dir/pyproject.toml" 2>/dev/null; then
+            if command -v uv >/dev/null 2>&1; then
+                DEVAGUE=(uv run devague)
+                return 0
+            fi
+            break
+        fi
+        dir=$(dirname "$dir")
+    done
+    cat >&2 <<'EOF'
+error: devague CLI not found.
+hint: install it with `uv tool install devague` (or `pipx install devague`),
+      or run from inside the devague checkout with `uv` available.
+      https://github.com/agentculture/devague
+EOF
+    return 1
+}
+
+usage() {
+    cat <<'EOF'
+think.sh — drive devague's working-backwards idea→spec engine (the /think skill).
+
+Usage:
+  think.sh <move> [args...]    forward a devague move
+  think.sh status [--frame S]  where the frame stands + the next move
+  think.sh help                this help
+
+Moves (forwarded to the devague CLI; run `devague learn` for the full method):
+  new          start a frame from the announcement ("pretend it shipped")
+  capture      record + classify a claim (--kind audience|after_state|...)
+  interrogate  pressure-test a claim (--honesty / --hard-question / --risk)
+  confirm      confirm a claim or honesty condition  (USER-only decision)
+  reject       reject a claim or honesty condition
+  park         record open vagueness instead of forcing an answer
+  converge     check whether the frame can export a spec
+  export       write the buildable spec (only after converge passes)
+  status       where the frame stands + the recommended next move
+  show / list  render a frame / list frames
+  learn        teach the method   |   explain <move>  explain one move
+
+Frames persist under .devague/ in the current directory — run from the repo
+you are speccing. Results go to stdout, diagnostics to stderr; pass --json to
+any move for structured output.
+
+Note: every move — including `status` — is forwarded verbatim to the devague
+CLI, so new devague moves work without editing this script. (`status` was
+internalised into the CLI in devague 0.11.0; it is no longer wrapper-only.)
+
+Next leg: once a frame exports a spec, hand off to the /spec-to-plan skill
+(`devague plan ...`) to turn that spec into a buildable plan.
+EOF
+}
+
+main() {
+    case "${1:-help}" in
+        help | -h | --help)
+            usage
+            return 0
+            ;;
+        *)
+            # Forward every move to the CLI verbatim (including --version, the
+            # internalised `status` verb, and any future devague move), so its
+            # own parser owns the surface.
+            resolve_devague
+            exec "${DEVAGUE[@]}" "$@"
+            ;;
+    esac
+}
+
+main "$@"

--- a/.claude/skills/think/scripts/think.sh
+++ b/.claude/skills/think/scripts/think.sh
@@ -27,8 +27,8 @@ resolve_devague() {
     fi
     # Local-dev fallback: inside the devague checkout, run via uv.
     local dir="$PWD"
-    while [ -n "$dir" ] && [ "$dir" != "/" ]; do
-        if [ -f "$dir/pyproject.toml" ] \
+    while [[ -n "$dir" && "$dir" != "/" ]]; do
+        if [[ -f "$dir/pyproject.toml" ]] \
             && grep -q '^name = "devague"' "$dir/pyproject.toml" 2>/dev/null; then
             if command -v uv >/dev/null 2>&1; then
                 DEVAGUE=(uv run devague)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented here. The format
 is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.0] - 2026-06-08
+
+### Added
+
+- skills/think, skills/spec-to-plan, skills/assign-to-workforce — the devague workflow trio (idea→spec→plan→parallel implementation), the agent-facing operator chain over the deterministic devague CLI. Vendored from guildmaster (re-broadcast of agentculture/devague, tracking devague 0.11.1 / c04b595, MIT). Each SKILL.md carries type: command frontmatter (required by the culture/agex skill loader). Runtime dep: uv tool install devague; assign-to-workforce additionally uses git worktree + the cicd skill for its final-PR gate. Resolves #39.
+
+### Changed
+
+- assign-to-workforce.sh: added an inline `# shellcheck disable=SC2016` (the backticks are literal text, not a subshell) — cultureflare-local hardening so the test-bash shellcheck gate stays green.
+
 ## [0.9.0] - 2026-05-26
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - assign-to-workforce.sh: added an inline `# shellcheck disable=SC2016` (the backticks are literal text, not a subshell) — cultureflare-local hardening so the test-bash shellcheck gate stays green.
+- think/spec-to-plan/assign-to-workforce scripts: repo-local shell hardening for SonarCloud's `shelldre` ruleset — `[[ … ]]` over `[ … ]` (S7688) and positional parameters assigned to locals (S7679) — clearing all 13 OPEN issues. Matches the `cicd` skill's documented vendored-script hardening; upstream (`agentculture/devague`) still carries the original `[ … ]` style.
 
 ## [0.9.0] - 2026-05-26
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,7 +54,10 @@ Skills under `.claude/skills/`:
   (re-broadcast of `agentculture/devague`, tracking devague `0.11.1` /
   `c04b595`, MIT). Divergences from upstream: each `SKILL.md` carries
   `type: command` (required by the culture/agex skill loader, harmless on
-  plain `claude-code`) and `assign-to-workforce.sh` carries a
+  plain `claude-code`); the scripts carry repo-local shell hardening for
+  SonarCloud's `shelldre` ruleset (`[[ … ]]` over `[ … ]` per S7688,
+  positional params assigned to locals per S7679) — matching the `cicd`
+  skill's vendored-script precedent; and `assign-to-workforce.sh` keeps a
   `# shellcheck disable=SC2016` (literal backticks) for the `test-bash` gate.
   Runtime dep: `uv tool install devague`; `assign-to-workforce` additionally
   uses `git worktree` + the `cicd` skill for its final-PR gate.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,17 @@ Skills under `.claude/skills/`:
 - `communicate/` — cross-repo issue posts / comments / fetches (agtag-backed,
   auto-signed) and Culture mesh channel messages. Vendored from steward 0.12.0.
 - `poll/` — background reviewer-wait subagent (drives `agex pr read --wait`).
+- `think/`, `spec-to-plan/`, `assign-to-workforce/` — the **devague workflow
+  trio**: the agent-facing operator chain over the deterministic `devague`
+  CLI (idea→spec via `think`, spec→plan via `spec-to-plan`, plan→parallel
+  implementation via `assign-to-workforce`). Vendored from `guildmaster`
+  (re-broadcast of `agentculture/devague`, tracking devague `0.11.1` /
+  `c04b595`, MIT). Divergences from upstream: each `SKILL.md` carries
+  `type: command` (required by the culture/agex skill loader, harmless on
+  plain `claude-code`) and `assign-to-workforce.sh` carries a
+  `# shellcheck disable=SC2016` (literal backticks) for the `test-bash` gate.
+  Runtime dep: `uv tool install devague`; `assign-to-workforce` additionally
+  uses `git worktree` + the `cicd` skill for its final-PR gate.
 - `cultureflare/` (package) — Python CLI installed via `uv tool install cultureflare`; entry point `cultureflare`. Noun/verb surface (`cultureflare <noun> <verb>`) with markdown-default + `--json` output and dry-run / `--apply` safety for mutations. See `pyproject.toml` and `docs/superpowers/specs/2026-04-24-cfafi-v0.1.0-python-cli-design.md`.
 
 Read each skill's `SKILL.md` for its current script inventory — don't

--- a/cultureflare/__init__.py
+++ b/cultureflare/__init__.py
@@ -8,7 +8,7 @@ from importlib.metadata import PackageNotFoundError, version as _pkg_version
 # version is rewritten to "0.3.0.devN" by the publish workflow) report
 # their actual version here. The legacy `cfafi` wheel (frozen at 0.2.2)
 # is the second-tier fallback for anyone still on the old install.
-__version__ = "0.9.0"
+__version__ = "0.10.0"
 
 try:
     __version__ = _pkg_version("cultureflare")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cultureflare"
-version = "0.9.0"
+version = "0.10.0"
 description = "CloudFlare Agent First Interface — agent-first CLI for CloudFlare management in the AgentCulture org."
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
<h3>PR Summary by Qodo</h3>

Add devague workflow skills (think/spec-to-plan/assign-to-workforce) and bump to 0.10.0
<code>✨ Enhancement</code> <code>📝 Documentation</code> <code>⚙️ Configuration changes</code> <code>🕐 20-40 Minutes</code>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>Walkthroughs</h3>

<details open>
<summary>User Description</summary>

<br/>

## Vendor the devague workflow trio — think / spec-to-plan / assign-to-workforce

Resolves #39.

Adds three **new** agent-facing skills as one coherent operator chain over the
deterministic `devague` CLI (no LLM inside it):

```text
idea ──think──▶ spec ──spec-to-plan──▶ plan ──assign-to-workforce──▶ parallel implementation
```

They are vendored **as a set** — each leg hands off to the next and the
`SKILL.md` descriptions cross-reference one another.

### What each leg does

- **`think`** — idea→spec. Work backwards from the announcement ("pretend it
  shipped"), capture/classify claims, interrogate with honesty conditions, park
  open vagueness, and export a spec only once the frame converges.
- **`spec-to-plan`** — spec→plan (drives `devague plan`). Seed from a converged
  frame, cover every coverage target with acceptance-gated, acyclically-ordered
  tasks, park unknowns as risks, export once the plan converges.
- **`assign-to-workforce`** — implementation. Read `devague plan waves`
  (read-only) and fan out independent tasks to one agent per task per wave in
  isolated git worktrees, with main-agent TDD-gated merges. Three human gates:
  spec / split plan / final PR (the last via the existing `cicd` skill).

### Provenance & divergences

- Vendored from **`guildmaster`** (the mesh re-broadcast point), which carries
  the upstream from **`agentculture/devague`** — tracking devague `0.11.1`
  (`c04b595`, MIT). Follows cultureflare's existing cite-don't-import pattern
  (`cicd`, `communicate`): each skill is self-contained (`SKILL.md` +
  `scripts/<name>.sh`); provenance is recorded inline + in `CLAUDE.md` Layout +
  `CHANGELOG`.
- Each `SKILL.md` carries `type: command` frontmatter (already present in the
  guildmaster copies) — required by the culture/agex `core.skill_loader`,
  harmless on plain `claude-code`.
- **One local divergence:** `assign-to-workforce.sh` gets an inline
  `# shellcheck disable=SC2016` on a `printf` with literal backticks (not a
  subshell), so the repo's `test-bash` shellcheck gate stays green. This mirrors
  the `cicd` skill's documented repo-local hardening kept across re-syncs.

### Testing

- `tests/shellcheck.sh` — clean across all 36 scripts (the 3 new included).
- `tests/markdownlint.sh` — clean (3 new `SKILL.md` + the `CLAUDE.md`/`CHANGELOG`
  edits).
- Existing bats suite — 256 tests pass (unaffected; no `cf-*.sh` touched). Like
  `cicd`/`communicate`, these thin `devague` wrappers add no bats files and the
  suite enforces no script↔test alignment.
- Smoke-tested each `<name>.sh help` path (exit 0; `devague` need not be
  installed to print usage).

### Runtime note (not a build dependency)

Driving the skills needs `uv tool install devague`; `assign-to-workforce` also
uses `git worktree` + the `cicd` skill for its final-PR gate (already present
here).

### Scope

This PR is **#39 only**. Issue #38 (resync the vendored `cicd` skill from
steward) is intentionally out of scope.

Version bumped `0.9.0 → 0.10.0`.

- cultureflare (Claude)

</details>

<details open>
<summary>AI Description</summary>

<br/>

<pre>
• Vendor three new agent-facing skills forming an idea→spec→plan→workforce chain over devague.
• Add portable bash wrappers that resolve devague and forward/format CLI output contracts.
• Document provenance/divergences and bump package version to 0.10.0.
</pre>
</details>

<details>
<summary>Diagram</summary>

<br/>

```mermaid
graph TD
  A1["/think skill"] --> A2(["devague CLI"])
  B1["/spec-to-plan skill"] --> A2 --> B2["Plan artifacts"]
  C1["/assign-to-workforce skill"] --> A2 --> C2["Wave schedule"] --> C3["git worktrees"] --> C4["cicd skill (PR gate)"]
  subgraph Legend
    direction LR
    _skill["Skill wrapper"] ~~~ _cli(["CLI tool"]) ~~~ _git["Git workflow"]
  end
```

</details>




<details>
<summary>High-Level Assessment</summary>

<br/>

The following are alternative approaches to this PR:

<details>
<summary><b>1. Factor out a shared bash helper (resolve_devague/usage patterns)</b></summary>

- ➕ Reduces duplicated resolver logic across the three scripts
- ➕ Makes future updates (e.g., new resolution strategy) one-touch
- ➖ Conflicts with the repo’s “self-contained skill” vendoring style
- ➖ Adds coupling/implicit dependencies between skills

</details>

<details>
<summary><b>2. Provide a single `devague-workflow` orchestrator skill instead of 3 legs</b></summary>

- ➕ Simplifies discovery and reduces handoff friction between legs
- ➕ Centralizes shared policy (human gates, invariants)
- ➖ Loses composability (can’t run only spec→plan, etc.)
- ➖ Harder to vendor/maintain as discrete upstream units

</details>

**Recommendation:** Keep the current 3-skill, self-contained vendoring approach: it matches the “cite, don’t import” policy, keeps each leg independently usable, and preserves clear human gates. If duplication becomes painful, consider a follow-up internal helper only if it can be vendored/stabilized without cross-skill coupling.

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>File Changes</h3>

<details>
<summary><strong>Enhancement</strong> (6)</summary>

<blockquote>
<details>
<summary><strong>SKILL.md</strong> <code>Add assign-to-workforce skill docs (plan waves → split-plan → fan-out)</code> <code>+242/-0</code></summary>

<br/>

>Add assign-to-workforce skill docs (plan waves → split-plan → fan-out)
>
><pre>
>• Introduces the SKILL.md contract for the implementation leg: reads &#x27;devague plan waves&#x27;, requires a human-approved split-plan, and describes TDD-gated merges and final PR gating via cicd. Records provenance and constraints (non-orchestrating devague, three human gates, worktree isolation).
></pre>
>
><a href='https://github.com/agentculture/cultureflare/pull/43/files#diff-7667525c11a5198c24d920faaf4285a1090287335182786e0ed4b1f84dd027fa'>.claude/skills/assign-to-workforce/SKILL.md</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>assign-to-workforce.sh</strong> <code>Add assign-to-workforce wrapper script with split-plan renderer</code> <code>+213/-0</code></summary>

<br/>

>Add assign-to-workforce wrapper script with split-plan renderer
>
><pre>
>• Adds a portable bash entrypoint that resolves the devague CLI (PATH first, uv fallback) and supports &#x27;waves&#x27; passthrough and &#x27;split-plan&#x27; rendering. Implements careful temp-file cleanup and preserves any prior EXIT trap; includes an inline shellcheck suppression for literal backticks in an error hint.
></pre>
>
><a href='https://github.com/agentculture/cultureflare/pull/43/files#diff-29c46ef3fee18c89b47c550793e2cf3ddc6b6154c1ac0ff718983be9403f304e'>.claude/skills/assign-to-workforce/scripts/assign-to-workforce.sh</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>SKILL.md</strong> <code>Add spec-to-plan skill docs (drives &#x27;devague plan&#x27; moves)</code> <code>+230/-0</code></summary>

<br/>

>Add spec-to-plan skill docs (drives &#x27;devague plan&#x27; moves)
>
><pre>
>• Documents the spec→plan workflow, move surface, and convergence/export contracts, including waves as scheduling metadata (not orchestration). Adds guidance for authoring small, file-disjoint, TDD-friendly tasks intended for workforce fan-out.
></pre>
>
><a href='https://github.com/agentculture/cultureflare/pull/43/files#diff-ab73747119d3fa30ee4ac31547ab841c06b0c4d08657cb2a28a0880e66d9d8aa'>.claude/skills/spec-to-plan/SKILL.md</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>spec-to-plan.sh</strong> <code>Add spec-to-plan forwarding wrapper for &#x27;devague plan&#x27;</code> <code>+102/-0</code></summary>

<br/>

>Add spec-to-plan forwarding wrapper for &#x27;devague plan&#x27;
>
><pre>
>• Introduces a minimal bash wrapper that resolves the devague CLI and forwards all arguments to &#x27;devague plan ...&#x27; verbatim. Provides a help surface that enumerates common moves while keeping the CLI as the source of truth.
></pre>
>
><a href='https://github.com/agentculture/cultureflare/pull/43/files#diff-80bd0259d25a888a0b380357db21ffb570532ed41416ead015d11440b4a80926'>.claude/skills/spec-to-plan/scripts/spec-to-plan.sh</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>SKILL.md</strong> <code>Add think skill docs (idea→spec via devague frames)</code> <code>+201/-0</code></summary>

<br/>

>Add think skill docs (idea→spec via devague frames)
>
><pre>
>• Adds the SKILL.md contract for working backwards from an announcement into a converged spec (claims, honesty conditions, parked vagueness). Documents the move surface, hard rules (user-only confirm), output contracts, and handoff to /spec-to-plan.
></pre>
>
><a href='https://github.com/agentculture/cultureflare/pull/43/files#diff-c456dacee3b3d5aa140001cf9ce3f8ff926b6c8d4bec8f00b7c45aba47a99a4f'>.claude/skills/think/SKILL.md</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>think.sh</strong> <code>Add think forwarding wrapper for devague CLI</code> <code>+101/-0</code></summary>

<br/>

>Add think forwarding wrapper for devague CLI
>
><pre>
>• Adds a portable bash wrapper that resolves devague (PATH or uv fallback) and forwards all moves verbatim, including the read-only &#x27;status&#x27; verb. Keeps usage/docs aligned with the deterministic CLI contract.
></pre>
>
><a href='https://github.com/agentculture/cultureflare/pull/43/files#diff-ea7382be29ca7068cb24262d0b9886b403e23f3a921b2c3b6a68844acf8f0298'>.claude/skills/think/scripts/think.sh</a>
<hr/>

</details>
</blockquote>

</details>

<details>
<summary><strong>Documentation</strong> (2)</summary>

<blockquote>
<details>
<summary><strong>CHANGELOG.md</strong> <code>Document 0.10.0 release: devague workflow trio and local shellcheck note</code> <code>+10/-0</code></summary>

<br/>

>Document 0.10.0 release: devague workflow trio and local shellcheck note
>
><pre>
>• Adds a 0.10.0 entry describing the three new skills, provenance, runtime requirements, and the local shellcheck divergence in assign-to-workforce.sh. Dates the release to 2026-06-08 and references resolving #39.
></pre>
>
><a href='https://github.com/agentculture/cultureflare/pull/43/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed'>CHANGELOG.md</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>CLAUDE.md</strong> <code>Add skills inventory entry for think/spec-to-plan/assign-to-workforce</code> <code>+11/-0</code></summary>

<br/>

>Add skills inventory entry for think/spec-to-plan/assign-to-workforce
>
><pre>
>• Updates the repo’s skills listing to include the devague workflow trio, including provenance, required SKILL.md frontmatter, the shellcheck divergence, and runtime notes (uv install, git worktree, cicd gate).
></pre>
>
><a href='https://github.com/agentculture/cultureflare/pull/43/files#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7'>CLAUDE.md</a>
<hr/>

</details>
</blockquote>

</details>

<details>
<summary><strong>Other</strong> (2)</summary>

<blockquote>
<details>
<summary><strong>__init__.py</strong> <code>Bump package version constant to 0.10.0</code> <code>+1/-1</code></summary>

<br/>

>Bump package version constant to 0.10.0
>
><pre>
>• Updates the module’s fallback __version__ string from 0.9.0 to 0.10.0 to match the release.
></pre>
>
><a href='https://github.com/agentculture/cultureflare/pull/43/files#diff-d5edea5ab3ce96174761d5196bed9228ec93ef56f5bbc63958652365b42977f8'>cultureflare/__init__.py</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>pyproject.toml</strong> <code>Bump project version to 0.10.0</code> <code>+1/-1</code></summary>

<br/>

>Bump project version to 0.10.0
>
><pre>
>• Updates the Poetry/PEP 621 project version from 0.9.0 to 0.10.0 to align packaging metadata with the changelog entry.
></pre>
>
><a href='https://github.com/agentculture/cultureflare/pull/43/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711'>pyproject.toml</a>
<hr/>

</details>
</blockquote>

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">


<a href="https://www.qodo.ai"><img src="https://www.qodo.ai/wp-content/uploads/2025/03/qodo-logo.svg" width="80" alt="Qodo Logo"></a>