### PR TITLE
feat(skills): resync cicd from steward 0.22.0 — adopt "Finishing a branch" (#38)

### DIFF
--- a/.claude/skills/cicd/SKILL.md
+++ b/.claude/skills/cicd/SKILL.md
@@ -8,7 +8,7 @@ description: >
   non-zero exit on Sonar ERROR or unresolved threads). Use when:
   creating PRs in cultureflare, handling review feedback, polling CI
   status, or the user says "create PR", "review comments", "address
-  feedback", "resolve threads", "/cicd". Vendored from steward 0.12.0;
+  feedback", "resolve threads", "/cicd". Vendored from steward 0.22.0;
   renamed from `pr-review` in steward 0.7.0; rebased on agex in 0.12.0.
 ---
 
@@ -131,6 +131,17 @@ currently `cultureflare`, since this repo has no `culture.yaml` yet.
 agex auto-appends the signature on `open` and `reply` only when the
 body isn't already signed. Hand-rolled `gh pr create` / `gh issue
 comment` calls should follow the same convention.
+
+## Finishing a branch
+
+When implementation on a branch is complete and tests pass, go straight
+to `workflow.sh open` (push the branch + open the PR). Do **not** stop to
+present a *merge / PR / keep / discard* menu and wait for a choice — in
+AgentCulture the standing default is **always "push and create a Pull
+Request."** This overrides the Superpowers `finishing-a-development-branch`
+skill's interactive menu, which otherwise pauses the flow at the moment
+work is ready to integrate. Merge-locally, keep-as-is, and discard happen
+only when the user explicitly asks for one of them.
 
 ## Triage rules
 

--- a/.claude/skills/cicd/scripts/workflow.sh
+++ b/.claude/skills/cicd/scripts/workflow.sh
@@ -4,7 +4,7 @@ shopt -s inherit_errexit
 
 # cultureflare cicd workflow — thin layer over `agex pr` plus two
 # steward extensions (`status`, `await`) for SonarCloud gating and
-# triage flow. Vendored from steward 0.12.0.
+# triage flow. Vendored from steward 0.22.0.
 #
 # Subcommands:
 #   lint                   `agex pr lint --exit-on-violation`. Same rules

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented here. The format
 is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.1] - 2026-06-08
+
+### Changed
+
+- skills/cicd: resynced from steward 0.22.0 (was 0.12.0). Adopted the new "Finishing a branch" convention (steward 0.18.0): go straight to workflow.sh open instead of stopping on the Superpowers branch-completion menu. Scripts unchanged — cultureflare hardened copies (shopt inherit_errexit, [[ ]] over [ ], sonar_curl timeout/retry, integer ID validation, SONAR_PROJECT_KEY=agentculture_cloudflare, extra portability carve-outs) remain a superset of steward simplified upstream. Deliberately did not pull steward agex-cli-inversion narrative, PyYAML note, or the poll/-dropping Long-waits rewrite. Resolves #38.
+
 ## [0.10.0] - 2026-06-08
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,10 +40,13 @@ Skills under `.claude/skills/`:
 - `cultureflare/` — read-only inventory (zones, DNS, Workers, Pages, status).
 - `cultureflare-write/` — mutations; dry-run by default, `--apply` to commit.
   Carries `templates/` and `references/` (including `cf-api-gotchas.md`).
-- `cicd/` — PR-review workflow (vendored from steward 0.12.0): a thin layer
+- `cicd/` — PR-review workflow (vendored from steward 0.22.0): a thin layer
   over the `agex pr` CLI (`lint` / `open` / `read` / `reply` / `delta`) plus
   two steward extensions, `status` and `await`, for SonarCloud gating.
-  Renamed from `pr-review` to match the AgentCulture standard.
+  Renamed from `pr-review` to match the AgentCulture standard. The 0.22.0
+  resync adopted the "Finishing a branch" convention (go straight to
+  `workflow.sh open` instead of the Superpowers branch-completion menu);
+  cultureflare's script hardening is kept as a documented superset.
 - `communicate/` — cross-repo issue posts / comments / fetches (agtag-backed,
   auto-signed) and Culture mesh channel messages. Vendored from steward 0.12.0.
 - `poll/` — background reviewer-wait subagent (drives `agex pr read --wait`).

--- a/cultureflare/__init__.py
+++ b/cultureflare/__init__.py
@@ -8,7 +8,7 @@ from importlib.metadata import PackageNotFoundError, version as _pkg_version
 # version is rewritten to "0.3.0.devN" by the publish workflow) report
 # their actual version here. The legacy `cfafi` wheel (frozen at 0.2.2)
 # is the second-tier fallback for anyone still on the old install.
-__version__ = "0.10.0"
+__version__ = "0.10.1"
 
 try:
     __version__ = _pkg_version("cultureflare")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cultureflare"
-version = "0.10.0"
+version = "0.10.1"
 description = "CloudFlare Agent First Interface — agent-first CLI for CloudFlare management in the AgentCulture org."
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
<h3>PR Summary by Qodo</h3>

Resync cicd skill docs to steward 0.22.0 and bump to 0.10.1
<code>📝 Documentation</code> <code>⚙️ Configuration changes</code> <code>🕐 10-20 Minutes</code>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>Walkthroughs</h3>

<details open>
<summary>User Description</summary>

<br/>

## Resync vendored `cicd` skill from steward 0.22.0

Resolves #38 (steward's auto-broadcast resync request).

cultureflare's `cicd` was pinned at **steward 0.12.0**; steward is now **0.22.0**.

### Why this is surgical, not a `cp -R`

The issue's recipe is a blind `cp -R ../steward/.claude/skills/cicd` — **that would
be wrong here.** A hunk-by-hunk 3-way compare shows cultureflare's 5 scripts are
already a **strict superset** of steward's. Everything steward changed in the
scripts between 0.12 and 0.22 is steward *removing* hardening for its own thin
agex-cli case:

- `shopt -s inherit_errexit`, `[[ … ]]` over `[ … ]`, `printf '%s'` over `echo`
- the `sonar_curl` timeout/retry/URL-encoding helper in `pr-status.sh`
- integer ID validation in `pr-reply.sh`
- extra portability carve-outs (`~/.claude/projects/`, `~/.config/`)
- the `SONAR_PROJECT_KEY=agentculture_cloudflare` export + `status` arg-forwarding

All of these are the divergences cultureflare's `cicd/SKILL.md` documents as
"kept across re-syncs," so they're preserved. **No script logic changes.**

### What's actually adopted

- **`SKILL.md`: new "Finishing a branch" section** (steward 0.18.0) — when a
  branch is done and tests pass, go straight to `workflow.sh open` (push + PR)
  instead of stopping on the Superpowers branch-completion menu. This is the one
  genuinely-new, repo-agnostic upstream convention.
- **Provenance refreshed to steward 0.22.0** — `SKILL.md` description,
  `workflow.sh` header comment, and the `CLAUDE.md` Layout bullet.

### Deliberately NOT pulled (steward-internal or a regression here)

- steward's "The agex-cli inversion" section + PyYAML/`agent-config` note —
  steward-internal narrative about a sibling consumer cultureflare doesn't vendor.
- steward's "Long waits" rewrite — it drops the `poll/` skill reference;
  cultureflare keeps `poll/` as a first-class skill (steward even credits the
  pattern to cfafi).
- steward dropping the Scripts table / marking its steps "greenfield no-op" —
  false for cultureflare's real shellcheck/bats/markdownlint CI.

### Testing

- `tests/shellcheck.sh` — clean (the `workflow.sh` change is a comment only).
- `tests/markdownlint.sh` — clean (SKILL.md + CHANGELOG + CLAUDE.md).
- `workflow.sh help` / `status` still resolve. No `cf-*.sh` touched.

Patch bump `0.10.0 → 0.10.1` (documentation/convention only).

- cultureflare (Claude)

</details>

<details open>
<summary>AI Description</summary>

<br/>

<pre>
• Update cicd skill provenance to steward 0.22.0 across docs and headers.
• Document the new &quot;Finishing a branch&quot; convention (go straight to <b><i>workflow.sh open</i></b>).
• Bump package version to 0.10.1 and record the change in the changelog.
</pre>
</details>

<details>
<summary>Diagram</summary>

<br/>

```mermaid
graph TD
  Agent["Contributor / Agent"] --> SkillDoc["cicd/SKILL.md"] --> Workflow["workflow.sh"] --> Agex["agex pr CLI"]
  RepoDoc["CLAUDE.md"] --> SkillDoc
  Release["Release bump"] --> PyProj["pyproject.toml"] --> PkgInit["cultureflare/__init__.py"] --> Changelog["CHANGELOG.md"]
```

</details>




<details>
<summary>High-Level Assessment</summary>

<br/>

The following are alternative approaches to this PR:

<details>
<summary><b>1. Track steward skill via git subtree/submodule</b></summary>

- ➕ Makes future resyncs mechanical and auditable (upstream commit history preserved).
- ➕ Reduces manual provenance edits and the risk of missing upstream doc changes.
- ➖ Adds repo management overhead and potential friction when carrying local hardening deltas.
- ➖ May be overkill when only selectively adopting upstream conventions (as here).

</details>

<details>
<summary><b>2. Add a dedicated upstream provenance block (commit SHA + diff policy)</b></summary>

- ➕ Clarifies exactly what &#x27;vendored from X&#x27; means (version + commit) and what is intentionally diverged.
- ➕ Keeps the current surgical approach while improving traceability.
- ➖ Still requires manual updates on each resync.
- ➖ Does not automate keeping content aligned with upstream.

</details>

**Recommendation:** The PR’s surgical approach is appropriate because cultureflare intentionally maintains hardened script behavior that upstream removed; adopting only the repo-agnostic &quot;Finishing a branch&quot; convention while refreshing provenance minimizes risk. For future resyncs, consider at least adding an explicit provenance block (version + upstream commit) to make the selective-vendoring policy easier to audit without forcing a subtree/submodule workflow.

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>File Changes</h3>

<details>
<summary><strong>Documentation</strong> (4)</summary>

<blockquote>
<details>
<summary><strong>SKILL.md</strong> <code>Refresh steward provenance and add &quot;Finishing a branch&quot; guidance</code> <code>+12/-1</code></summary>

<br/>

>Refresh steward provenance and add &quot;Finishing a branch&quot; guidance
>
><pre>
>• Updates the documented vendored-from version to steward 0.22.0. Adds a new section instructing that when work is complete and tests pass, the default is to proceed directly to &#x27;workflow.sh open&#x27; rather than pausing for an interactive branch-finishing menu.
></pre>
>
><a href='https://github.com/agentculture/cultureflare/pull/44/files#diff-965a90e8d137e2cbf0288cc7bf30f9c3e369e933cbba49ccf522f5084b85279a'>.claude/skills/cicd/SKILL.md</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>workflow.sh</strong> <code>Update workflow header provenance comment</code> <code>+1/-1</code></summary>

<br/>

>Update workflow header provenance comment
>
><pre>
>• Changes the header comment to reflect that the script is vendored from steward 0.22.0. No functional changes to workflow behavior or subcommands.
></pre>
>
><a href='https://github.com/agentculture/cultureflare/pull/44/files#diff-847bef201469e3c853c8b44c2d95261a99e6400a46044b8d505680b329bdb3f1'>.claude/skills/cicd/scripts/workflow.sh</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>CHANGELOG.md</strong> <code>Add 0.10.1 release notes for cicd resync and convention change</code> <code>+6/-0</code></summary>

<br/>

>Add 0.10.1 release notes for cicd resync and convention change
>
><pre>
>• Introduces a 0.10.1 entry dated 2026-06-08 describing the steward 0.22.0 resync and the adopted &quot;Finishing a branch&quot; convention, while explicitly noting scripts are unchanged and certain upstream narrative edits were intentionally skipped.
></pre>
>
><a href='https://github.com/agentculture/cultureflare/pull/44/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed'>CHANGELOG.md</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>CLAUDE.md</strong> <code>Update cicd skill listing with resync notes and new convention</code> <code>+5/-2</code></summary>

<br/>

>Update cicd skill listing with resync notes and new convention
>
><pre>
>• Refreshes the stated cicd vendored version to steward 0.22.0. Adds a short note that the resync adopted the &quot;Finishing a branch&quot; convention and that cultureflare keeps a hardened script superset.
></pre>
>
><a href='https://github.com/agentculture/cultureflare/pull/44/files#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7'>CLAUDE.md</a>
<hr/>

</details>
</blockquote>

</details>

<details>
<summary><strong>Other</strong> (2)</summary>

<blockquote>
<details>
<summary><strong>__init__.py</strong> <code>Bump package __version__ to 0.10.1</code> <code>+1/-1</code></summary>

<br/>

>Bump package __version__ to 0.10.1
>
><pre>
>• Updates the package version constant from 0.10.0 to 0.10.1 to match the patch release described in the changelog.
></pre>
>
><a href='https://github.com/agentculture/cultureflare/pull/44/files#diff-d5edea5ab3ce96174761d5196bed9228ec93ef56f5bbc63958652365b42977f8'>cultureflare/__init__.py</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>pyproject.toml</strong> <code>Bump project version to 0.10.1</code> <code>+1/-1</code></summary>

<br/>

>Bump project version to 0.10.1
>
><pre>
>• Updates the project version field from 0.10.0 to 0.10.1 to align packaging metadata with the patch release.
></pre>
>
><a href='https://github.com/agentculture/cultureflare/pull/44/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711'>pyproject.toml</a>
<hr/>

</details>
</blockquote>

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">


<a href="https://www.qodo.ai"><img src="https://www.qodo.ai/wp-content/uploads/2025/03/qodo-logo.svg" width="80" alt="Qodo Logo"></a>