### PR TITLE
feat(remote-login): tunnel-only --no-access mode (#42)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented here. The format
 is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.0] - 2026-06-09
+
+### Added
+
+- `remote-login setup --no-access` — tunnel-only mode: provision a hostname with Tunnel + ingress + DNS only, skipping the Cloudflare Access app / allow-policy / service-token (and the Zero Trust org check), so a backend that authenticates itself (e.g. an OpenAI-style bearer token in front of a local model server) can be exposed. `--allow`/`--allow-domain`/`--with-service-token` are rejected in this mode; the tunnel token still seals to shushu with `--shushu`. Reuses the existing tunnel/DNS/seal machinery — `setup()` gains a `with_access` flag and `SetupResult`'s Access fields default to None/empty. Resolves #42 (cultureflare side; the model-gear local `model tunnel` runner is tracked separately).
+
 ## [0.10.1] - 2026-06-08
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `remote-login setup --no-access` — tunnel-only mode: provision a hostname with Tunnel + ingress + DNS only, skipping the Cloudflare Access app / allow-policy / service-token (and the Zero Trust org check), so a backend that authenticates itself (e.g. an OpenAI-style bearer token in front of a local model server) can be exposed. `--allow`/`--allow-domain`/`--with-service-token` are rejected in this mode; the tunnel token still seals to shushu with `--shushu`. Reuses the existing tunnel/DNS/seal machinery — `setup()` gains a `with_access` flag and `SetupResult`'s Access fields default to None/empty. Resolves #42 (cultureflare side; the model-gear local `model tunnel` runner is tracked separately).
+- `remote-login teardown` now mirrors `show()`'s Zero-Trust guard: when `find_org()` returns None (Zero Trust disabled), it skips the `/access/*` cleanup and proceeds to DNS + tunnel + shushu deletion — so a `--no-access` hostname is removable on accounts without Zero Trust instead of aborting on CF error 9999 (qodo PR #45).
+- README documents the `--no-access` security model: tunnel-only puts no Cloudflare Access gate in front, so the backend **must** enforce its own auth; per-service auth/client docs live with that service, not in this generic tool.
 
 ## [0.10.1] - 2026-06-08
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,10 @@ cultureflare dns create culture.dev TXT _cfafi-test "hello"
 cultureflare dns create culture.dev TXT _cfafi-test "hello" --apply
 
 # Higher-level orchestration
-cultureflare remote-login setup --hostname irc.culture.dev --allow you@example.com --apply
+cultureflare remote-login setup --hostname irc.culture.dev --service http://localhost:8080 --allow you@example.com --apply
+# Tunnel + DNS only (no Cloudflare Access) — the backend service does its own
+# auth, e.g. an OpenAI-style bearer token in front of a local model server:
+cultureflare remote-login setup --hostname api.culture.dev --service http://127.0.0.1:8000 --no-access --apply
 ```
 
 `cfafi <verb>` works identically as a backward-compat alias.
@@ -60,7 +63,7 @@ cultureflare remote-login setup --hostname irc.culture.dev --allow you@example.c
 |---|---|---|---|
 | Zones | ✓ `zones list` | — | All zones in the token's account |
 | DNS records | ✓ via `dns create` lookup | ✓ `dns create` (with `--apply`) | Idempotent; conflict-aware |
-| Cloudflare Access (Zero Trust) | ✓ `remote-login show` | ✓ `remote-login setup` / `teardown` (with `--apply`) | Per-hostname Tunnel + Access app + allow-policy + optional service token |
+| Cloudflare Access (Zero Trust) | ✓ `remote-login show` | ✓ `remote-login setup` / `teardown` (with `--apply`) | Per-hostname Tunnel + Access app + allow-policy + optional service token. `--no-access` provisions Tunnel + DNS only (no Access app) for a backend that authenticates itself |
 | Token verify | ✓ `whoami` | — | Status only (no scope inspection — CF doesn't expose) |
 | Workers scripts / routes | bash skills only | — | Python port pending |
 | Pages projects / deployments | bash skills only | bash `cf-pages-project-create.sh` / `cf-pages-deployments-purge.sh` | Python port pending |
@@ -74,7 +77,8 @@ cultureflare remote-login setup --hostname irc.culture.dev --allow you@example.c
 | `cultureflare whoami` | Verify the configured API token is alive |
 | `cultureflare zones list` | List zones in the token's account |
 | `cultureflare dns create ZONE TYPE NAME CONTENT` | Create a DNS record (dry-run; `--apply` to commit) |
-| `cultureflare remote-login setup --hostname H --allow EMAIL` | Provision the full Tunnel + DNS + Access stack for `H` (dry-run; `--apply` to commit) |
+| `cultureflare remote-login setup --hostname H --service URL --allow EMAIL` | Provision the full Tunnel + DNS + Access stack for `H` (dry-run; `--apply` to commit) |
+| `cultureflare remote-login setup --hostname H --service URL --no-access` | Tunnel + DNS only — no Access app; the backend at `URL` provides its own auth |
 | `cultureflare remote-login show --hostname H` | Inspect what's currently provisioned for `H` |
 | `cultureflare remote-login teardown --hostname H` | Reverse `setup` (dry-run; `--apply` to commit) |
 | `cultureflare learn` | Self-teaching prompt for agents |
@@ -137,7 +141,7 @@ Every mutating verb is **dry-run by default**. Without `--apply`,
 the command:
 
 - Validates inputs (e.g. `--allow user@example.com` is required for
-  `remote-login setup`).
+  `remote-login setup` unless `--no-access` is given).
 - Runs read-side preflight (`whoami`, zone resolution).
 - Prints the plan (or the body it would `POST`) and exits cleanly.
 - Performs no `POST` / `PUT` / `DELETE` against CloudFlare.

--- a/README.md
+++ b/README.md
@@ -57,6 +57,14 @@ cultureflare remote-login setup --hostname api.culture.dev --service http://127.
 
 `cfafi <verb>` works identically as a backward-compat alias.
 
+> **Security — `--no-access`:** tunnel-only mode puts **no Cloudflare Access
+> gate** in front of the hostname; the backend at `--service` is reachable by
+> anyone who resolves the name and **must enforce its own authentication**
+> (e.g. an OpenAI-style bearer token). Exposing an unauthenticated service this
+> way is unsafe for anything but local testing. Per-service auth and
+> client-usage docs (a model server's API key, `/v1` endpoints, SDK examples)
+> live with that service, not in this generic CloudFlare tool.
+
 ## Scope (current)
 
 | Resource | Read | Write | Notes |

--- a/cultureflare/__init__.py
+++ b/cultureflare/__init__.py
@@ -8,7 +8,7 @@ from importlib.metadata import PackageNotFoundError, version as _pkg_version
 # version is rewritten to "0.3.0.devN" by the publish workflow) report
 # their actual version here. The legacy `cfafi` wheel (frozen at 0.2.2)
 # is the second-tier fallback for anyone still on the old install.
-__version__ = "0.10.1"
+__version__ = "0.11.0"
 
 try:
     __version__ = _pkg_version("cultureflare")

--- a/cultureflare/_remote_login/__init__.py
+++ b/cultureflare/_remote_login/__init__.py
@@ -471,6 +471,58 @@ def show(*, ctx: Context, seal: SealPlan | None = None) -> ShowResult:
     )
 
 
+def _teardown_access(*, ctx: Context, steps: list[StepRecord]) -> None:
+    """Delete the Access-side resources (service token, policies, app).
+
+    Guarded on ``find_org``: when Zero Trust is disabled — a tunnel-only
+    (``--no-access``) hostname, or any non-ZT account — the ``/access/*``
+    endpoints return CF 9999, so skip them and let the caller proceed to
+    DNS + tunnel cleanup. ``svc`` is captured before its delete so the
+    service-token policy can still be looked up by token id.
+    """
+    if find_org(account_id=ctx.account_id) is None:
+        return
+    svc = find_service_token(
+        account_id=ctx.account_id, name=ctx.names.service_token_name,
+    )
+    if svc is not None:
+        delete_service_token(account_id=ctx.account_id, token_id=svc["id"])
+        steps.append(StepRecord(
+            name="service-token", action="deleted", detail=f"id={svc['id']}",
+        ))
+    app = find_app(account_id=ctx.account_id, hostname=ctx.hostname)
+    if app is None:
+        return
+    if svc is not None:
+        svc_policy = find_service_token_policy(
+            account_id=ctx.account_id, app_id=app["id"], token_id=svc["id"],
+        )
+        if svc_policy is not None:
+            delete_policy(
+                account_id=ctx.account_id, app_id=app["id"],
+                policy_id=svc_policy["id"],
+            )
+            steps.append(StepRecord(
+                name="service-token-policy", action="deleted",
+                detail=f"id={svc_policy['id']}",
+            ))
+    policy = find_policy(
+        account_id=ctx.account_id, app_id=app["id"],
+        name=ctx.names.policy_name,
+    )
+    if policy is not None:
+        delete_policy(
+            account_id=ctx.account_id, app_id=app["id"], policy_id=policy["id"],
+        )
+        steps.append(StepRecord(
+            name="allow-policy", action="deleted", detail=f"id={policy['id']}",
+        ))
+    delete_app(account_id=ctx.account_id, app_id=app["id"])
+    steps.append(StepRecord(
+        name="access-app", action="deleted", detail=f"id={app['id']}",
+    ))
+
+
 def teardown(
     *,
     ctx: Context,
@@ -488,65 +540,8 @@ def teardown(
         seal = derive_seal_plan(hostname=ctx.hostname, shushu_arg=None)
     steps: list[StepRecord] = []
 
-    # Access-side cleanup (service token, policies, app) only exists when Zero
-    # Trust is enabled. On a tunnel-only (--no-access) hostname — or any account
-    # without Zero Trust — the /access/* endpoints return CF 9999, so guard on
-    # find_org() (as show() does) and skip straight to DNS + tunnel cleanup.
-    svc = None
-    app = None
-    if find_org(account_id=ctx.account_id) is not None:
-        # 1. Service token (captured before delete for the policy lookup below).
-        svc = find_service_token(
-            account_id=ctx.account_id, name=ctx.names.service_token_name,
-        )
-        # 2. Allow-policy + service-token policy + 3. Access app.
-        app = find_app(account_id=ctx.account_id, hostname=ctx.hostname)
-
-    # 1. Service token.
-    if svc is not None:
-        delete_service_token(account_id=ctx.account_id, token_id=svc["id"])
-        steps.append(StepRecord(
-            name="service-token", action="deleted", detail=f"id={svc['id']}",
-        ))
-
-    # 2 + 3. Allow-policy + service-token policy + Access app.
-    if app is not None:
-        # Service-token policy: matched by include[].service_token.token_id.
-        # ``svc`` was captured BEFORE the token delete in step 1, so we
-        # still have the right id to look the policy up by even though
-        # the token itself is gone. Delete-app would cascade-delete any
-        # leftover policy too, but we surface the step explicitly.
-        if svc is not None:
-            svc_policy = find_service_token_policy(
-                account_id=ctx.account_id, app_id=app["id"],
-                token_id=svc["id"],
-            )
-            if svc_policy is not None:
-                delete_policy(
-                    account_id=ctx.account_id, app_id=app["id"],
-                    policy_id=svc_policy["id"],
-                )
-                steps.append(StepRecord(
-                    name="service-token-policy", action="deleted",
-                    detail=f"id={svc_policy['id']}",
-                ))
-        policy = find_policy(
-            account_id=ctx.account_id, app_id=app["id"],
-            name=ctx.names.policy_name,
-        )
-        if policy is not None:
-            delete_policy(
-                account_id=ctx.account_id, app_id=app["id"],
-                policy_id=policy["id"],
-            )
-            steps.append(StepRecord(
-                name="allow-policy", action="deleted",
-                detail=f"id={policy['id']}",
-            ))
-        delete_app(account_id=ctx.account_id, app_id=app["id"])
-        steps.append(StepRecord(
-            name="access-app", action="deleted", detail=f"id={app['id']}",
-        ))
+    # Access-side cleanup (Zero-Trust-guarded; skipped for tunnel-only / non-ZT).
+    _teardown_access(ctx=ctx, steps=steps)
 
     # 4. DNS.
     dns = find_cname(zone_id=ctx.zone_id, hostname=ctx.hostname)

--- a/cultureflare/_remote_login/__init__.py
+++ b/cultureflare/_remote_login/__init__.py
@@ -488,18 +488,28 @@ def teardown(
         seal = derive_seal_plan(hostname=ctx.hostname, shushu_arg=None)
     steps: list[StepRecord] = []
 
+    # Access-side cleanup (service token, policies, app) only exists when Zero
+    # Trust is enabled. On a tunnel-only (--no-access) hostname — or any account
+    # without Zero Trust — the /access/* endpoints return CF 9999, so guard on
+    # find_org() (as show() does) and skip straight to DNS + tunnel cleanup.
+    svc = None
+    app = None
+    if find_org(account_id=ctx.account_id) is not None:
+        # 1. Service token (captured before delete for the policy lookup below).
+        svc = find_service_token(
+            account_id=ctx.account_id, name=ctx.names.service_token_name,
+        )
+        # 2. Allow-policy + service-token policy + 3. Access app.
+        app = find_app(account_id=ctx.account_id, hostname=ctx.hostname)
+
     # 1. Service token.
-    svc = find_service_token(
-        account_id=ctx.account_id, name=ctx.names.service_token_name,
-    )
     if svc is not None:
         delete_service_token(account_id=ctx.account_id, token_id=svc["id"])
         steps.append(StepRecord(
             name="service-token", action="deleted", detail=f"id={svc['id']}",
         ))
 
-    # 2. Allow-policy + service-token policy + 3. Access app.
-    app = find_app(account_id=ctx.account_id, hostname=ctx.hostname)
+    # 2 + 3. Allow-policy + service-token policy + Access app.
     if app is not None:
         # Service-token policy: matched by include[].service_token.token_id.
         # ``svc`` was captured BEFORE the token delete in step 1, so we

--- a/cultureflare/_remote_login/__init__.py
+++ b/cultureflare/_remote_login/__init__.py
@@ -227,6 +227,7 @@ def setup(
     domains: list[str],
     with_service_token: bool,
     session_duration: str,
+    with_access: bool = True,
     seal: SealPlan | None = None,
 ) -> SetupResult:
     """Run the full setup against the live CF API.
@@ -234,6 +235,12 @@ def setup(
     v1 assumes Zero Trust is already enabled on the account; if absent,
     we surface a clear error rather than auto-onboard (onboarding needs
     an auth_domain we don't have at this layer).
+
+    ``with_access=False`` is the tunnel-only mode: create just the tunnel,
+    its ingress route, and the DNS CNAME (plus the optional tunnel-token
+    seal), skipping the Zero Trust org check, the Access app, the
+    allow-policy, and any service token. The upstream service is then
+    responsible for its own auth (e.g. an OpenAI-style bearer token).
     """
     if seal is None:
         seal = derive_seal_plan(hostname=ctx.hostname, shushu_arg=None)
@@ -249,23 +256,27 @@ def setup(
         )
     steps: list[StepRecord] = []
 
-    # 1. Zero Trust org — verified, never created here.
-    org = find_org(account_id=ctx.account_id)
-    if org is None:
-        raise CfafiError(
-            code=EXIT_USER_ERROR,
-            message="Zero Trust is not enabled for this account",
-            remediation=(
-                "enable Zero Trust at "
-                "https://one.dash.cloudflare.com/?to=/:account/access "
-                "(pick a team subdomain), then re-run setup"
-            ),
-        )
-    team_domain = org.get("auth_domain")
-    steps.append(StepRecord(
-        name="zero-trust-org", action="ensured",
-        detail=f"existing auth_domain={team_domain}",
-    ))
+    # 1. Zero Trust org — verified, never created here. Access-only.
+    team_domain: str | None = None
+    if with_access:
+        org = find_org(account_id=ctx.account_id)
+        if org is None:
+            raise CfafiError(
+                code=EXIT_USER_ERROR,
+                message="Zero Trust is not enabled for this account",
+                remediation=(
+                    "enable Zero Trust at "
+                    "https://one.dash.cloudflare.com/?to=/:account/access "
+                    "(pick a team subdomain), then re-run setup — or pass "
+                    "--no-access for a tunnel-only hostname whose backend "
+                    "service handles its own auth"
+                ),
+            )
+        team_domain = org.get("auth_domain")
+        steps.append(StepRecord(
+            name="zero-trust-org", action="ensured",
+            detail=f"existing auth_domain={team_domain}",
+        ))
 
     # 2. Tunnel.
     tunnel_id, tunnel_created = ensure_tunnel(
@@ -304,34 +315,47 @@ def setup(
         detail=f"CNAME {ctx.hostname} → {dns_target}",
     ))
 
-    # 4. Access app.
-    app_id, app_created = ensure_app(
-        account_id=ctx.account_id,
-        hostname=ctx.hostname,
-        app_name=ctx.names.app_name,
-        session_duration=session_duration,
-    )
-    steps.append(StepRecord(
-        name="access-app", action=_action(app_created), detail=f"id={app_id}",
-    ))
+    # Steps 4–6 are Access-only. In tunnel-only mode the public hostname
+    # reaches the backend through the tunnel and the backend authenticates.
+    app_id: str | None = None
+    policy_id: str | None = None
+    svc_cid: str | None = None
+    svc_secret: str | None = None
+    svc_policy_id: str | None = None
+    if with_access:
+        # 4. Access app.
+        app_id, app_created = ensure_app(
+            account_id=ctx.account_id,
+            hostname=ctx.hostname,
+            app_name=ctx.names.app_name,
+            session_duration=session_duration,
+        )
+        steps.append(StepRecord(
+            name="access-app", action=_action(app_created), detail=f"id={app_id}",
+        ))
 
-    # 5. Allow-policy.
-    policy_id, policy_created = ensure_allow_policy(
-        account_id=ctx.account_id, app_id=app_id,
-        name=ctx.names.policy_name,
-        emails=emails, domains=domains,
-    )
-    steps.append(StepRecord(
-        name="allow-policy", action=_action(policy_created),
-        detail=f"id={policy_id}",
-    ))
+        # 5. Allow-policy.
+        policy_id, policy_created = ensure_allow_policy(
+            account_id=ctx.account_id, app_id=app_id,
+            name=ctx.names.policy_name,
+            emails=emails, domains=domains,
+        )
+        steps.append(StepRecord(
+            name="allow-policy", action=_action(policy_created),
+            detail=f"id={policy_id}",
+        ))
 
-    # 6. Service token + non_identity policy (optional, paired).
-    svc_cid, svc_secret, svc_policy_id = _ensure_service_token_step(
-        ctx=ctx, app_id=app_id,
-        with_service_token=with_service_token,
-        steps=steps,
-    )
+        # 6. Service token + non_identity policy (optional, paired).
+        svc_cid, svc_secret, svc_policy_id = _ensure_service_token_step(
+            ctx=ctx, app_id=app_id,
+            with_service_token=with_service_token,
+            steps=steps,
+        )
+    else:
+        steps.append(StepRecord(
+            name="access", action="skipped",
+            detail="tunnel-only (--no-access); backend service handles auth",
+        ))
 
     sealed_in: dict[str, str] = {}
     if seal.enabled:
@@ -356,8 +380,8 @@ def setup(
         dns_target=dns_target,
         access_app_id=app_id,
         policy_id=policy_id,
-        policy_emails=list(emails),
-        policy_domains=list(domains),
+        policy_emails=list(emails) if with_access else [],
+        policy_domains=list(domains) if with_access else [],
         service_token_client_id=svc_cid,
         service_token_client_secret=svc_secret,
         service_token_policy_id=svc_policy_id,

--- a/cultureflare/_remote_login/_common.py
+++ b/cultureflare/_remote_login/_common.py
@@ -66,13 +66,16 @@ class SetupResult:
     tunnel_token: str | None
     dns_record_id: str
     dns_target: str
-    access_app_id: str
-    policy_id: str
-    policy_emails: list[str]
-    policy_domains: list[str]
-    service_token_client_id: str | None
-    service_token_client_secret: str | None
-    steps: list[StepRecord]
+    # Access fields are None / empty in tunnel-only (--no-access) mode, where
+    # the upstream service provides its own auth. They are defaulted so a
+    # tunnel-only result is valid; full setup always passes them by keyword.
+    access_app_id: str | None = None
+    policy_id: str | None = None
+    policy_emails: list[str] = field(default_factory=list)
+    policy_domains: list[str] = field(default_factory=list)
+    service_token_client_id: str | None = None
+    service_token_client_secret: str | None = None
+    steps: list[StepRecord] = field(default_factory=list)
     sealed_in: dict[str, str] = field(default_factory=dict)
     # Added in #28: tunnel ingress route + non_identity service-token policy.
     # Defaulted to None so older test fixtures keep compiling.

--- a/cultureflare/_remote_login/_render.py
+++ b/cultureflare/_remote_login/_render.py
@@ -30,29 +30,38 @@ def render_setup_markdown(result: SetupResult, *, hostname: str) -> str:
     lines.append(
         f"- **DNS:** CNAME {hostname} → {result.dns_target} (proxied)"
     )
-    lines.append(f"- **ACCESS_APP_ID:** {result.access_app_id}")
-    policy_bits = []
-    if result.policy_emails:
-        policy_bits.append(f"allow [{', '.join(result.policy_emails)}]")
-    if result.policy_domains:
-        policy_bits.append(f"allow-domain [{', '.join(result.policy_domains)}]")
-    lines.append(f"- **POLICY:** {'; '.join(policy_bits)}")
-    if result.service_token_client_id is not None:
+    if result.access_app_id is None:
         lines.append(
-            f"- **SERVICE_TOKEN_CLIENT_ID:** {result.service_token_client_id}"
+            "- **ACCESS:** (none — tunnel-only; the backend service provides "
+            "its own auth)"
         )
-        if (
-            "service_token_client_secret" in result.sealed_in
-            or result.service_token_client_secret is not None
-        ):
+    else:
+        lines.append(f"- **ACCESS_APP_ID:** {result.access_app_id}")
+        policy_bits = []
+        if result.policy_emails:
+            policy_bits.append(f"allow [{', '.join(result.policy_emails)}]")
+        if result.policy_domains:
+            policy_bits.append(f"allow-domain [{', '.join(result.policy_domains)}]")
+        lines.append(f"- **POLICY:** {'; '.join(policy_bits)}")
+        if result.service_token_client_id is not None:
             lines.append(
-                f"- **SERVICE_TOKEN_CLIENT_SECRET:** "
-                f"{_seal_or_value(result, 'service_token_client_secret', result.service_token_client_secret)}"
+                f"- **SERVICE_TOKEN_CLIENT_ID:** {result.service_token_client_id}"
             )
-        if result.service_token_policy_id is not None:
-            lines.append(
-                f"- **SERVICE_TOKEN_POLICY_ID:** {result.service_token_policy_id}"
-            )
+            if (
+                "service_token_client_secret" in result.sealed_in
+                or result.service_token_client_secret is not None
+            ):
+                secret_display = _seal_or_value(
+                    result, "service_token_client_secret",
+                    result.service_token_client_secret,
+                )
+                lines.append(
+                    f"- **SERVICE_TOKEN_CLIENT_SECRET:** {secret_display}"
+                )
+            if result.service_token_policy_id is not None:
+                lines.append(
+                    f"- **SERVICE_TOKEN_POLICY_ID:** {result.service_token_policy_id}"
+                )
     lines.append("")
     lines.append("## Steps")
     for i, step in enumerate(result.steps, start=1):
@@ -102,6 +111,7 @@ def render_setup_dryrun_markdown(
     domains: list[str],
     with_service_token: bool,
     session_duration: str,
+    no_access: bool = False,
     seal_user: str | None = None,
     seal_tunnel_name: str | None = None,
     seal_svc_name: str | None = None,
@@ -117,7 +127,10 @@ def render_setup_dryrun_markdown(
         step += 1
         return step
 
-    lines.append(f"{_step()}. ensure Zero Trust org (existing required for v1)")
+    if not no_access:
+        lines.append(
+            f"{_step()}. ensure Zero Trust org (existing required for v1)"
+        )
     lines.append(f"{_step()}. ensure tunnel `{tunnel_name}`")
     lines.append(
         f"{_step()}. ensure tunnel ingress {hostname} → {service}"
@@ -126,27 +139,35 @@ def render_setup_dryrun_markdown(
         f"{_step()}. ensure DNS CNAME {hostname} → "
         "<tunnel_id>.cfargotunnel.com (proxied)"
     )
-    lines.append(
-        f"{_step()}. ensure Access app `{app_name}` "
-        f"(session_duration={session_duration})"
-    )
-    policy_parts: list[str] = []
-    if emails:
-        policy_parts.append(f"allow [{', '.join(emails)}]")
-    if domains:
-        policy_parts.append(f"allow-domain [{', '.join(domains)}]")
-    lines.append(f"{_step()}. ensure allow-policy ({'; '.join(policy_parts)})")
-    if with_service_token:
-        lines.append(f"{_step()}. ensure service-token (one-shot secret)")
+    if no_access:
         lines.append(
-            f"{_step()}. ensure non_identity service-token policy admitting it"
+            f"{_step()}. skip Cloudflare Access — tunnel-only; the backend "
+            "service handles its own auth"
         )
+    else:
+        lines.append(
+            f"{_step()}. ensure Access app `{app_name}` "
+            f"(session_duration={session_duration})"
+        )
+        policy_parts: list[str] = []
+        if emails:
+            policy_parts.append(f"allow [{', '.join(emails)}]")
+        if domains:
+            policy_parts.append(f"allow-domain [{', '.join(domains)}]")
+        lines.append(
+            f"{_step()}. ensure allow-policy ({'; '.join(policy_parts)})"
+        )
+        if with_service_token:
+            lines.append(f"{_step()}. ensure service-token (one-shot secret)")
+            lines.append(
+                f"{_step()}. ensure non_identity service-token policy admitting it"
+            )
     if seal_tunnel_name is not None:
         u = seal_user or "<self>"
         lines.append(
             f"{_step()}. seal tunnel_token into shushu/{u}/{seal_tunnel_name}"
         )
-        if with_service_token and seal_svc_name is not None:
+        if with_service_token and not no_access and seal_svc_name is not None:
             lines.append(
                 f"{_step()}. seal service-token client_secret into "
                 f"shushu/{u}/{seal_svc_name}"

--- a/cultureflare/_remote_login/_render.py
+++ b/cultureflare/_remote_login/_render.py
@@ -13,6 +13,41 @@ def _seal_or_value(result: SetupResult, key: str, fallback: str | None) -> str:
     return str(fallback) if fallback is not None else "(none)"
 
 
+def _render_setup_access_lines(result: SetupResult) -> list[str]:
+    """Render the Access section of a setup result (empty-shaped in tunnel-only)."""
+    if result.access_app_id is None:
+        return [
+            "- **ACCESS:** (none — tunnel-only; the backend service provides "
+            "its own auth)"
+        ]
+    lines = [f"- **ACCESS_APP_ID:** {result.access_app_id}"]
+    policy_bits = []
+    if result.policy_emails:
+        policy_bits.append(f"allow [{', '.join(result.policy_emails)}]")
+    if result.policy_domains:
+        policy_bits.append(f"allow-domain [{', '.join(result.policy_domains)}]")
+    lines.append(f"- **POLICY:** {'; '.join(policy_bits)}")
+    if result.service_token_client_id is None:
+        return lines
+    lines.append(
+        f"- **SERVICE_TOKEN_CLIENT_ID:** {result.service_token_client_id}"
+    )
+    if (
+        "service_token_client_secret" in result.sealed_in
+        or result.service_token_client_secret is not None
+    ):
+        secret_display = _seal_or_value(
+            result, "service_token_client_secret",
+            result.service_token_client_secret,
+        )
+        lines.append(f"- **SERVICE_TOKEN_CLIENT_SECRET:** {secret_display}")
+    if result.service_token_policy_id is not None:
+        lines.append(
+            f"- **SERVICE_TOKEN_POLICY_ID:** {result.service_token_policy_id}"
+        )
+    return lines
+
+
 def render_setup_markdown(result: SetupResult, *, hostname: str) -> str:
     lines: list[str] = []
     lines.append(f"## Remote login set up — {hostname}")
@@ -30,38 +65,7 @@ def render_setup_markdown(result: SetupResult, *, hostname: str) -> str:
     lines.append(
         f"- **DNS:** CNAME {hostname} → {result.dns_target} (proxied)"
     )
-    if result.access_app_id is None:
-        lines.append(
-            "- **ACCESS:** (none — tunnel-only; the backend service provides "
-            "its own auth)"
-        )
-    else:
-        lines.append(f"- **ACCESS_APP_ID:** {result.access_app_id}")
-        policy_bits = []
-        if result.policy_emails:
-            policy_bits.append(f"allow [{', '.join(result.policy_emails)}]")
-        if result.policy_domains:
-            policy_bits.append(f"allow-domain [{', '.join(result.policy_domains)}]")
-        lines.append(f"- **POLICY:** {'; '.join(policy_bits)}")
-        if result.service_token_client_id is not None:
-            lines.append(
-                f"- **SERVICE_TOKEN_CLIENT_ID:** {result.service_token_client_id}"
-            )
-            if (
-                "service_token_client_secret" in result.sealed_in
-                or result.service_token_client_secret is not None
-            ):
-                secret_display = _seal_or_value(
-                    result, "service_token_client_secret",
-                    result.service_token_client_secret,
-                )
-                lines.append(
-                    f"- **SERVICE_TOKEN_CLIENT_SECRET:** {secret_display}"
-                )
-            if result.service_token_policy_id is not None:
-                lines.append(
-                    f"- **SERVICE_TOKEN_POLICY_ID:** {result.service_token_policy_id}"
-                )
+    lines.extend(_render_setup_access_lines(result))
     lines.append("")
     lines.append("## Steps")
     for i, step in enumerate(result.steps, start=1):

--- a/cultureflare/cli/_commands/remote_login.py
+++ b/cultureflare/cli/_commands/remote_login.py
@@ -92,6 +92,7 @@ def _emit_setup_dryrun(
             "service": args.service,
             "with_service_token": args.with_service_token,
             "session_duration": args.session_duration,
+            "no_access": args.no_access,
             "emails": list(args.allow),
             "domains": list(args.allow_domain),
         }
@@ -121,6 +122,7 @@ def _emit_setup_dryrun(
                 domains=list(args.allow_domain),
                 with_service_token=args.with_service_token,
                 session_duration=args.session_duration,
+                no_access=args.no_access,
                 seal_user=seal.user if seal.enabled else None,
                 seal_tunnel_name=seal.tunnel_token_target.name if seal.enabled else None,
                 seal_svc_name=seal.service_token_secret_target.name if seal.enabled else None,
@@ -140,6 +142,7 @@ def _emit_setup_apply(
         domains=list(args.allow_domain),
         with_service_token=args.with_service_token,
         session_duration=args.session_duration,
+        with_access=not args.no_access,
         seal=seal,
     )
     if json_mode:
@@ -152,11 +155,31 @@ def _emit_setup_apply(
 
 
 def cmd_setup(args: argparse.Namespace) -> None:
-    if not args.allow and not args.allow_domain:
+    # Normalize the optional flag so hand-built namespaces (and the dry-run /
+    # apply emitters below, which read it off the same args) stay valid.
+    args.no_access = getattr(args, "no_access", False)
+    if args.no_access:
+        if args.allow or args.allow_domain or args.with_service_token:
+            raise CfafiError(
+                code=EXIT_USER_ERROR,
+                message=(
+                    "--no-access cannot be combined with "
+                    "--allow / --allow-domain / --with-service-token"
+                ),
+                remediation=(
+                    "--no-access skips the Cloudflare Access app entirely; "
+                    "drop those flags (the backend service does its own auth)"
+                ),
+            )
+    elif not args.allow and not args.allow_domain:
         raise CfafiError(
             code=EXIT_USER_ERROR,
             message="at least one of --allow / --allow-domain is required",
-            remediation="pass --allow user@example.com or --allow-domain @example.com",
+            remediation=(
+                "pass --allow user@example.com or --allow-domain @example.com "
+                "— or --no-access for a tunnel-only hostname whose backend "
+                "handles its own auth"
+            ),
         )
     args.service = _validate_service_url(args.service)
     check_token_alive()
@@ -235,6 +258,15 @@ def register(sub: argparse._SubParsersAction) -> None:
     s.add_argument(
         "--allow-domain", action="append", default=[],
         help="Email-domain to allow, e.g. @example.com (repeatable).",
+    )
+    s.add_argument(
+        "--no-access", action="store_true",
+        help=(
+            "Tunnel + DNS only: skip the Cloudflare Access app/policy so the "
+            "backend service provides its own auth (e.g. an OpenAI-style "
+            "bearer token). --allow/--allow-domain/--with-service-token are "
+            "not used in this mode."
+        ),
     )
     s.add_argument(
         "--service", required=True,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cultureflare"
-version = "0.10.1"
+version = "0.11.0"
 description = "CloudFlare Agent First Interface — agent-first CLI for CloudFlare management in the AgentCulture org."
 readme = "README.md"
 license = "MIT"

--- a/tests/test_cli_remote_login.py
+++ b/tests/test_cli_remote_login.py
@@ -64,6 +64,39 @@ def test_setup_requires_at_least_one_allow(http_stub, capsys):
     assert rc != 0
 
 
+def test_setup_no_access_dry_run_skips_access_and_needs_no_allow(http_stub, capsys):
+    # --no-access: tunnel + DNS only; --allow is not required and the plan
+    # explicitly skips Cloudflare Access.
+    http_stub.set("GET", "/user/tokens/verify", _verify_alive())
+    http_stub.set("GET", "/zones", _zones_one())
+    rc = main([
+        "remote-login", "setup",
+        "--hostname", "vllm.culture.dev",
+        "--service", "http://127.0.0.1:8000",
+        "--no-access",
+    ])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "Dry-run" in out
+    assert "skip Cloudflare Access" in out
+    assert "Zero Trust org" not in out
+    assert "allow-policy" not in out
+    assert [c for c in http_stub.calls if c[0] == "POST"] == []
+
+
+def test_setup_no_access_rejects_allow_flags(http_stub, capsys):
+    rc = main([
+        "remote-login", "setup",
+        "--hostname", "vllm.culture.dev",
+        "--service", "http://127.0.0.1:8000",
+        "--no-access",
+        "--allow", "me@example.com",
+    ])
+    err = capsys.readouterr().err
+    assert rc != 0
+    assert "no-access" in err
+
+
 def test_setup_requires_service(http_stub, capsys):
     # argparse raises SystemExit at parse time; the structured error
     # message still goes to stderr via _CfafiArgumentParser.error().

--- a/tests/test_remote_login_orchestrator.py
+++ b/tests/test_remote_login_orchestrator.py
@@ -386,6 +386,7 @@ def _program_teardown_happy_path(
     svc_name = f"{hostname}-svc"
     policy_name = f"{hostname}-allow"
 
+    http_stub.set("GET", f"/accounts/{account_id}/access/organizations", _zt_existing())
     http_stub.set(
         "GET", f"/accounts/{account_id}/access/service_tokens",
         _list_envelope({"id": svc_id, "name": svc_name, "client_id": "CID"}),
@@ -457,12 +458,51 @@ def test_teardown_reverses_setup_skipping_zt_org(http_stub):
 
 
 def test_teardown_keep_tunnel_skips_tunnel_delete(http_stub):
+    http_stub.set("GET", "/accounts/acc-1/access/organizations", _zt_existing())
     http_stub.set("GET", "/accounts/acc-1/access/service_tokens", _empty_list())
     http_stub.set("GET", "/accounts/acc-1/access/apps", _empty_list())
     http_stub.set("GET", "/zones/zid-1/dns_records", _empty_list())
     # tunnel listing is skipped entirely under keep_tunnel
     result = teardown(ctx=_ctx(), keep_tunnel=True)
     assert "tunnel" not in [s.name for s in result.steps]
+
+
+def test_teardown_no_access_skips_access_when_zt_disabled(http_stub):
+    # Bug fix (qodo PR #45): a --no-access hostname has no Access resources;
+    # on an account without Zero Trust, find_org() returns None (CF 9999) and
+    # teardown must skip /access/* entirely while still deleting DNS + tunnel.
+    http_stub.set(
+        "GET", "/accounts/acc-1/access/organizations",
+        CfafiError(
+            code=EXIT_API,
+            message="CloudFlare API 9999: access.api.error.not_enabled: ...",
+            remediation="...",
+            cf_error_code=9999,
+        ),
+    )
+    http_stub.set(
+        "GET", "/zones/zid-1/dns_records",
+        _list_envelope({
+            "id": "rec-1", "type": "CNAME", "name": "irc.culture.dev",
+            "content": "tun-1.cfargotunnel.com", "proxied": True,
+        }),
+    )
+    http_stub.set("DELETE", "/zones/zid-1/dns_records/rec-1",
+                  {"success": True, "errors": [], "messages": [],
+                   "result": {"id": "rec-1"}})
+    http_stub.set(
+        "GET", "/accounts/acc-1/cfd_tunnel",
+        _list_envelope({"id": "tun-1", "name": "irc-culture-dev"}),
+    )
+    http_stub.set("DELETE", "/accounts/acc-1/cfd_tunnel/tun-1",
+                  {"success": True, "errors": [], "messages": [],
+                   "result": {"id": "tun-1"}})
+
+    result = teardown(ctx=_ctx(), keep_tunnel=False)
+    assert [s.name for s in result.steps] == ["dns", "tunnel"]
+    paths = [c[1] for c in http_stub.calls]
+    assert "/accounts/acc-1/access/service_tokens" not in paths
+    assert "/accounts/acc-1/access/apps" not in paths
 
 
 def test_setup_raises_clean_error_when_zt_not_enabled(http_stub):

--- a/tests/test_remote_login_orchestrator.py
+++ b/tests/test_remote_login_orchestrator.py
@@ -227,6 +227,66 @@ def test_setup_skips_service_token_step_when_not_requested(http_stub):
     assert "/accounts/acc-1/access/service_tokens" not in paths
 
 
+def test_setup_no_access_creates_tunnel_dns_only(http_stub):
+    # Tunnel-only mode (--no-access): no Zero Trust org check, no Access
+    # app/policy, no service token. Only the tunnel + ingress + DNS endpoints
+    # are programmed — any Access call would hit an unprogrammed stub and fail.
+    http_stub.set("GET", "/accounts/acc-1/cfd_tunnel", _empty_list())
+    http_stub.set("POST", "/accounts/acc-1/cfd_tunnel", {
+        "success": True, "errors": [], "messages": [], "result": {"id": "tun-1"},
+    })
+    http_stub.set(
+        "GET", "/accounts/acc-1/cfd_tunnel/tun-1/token",
+        {"success": True, "errors": [], "messages": [], "result": "TUN-TOK"},
+    )
+    http_stub.set(
+        "GET", "/accounts/acc-1/cfd_tunnel/tun-1/configurations",
+        {"success": True, "errors": [], "messages": [],
+         "result": {"config": {"ingress": []}}},
+    )
+    http_stub.set(
+        "PUT", "/accounts/acc-1/cfd_tunnel/tun-1/configurations",
+        {"success": True, "errors": [], "messages": [],
+         "result": {"config": {"ingress": [
+             {"hostname": "vllm.culture.dev", "service": "http://127.0.0.1:8000"},
+             {"service": "http_status:404"},
+         ]}}},
+    )
+    http_stub.set("GET", "/zones/zid-1/dns_records", _empty_list())
+    http_stub.set("POST", "/zones/zid-1/dns_records",
+                  {"success": True, "errors": [], "messages": [],
+                   "result": {"id": "rec-1"}})
+
+    ctx = Context(
+        account_id="acc-1", zone_id="zid-1", hostname="vllm.culture.dev",
+        names=derive_names(hostname="vllm.culture.dev"),
+        service="http://127.0.0.1:8000",
+    )
+    result = setup(
+        ctx=ctx, emails=[], domains=[],
+        with_service_token=False, session_duration="24h",
+        with_access=False,
+    )
+    assert result.tunnel_id == "tun-1"
+    assert result.tunnel_token == "TUN-TOK"
+    assert result.dns_record_id == "rec-1"
+    assert result.tunnel_service == "http://127.0.0.1:8000"
+    # No Access resources were created.
+    assert result.team_domain is None
+    assert result.access_app_id is None
+    assert result.policy_id is None
+    assert result.policy_emails == []
+    assert result.policy_domains == []
+    assert result.service_token_client_id is None
+    assert result.service_token_policy_id is None
+    assert [s.name for s in result.steps] == [
+        "tunnel", "tunnel-config", "dns", "access",
+    ]
+    assert result.steps[-1].action == "skipped"
+    # Not a single Access API path was touched.
+    assert not any("/access/" in c[1] for c in http_stub.calls)
+
+
 def _program_show_happy_path(
     http_stub,
     *,

--- a/tests/test_remote_login_render.py
+++ b/tests/test_remote_login_render.py
@@ -56,6 +56,32 @@ def test_render_setup_markdown_omits_service_token_when_absent():
     assert "**SERVICE_TOKEN_CLIENT_SECRET:**" not in md
 
 
+def test_render_setup_markdown_tunnel_only_shows_no_access():
+    # --no-access result: Access fields default to None/empty; the markdown
+    # renders the tunnel-only marker and omits Access / policy / service-token.
+    result = SetupResult(
+        team_domain=None,
+        tunnel_id="tun-1", tunnel_name="vllm-culture-dev",
+        tunnel_token="TUN-TOK",
+        dns_record_id="rec-1",
+        dns_target="tun-1.cfargotunnel.com",
+        tunnel_service="http://127.0.0.1:8000",
+        steps=[
+            StepRecord("tunnel", "ensured", "vllm-culture-dev"),
+            StepRecord("tunnel-config", "ensured", "ingress"),
+            StepRecord("dns", "ensured", "CNAME"),
+            StepRecord("access", "skipped", "tunnel-only"),
+        ],
+    )
+    md = render_setup_markdown(result, hostname="vllm.culture.dev")
+    assert "**ACCESS:**" in md
+    assert "tunnel-only" in md
+    assert "**TUNNEL_INGRESS:**" in md
+    assert "**ACCESS_APP_ID:**" not in md
+    assert "**POLICY:**" not in md
+    assert "**SERVICE_TOKEN_CLIENT_ID:**" not in md
+
+
 def test_render_setup_json_envelope_shape():
     env = render_setup_json(_setup_fixture(), hostname="irc.culture.dev")
     assert env["success"] is True


### PR DESCRIPTION
<h3>PR Summary by Qodo</h3>

Add tunnel-only `remote-login setup --no-access` mode
<code>✨ Enhancement</code> <code>🧪 Tests</code> <code>📝 Documentation</code> <code>⚙️ Configuration changes</code> <code>🕐 40+ Minutes</code>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>Walkthroughs</h3>

<details open>
<summary>User Description</summary>

<br/>

## remote-login: tunnel-only `--no-access` mode

Resolves #42 (cultureflare side).

Issue #42 wants a local OpenAI-compatible vLLM server exposed at an
owner-selected hostname on culture.dev, callable from anywhere with a plain
bearer token — **no Cloudflare Access in front**. cultureflare's `remote-login`
already does tunnel + ingress + DNS + shushu-sealed token; the only gap was that
`setup` **forced** a Cloudflare Access app. This adds a tunnel-only mode and
reuses everything else.

### What changed

- `setup(..., with_access=True)` — the Zero-Trust-org check and the Access app /
  allow-policy / service-token steps are guarded behind the flag. With
  `--no-access` only the tunnel, its ingress route, the DNS CNAME, and the
  optional tunnel-token seal run.
- `SetupResult`'s Access fields (`access_app_id`, `policy_id`, `policy_emails`,
  `policy_domains`, service-token fields) default to `None`/`[]` so a tunnel-only
  result is valid; the tunnel/DNS/ingress core is unchanged.
- CLI `--no-access`: `--allow` / `--allow-domain` / `--with-service-token` are
  rejected in this mode (the backend authenticates itself); the dry-run plan and
  the apply-path markdown render the tunnel-only shape.

### Dry-run output

```text
$ cultureflare remote-login setup --hostname vllm.culture.dev \
    --service http://127.0.0.1:8000 --no-access
**Dry-run — no changes applied**

## Plan for vllm.culture.dev
1. ensure tunnel `vllm-culture-dev`
2. ensure tunnel ingress vllm.culture.dev -> http://127.0.0.1:8000
3. ensure DNS CNAME vllm.culture.dev -> <tunnel_id>.cfargotunnel.com (proxied)
4. skip Cloudflare Access - tunnel-only; the backend service handles its own auth

Pass --apply to commit.
```

### Tests

235 pass. New coverage: orchestrator asserts **no** Access API path is touched
and the result has `access_app_id is None`; CLI asserts `--no-access` needs no
`--allow` and rejects the incompatible flags; render asserts the tunnel-only
markdown branch.

### Scope

This is the cultureflare half of #42. The local `model tunnel` runner (serve
vLLM with bearer auth + run `cloudflared`) is handed off as a separate issue on
`agentculture/model-gear`. Live `vllm.culture.dev` provisioning happens after,
owner-driven (`setup --no-access --shushu --apply`).

- cultureflare (Claude)

</details>

<details open>
<summary>AI Description</summary>

<br/>

<pre>
• Add <b><i>--no-access</i></b> to provision Tunnel + ingress + DNS without Cloudflare Access.
• Make <b><i>setup()</i></b> and <b><i>SetupResult</i></b> support Access-optional results and rendering.
• Add CLI validation, dry-run/apply output updates, and coverage for tunnel-only flows.
</pre>
</details>

<details>
<summary>Diagram</summary>

<br/>

```mermaid
graph TD
  A["cultureflare CLI\nremote-login setup"] --> B["remote_login.cmd_setup"] --> C["remote_login.setup()\norchestrator"] --> D{{"Mode"}}
  C --> E{{"CF Tunnel API"}} --> F{{"CF DNS API"}} --> G["SetupResult"]
  D -->|"with_access"| H{{"CF Access API"}} --> G
  D -->|"--no-access"| I["Skip Access"] --> G
  C --> J[("shushu seal\n(optional)")] --> G
  subgraph Legend
    direction LR
    _int["Internal module"] ~~~ _ext{{"Cloudflare API"}} ~~~ _dec{"Decision"} ~~~ _sec[("Secret store")]
  end
```

</details>




<details>
<summary>High-Level Assessment</summary>

<br/>

The following are alternative approaches to this PR:

<details>
<summary><b>1. Separate subcommand (`remote-login setup-tunnel-only`)</b></summary>

- ➕ Avoids a mode flag and reduces conditional logic in setup()/render paths
- ➕ Clearer UX separation between Access-managed vs backend-authenticated deployments
- ➖ More CLI surface area and duplicated docs/tests
- ➖ Harder to keep tunnel/DNS behavior perfectly consistent across commands

</details>

<details>
<summary><b>2. Split orchestrator into two explicit functions (`setup_with_access` / `setup_tunnel_only`)</b></summary>

- ➕ Keeps each code path linear and easier to reason about
- ➕ Reduces risk of accidentally calling Access APIs in no-access mode
- ➖ More refactoring churn and potential for duplication
- ➖ Public API change pressure if callers already import `setup()`

</details>

**Recommendation:** Current approach (single `setup(..., with_access=True)` plus `--no-access`) is a good tradeoff for backwards compatibility and minimal churn while still preventing Access calls via an explicit guard. If this area grows further, consider extracting the Access-only block into a helper (or two orchestrators) to keep the branching contained and easier to test.

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>File Changes</h3>

<details>
<summary><strong>Enhancement</strong> (4)</summary>

<blockquote>
<details>
<summary><strong>__init__.py</strong> <code>Add &#x27;with_access&#x27; flag to setup orchestrator and skip Access steps</code> <code>+69/-45</code></summary>

<br/>

>Add &#x27;with_access&#x27; flag to setup orchestrator and skip Access steps
>
><pre>
>• Introduces &#x27;with_access&#x27; (default True) to support tunnel-only provisioning. Guards Zero Trust org verification and all Access app/policy/service-token calls behind the flag, and records an explicit skipped step in tunnel-only mode.
></pre>
>
><a href='https://github.com/agentculture/cultureflare/pull/45/files#diff-69f6880a7d5b1da9f6f6015f3526d9ce68dba0388a6e19e2ab585978daa8b509'>cultureflare/_remote_login/__init__.py</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>_common.py</strong> <code>Make Access fields optional in &#x27;SetupResult&#x27; for tunnel-only results</code> <code>+10/-7</code></summary>

<br/>

>Make Access fields optional in &#x27;SetupResult&#x27; for tunnel-only results
>
><pre>
>• Changes Access-related fields to default to None/empty lists so tunnel-only runs can return a valid result. Also defaults &#x27;steps&#x27; to an empty list for safer construction in tests and callers.
></pre>
>
><a href='https://github.com/agentculture/cultureflare/pull/45/files#diff-ea01f1b85bdc23df7c0e253b502eefbb9753e9cd3b6bc2641491c2814d65021d'>cultureflare/_remote_login/_common.py</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>_render.py</strong> <code>Render tunnel-only results and update dry-run plan for &#x27;--no-access&#x27;</code> <code>+55/-34</code></summary>

<br/>

>Render tunnel-only results and update dry-run plan for &#x27;--no-access&#x27;
>
><pre>
>• Updates setup markdown rendering to show an explicit &#x27;no Access&#x27; marker when &#x27;access_app_id&#x27; is None. Extends dry-run markdown generation with a &#x27;no_access&#x27; switch to omit Zero Trust/Access steps and adjust sealing steps accordingly.
></pre>
>
><a href='https://github.com/agentculture/cultureflare/pull/45/files#diff-b5a3a9079ec4743c71c63a87359d380a244f963e3388eee09007d5f57753db2c'>cultureflare/_remote_login/_render.py</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>remote_login.py</strong> <code>Add CLI &#x27;--no-access&#x27; flag with validation and wiring to orchestrator/render</code> <code>+34/-2</code></summary>

<br/>

>Add CLI &#x27;--no-access&#x27; flag with validation and wiring to orchestrator/render
>
><pre>
>• Adds the &#x27;--no-access&#x27; argparse option, rejects incompatible flags (&#x27;--allow&#x27;, &#x27;--allow-domain&#x27;, &#x27;--with-service-token&#x27;) in this mode, and relaxes the allow requirement when tunnel-only. Wires the mode into dry-run rendering and apply execution via &#x27;with_access=not args.no_access&#x27;.
></pre>
>
><a href='https://github.com/agentculture/cultureflare/pull/45/files#diff-d7ccff7c62d73ac94b77349ff12f11ee00807e529adad5d66d4ae4ed4f1c16f7'>cultureflare/cli/_commands/remote_login.py</a>
<hr/>

</details>
</blockquote>

</details>

<details>
<summary><strong>Tests</strong> (3)</summary>

<blockquote>
<details>
<summary><strong>test_cli_remote_login.py</strong> <code>Add CLI tests for &#x27;--no-access&#x27; dry-run and invalid flag combinations</code> <code>+33/-0</code></summary>

<br/>

>Add CLI tests for &#x27;--no-access&#x27; dry-run and invalid flag combinations
>
><pre>
>• Adds coverage ensuring tunnel-only dry-run does not require allow flags and that the plan omits Zero Trust/Access steps. Adds a validation test asserting &#x27;--no-access&#x27; rejects allow flags.
></pre>
>
><a href='https://github.com/agentculture/cultureflare/pull/45/files#diff-863d6de6fcb0eddf4afda80de8ac9901a4127484e0b0a14ad50abcdb8039e6a8'>tests/test_cli_remote_login.py</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>test_remote_login_orchestrator.py</strong> <code>Add orchestrator test ensuring tunnel-only mode never calls Access APIs</code> <code>+60/-0</code></summary>

<br/>

>Add orchestrator test ensuring tunnel-only mode never calls Access APIs
>
><pre>
>• Adds a tunnel-only setup test that stubs only tunnel/ingress/DNS endpoints and asserts Access fields remain None/empty. Verifies an explicit skipped &#x27;access&#x27; step is recorded and that no &#x27;/access/&#x27; API paths are touched.
></pre>
>
><a href='https://github.com/agentculture/cultureflare/pull/45/files#diff-6aa7c6b117f8abd6a346327e5b054a6a992f9be0b5a1e4a8feaee093404ba1fa'>tests/test_remote_login_orchestrator.py</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>test_remote_login_render.py</strong> <code>Add rendering test for tunnel-only SetupResult markdown</code> <code>+26/-0</code></summary>

<br/>

>Add rendering test for tunnel-only SetupResult markdown
>
><pre>
>• Adds a test that constructs a tunnel-only &#x27;SetupResult&#x27; and asserts markdown shows the &#x27;ACCESS: none&#x27; marker while omitting Access/policy/service-token fields.
></pre>
>
><a href='https://github.com/agentculture/cultureflare/pull/45/files#diff-6a4d7a0045e34c84ced0b26f59c3b3372d4740044eb781a33eee69b74b65190e'>tests/test_remote_login_render.py</a>
<hr/>

</details>
</blockquote>

</details>

<details>
<summary><strong>Documentation</strong> (2)</summary>

<blockquote>
<details>
<summary><strong>CHANGELOG.md</strong> <code>Document 0.11.0 and &#x27;--no-access&#x27; tunnel-only setup mode</code> <code>+6/-0</code></summary>

<br/>

>Document 0.11.0 and &#x27;--no-access&#x27; tunnel-only setup mode
>
><pre>
>• Adds a 0.11.0 release entry describing tunnel-only remote-login provisioning. Explicitly notes rejected flags in this mode and that sealing to shushu still works.
></pre>
>
><a href='https://github.com/agentculture/cultureflare/pull/45/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed'>CHANGELOG.md</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>README.md</strong> <code>Update remote-login examples and describe tunnel-only &#x27;--no-access&#x27; usage</code> <code>+8/-4</code></summary>

<br/>

>Update remote-login examples and describe tunnel-only &#x27;--no-access&#x27; usage
>
><pre>
>• Updates the setup example to require &#x27;--service&#x27; and adds a tunnel-only example that skips Cloudflare Access. Adjusts capability/command tables and dry-run validation wording to reflect &#x27;--no-access&#x27; behavior.
></pre>
>
><a href='https://github.com/agentculture/cultureflare/pull/45/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5'>README.md</a>
<hr/>

</details>
</blockquote>

</details>

<details>
<summary><strong>Other</strong> (2)</summary>

<blockquote>
<details>
<summary><strong>__init__.py</strong> <code>Bump package version to 0.11.0</code> <code>+1/-1</code></summary>

<br/>

>Bump package version to 0.11.0
>
><pre>
>• Updates &#x27;__version__&#x27; to 0.11.0 to match the new release.
></pre>
>
><a href='https://github.com/agentculture/cultureflare/pull/45/files#diff-d5edea5ab3ce96174761d5196bed9228ec93ef56f5bbc63958652365b42977f8'>cultureflare/__init__.py</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>pyproject.toml</strong> <code>Bump project version to 0.11.0</code> <code>+1/-1</code></summary>

<br/>

>Bump project version to 0.11.0
>
><pre>
>• Updates the package version in project metadata to 0.11.0.
></pre>
>
><a href='https://github.com/agentculture/cultureflare/pull/45/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711'>pyproject.toml</a>
<hr/>

</details>
</blockquote>

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">


<a href="https://www.qodo.ai"><img src="https://www.qodo.ai/wp-content/uploads/2025/03/qodo-logo.svg" width="80" alt="Qodo Logo"></a>