### PR TITLE
feat(pages): pages deployments create — Pages build trigger

### DIFF
--- a/.claude/skills/cultureflare-write/SKILL.md
+++ b/.claude/skills/cultureflare-write/SKILL.md
@@ -57,8 +57,9 @@ token**) with these *additional* scopes on top of the read scopes:
 - **Zone · DNS · Edit** (All zones from AgentCulture) —
   required by `cultureflare dns create` and `cf-dns-create.sh`
 - **Account · Cloudflare Pages · Edit** (this account) —
-  required by `cf-pages-project-create.sh`,
-  `cf-pages-domain-add.sh`, `cf-pages-domain-remove.sh`,
+  required by `cultureflare pages deployments create`,
+  `cf-pages-project-create.sh`, `cf-pages-domain-add.sh`,
+  `cf-pages-domain-remove.sh`, `cf-pages-deployment-create.sh`,
   `cf-pages-deployment-delete.sh`, and
   `cf-pages-deployments-purge.sh`. Creating a **GitHub-connected**
   Pages project (no `--direct-upload`) additionally needs the
@@ -116,6 +117,7 @@ Every write operation in this skill follows the same shape:
 | Deploy a Worker | `bash .claude/skills/cultureflare-write/scripts/cf-worker-create.sh ...` |
 | Route a Worker | `bash .claude/skills/cultureflare-write/scripts/cf-workers-route-create.sh ...` |
 | Add a redirect | `bash .claude/skills/cultureflare-write/scripts/cf-redirect-create.sh ...` |
+| Trigger a Pages deployment / build | `cultureflare pages deployments create <project> [--branch B]` *(dry-run; `--apply` to commit; bash: `cf-pages-deployment-create.sh`)* |
 | Delete one Pages deployment | `bash .claude/skills/cultureflare-write/scripts/cf-pages-deployment-delete.sh ...` |
 | Bulk-delete all deployments in a Pages project | `bash .claude/skills/cultureflare-write/scripts/cf-pages-deployments-purge.sh ...` (two-phase, see §3.3) |
 | Delete a DNS record | `bash .claude/skills/cultureflare-write/scripts/cf-dns-delete.sh ...` |

--- a/.claude/skills/cultureflare-write/scripts/cf-pages-deployment-create.sh
+++ b/.claude/skills/cultureflare-write/scripts/cf-pages-deployment-create.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+# Trigger a new CloudFlare Pages deployment (production build) for a
+# git-connected project.
+#
+# Usage:
+#   cf-pages-deployment-create.sh PROJECT [--branch=BRANCH] [--apply] [--json]
+#
+# Default is DRY-RUN: resolves the project (which confirms it exists and
+# that it has a git source), determines the branch that will be built,
+# prints the deployments endpoint it would POST to, and exits 0 WITHOUT
+# mutating anything. Pass --apply to actually POST and kick the build.
+#
+# Why this exists: a Pages project created via the REST API does not
+# always get its GitHub webhook installed (the dashboard connect flow
+# does extra OAuth + webhook setup the API create skips), so pushes to
+# the production branch may not auto-deploy. This endpoint clones the
+# repo at the branch HEAD server-side, so it triggers a build regardless
+# of the webhook state. It's also the manual "redeploy" primitive for any
+# git-backed project.
+#
+# Flags:
+#   --branch=BRANCH   git branch to build. Defaults to the project's
+#                     production_branch (resolved from project metadata).
+#                     A deployment whose branch == production_branch is a
+#                     PRODUCTION deployment; any other branch is a PREVIEW.
+#   --apply           actually POST (without it, this is a dry-run)
+#   --json            raw CloudFlare response envelope (or simulated body
+#                     in dry-run)
+#
+# Only works on git-connected (github / gitlab source) projects. A
+# Direct Upload project has no git source to build from and is refused.
+#
+# Exits 1 on: project not found, direct-upload project, API error.
+# Exits 2 on usage error.
+
+set -euo pipefail
+shopt -s inherit_errexit
+
+mode=md
+apply=0
+branch=""
+branch_set=0
+positional=()
+
+for arg in "$@"; do
+  case "$arg" in
+    --json)       mode=json ;;
+    --apply)      apply=1 ;;
+    --branch=*)   branch="${arg#*=}"; branch_set=1 ;;
+    -h|--help)
+      awk 'NR==1{next} /^#/{sub(/^# ?/, ""); print; next} {exit}' "$0"
+      exit 0
+      ;;
+    -*)
+      echo "ERROR: unknown flag: $arg" >&2
+      exit 2
+      ;;
+    *)
+      positional+=("$arg")
+      ;;
+  esac
+done
+
+if (( ${#positional[@]} != 1 )); then
+  echo "ERROR: expected exactly one PROJECT positional arg, got ${#positional[@]}" >&2
+  echo "usage: cf-pages-deployment-create.sh PROJECT [--branch=BRANCH] [--apply] [--json]" >&2
+  exit 2
+fi
+project="${positional[0]}"
+
+# Project name is CF-restricted (lowercase, digits, dashes); reject
+# anything that could escape the URL path. Matches the validation in the
+# sibling cf-pages-*.sh scripts.
+if [[ ! "$project" =~ ^[a-zA-Z0-9][a-zA-Z0-9._-]*$ ]]; then
+  echo "ERROR: invalid project name: $project" >&2
+  exit 2
+fi
+
+# Git branch names: alnum plus . _ / - (same set as cf-pages-project-create's
+# --production-branch). Validated only when --branch is given.
+if (( branch_set )); then
+  branch_re='^[A-Za-z0-9._/-]{1,255}$'
+  if [[ ! "$branch" =~ $branch_re ]]; then
+    echo "ERROR: invalid --branch: $branch" >&2
+    exit 2
+  fi
+fi
+
+# shellcheck source=../../cloudflare/scripts/_lib.sh
+source "$(dirname "${BASH_SOURCE[0]}")/_lib.sh"
+cf_require_account_id
+
+project_encoded=$(jq -rn --arg v "$project" '$v|@uri')
+
+# Fetch project metadata: confirms the project exists, gives us the
+# production_branch to default to, and tells us whether the project has a
+# git source at all. Single-object GET → cf_api, not _paginated. Let
+# cf_api's own diagnostic through (it distinguishes missing-project from
+# scope/transport failures); add a resolution hint.
+if ! project_json=$(cf_api "/accounts/$CLOUDFLARE_ACCOUNT_ID/pages/projects/$project_encoded"); then
+  echo "HINT: could not resolve Pages project '$project'. Check the project name with cf-pages.sh." >&2
+  exit 1
+fi
+
+source_type=$(printf '%s' "$project_json" | jq -r '.result.source.type // ""')
+production_branch=$(printf '%s' "$project_json" | jq -r '.result.production_branch // "main"')
+
+# Direct Upload projects (source null/absent) have no git to build from.
+if [[ -z "$source_type" ]]; then
+  echo "ERROR: project $project has no git source (Direct Upload)" >&2
+  echo "       there is nothing to build from a branch; deploy it with wrangler / the direct-upload API instead." >&2
+  exit 1
+fi
+
+if (( branch_set )); then
+  effective_branch="$branch"
+else
+  effective_branch="$production_branch"
+fi
+
+# Environment classification mirrors CF: branch == production_branch is a
+# production deployment, anything else is a preview.
+if [[ "$effective_branch" == "$production_branch" ]]; then
+  environment=production
+else
+  environment=preview
+fi
+
+deploy_path="/accounts/$CLOUDFLARE_ACCOUNT_ID/pages/projects/$project_encoded/deployments"
+
+render_summary_kv() {
+  printf -- '- **project:** %s\n' "$project"
+  printf -- '- **source:** %s\n' "$source_type"
+  printf -- '- **branch:** %s\n' "$effective_branch"
+  printf -- '- **environment:** %s\n' "$environment"
+  return 0
+}
+
+if (( apply == 0 )); then
+  if [[ "$mode" == "json" ]]; then
+    # shellcheck disable=SC2016  # single-quoted jq filter
+    jq -n \
+      --arg project "$project" \
+      --arg branch "$effective_branch" \
+      --arg environment "$environment" \
+      --arg deploy_path "$deploy_path" \
+      '{success: true, errors: [], messages: ["dry-run: no changes applied"],
+        result: {dry_run: true, project: $project, branch: $branch,
+                 environment: $environment, would_post: $deploy_path}}'
+    exit 0
+  fi
+  printf '**Dry-run — no changes applied**\n\n'
+  render_summary_kv
+  # shellcheck disable=SC2016  # literal backticks wrap markdown inline code
+  printf '\n**would POST** `%s` (branch=%s)\n' "$deploy_path" "$effective_branch"
+  exit 0
+fi
+
+# Apply path. Multipart form POST — the deployments endpoint requires it,
+# so route through cf_api_form (NOT cf_api, which forces JSON).
+response=$(cf_api_form "$deploy_path" -F "branch=$effective_branch")
+
+if [[ "$mode" == "json" ]]; then
+  printf '%s\n' "$response"
+  exit 0
+fi
+
+deployment_id=$(printf '%s' "$response" | jq -r '.result.id // "—"')
+short_id=$(printf '%s' "$response" | jq -r '.result.short_id // "—"')
+deploy_url=$(printf '%s' "$response" | jq -r '.result.url // "—"')
+stage_name=$(printf '%s' "$response" | jq -r '.result.latest_stage.name // "—"')
+stage_status=$(printf '%s' "$response" | jq -r '.result.latest_stage.status // "—"')
+
+printf '**Deployment triggered**\n\n'
+render_summary_kv
+printf -- '- **deployment:** %s (id=%s)\n' "$short_id" "$deployment_id"
+printf -- '- **stage:** %s/%s\n' "$stage_name" "$stage_status"
+printf -- '- **url:** %s\n' "$deploy_url"

--- a/.claude/skills/cultureflare/scripts/_lib.sh
+++ b/.claude/skills/cultureflare/scripts/_lib.sh
@@ -94,6 +94,40 @@ cf_api() {
   return 0
 }
 
+# cf_api_form PATH [CURL_OPTS...]
+# POST CF_API_BASE$PATH as multipart/form-data with the bearer token.
+# Same auth and .success error handling as cf_api, but DELIBERATELY does
+# NOT send `Content-Type: application/json` — endpoints like CF Pages'
+# "create deployment" require multipart, and curl needs to generate the
+# boundary itself. Passing `-H "Content-Type: application/json"` alongside
+# `-F field=value` (as cf_api does) makes curl emit a corrupt
+# `Content-Type: application/json; boundary=…` header, so this is a
+# separate helper rather than a flag on cf_api. Callers pass `-F` form
+# fields via CURL_OPTS; with none, this is an empty multipart POST.
+cf_api_form() {
+  local path="$1"; shift
+  local response url
+  url="$CF_API_BASE$path"
+
+  if ! response=$(curl -sS \
+      -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+      -X POST \
+      "$@" \
+      "$url" 2>&1); then
+    echo "ERROR: CloudFlare API transport failure: $url" >&2
+    printf '%s\n' "$response" >&2
+    exit 1
+  fi
+
+  if ! printf '%s' "$response" | jq -e '.success == true' >/dev/null 2>&1; then
+    echo "ERROR: CloudFlare API request failed: $path" >&2
+    printf '%s' "$response" | jq '.errors // .' >&2 || printf '%s\n' "$response" >&2
+    exit 1
+  fi
+  printf '%s\n' "$response"
+  return 0
+}
+
 # cf_output JSON MODE JQ_TSV_FILTER [HEADER]
 # MODE   : md | json
 # FILTER : jq expression producing tab-separated rows (@tsv)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented here. The format
 is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.12.0] - 2026-06-22
+
+### Added
+
+- `cultureflare pages deployments create <project> [--branch B]` — trigger a Pages deployment / build for a git-connected project (dry-run by default; `--apply` commits). New `pages` noun in the Python CLI.
+- `cf-pages-deployment-create.sh` bash twin under `cultureflare-write/scripts/`, plus a shared `cf_api_form` multipart helper in `_lib.sh`.
+- `_output.dry_run_envelope()` helper and `_api.http_request(form=...)` multipart support.
+
+### Changed
+
+- Refactored `dns create`s dry-run JSON to share the new `dry_run_envelope()` helper (identical output).
+
 ## [0.11.0] - 2026-06-09
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -74,17 +74,18 @@ cultureflare remote-login setup --hostname api.culture.dev --service http://127.
 | Cloudflare Access (Zero Trust) | ✓ `remote-login show` | ✓ `remote-login setup` / `teardown` (with `--apply`) | Per-hostname Tunnel + Access app + allow-policy + optional service token. `--no-access` provisions Tunnel + DNS only (no Access app) for a backend that authenticates itself |
 | Token verify | ✓ `whoami` | — | Status only (no scope inspection — CF doesn't expose) |
 | Workers scripts / routes | bash skills only | — | Python port pending |
-| Pages projects / deployments | bash skills only | bash `cf-pages-project-create.sh` / `cf-pages-deployments-purge.sh` | Python port pending |
+| Pages projects / deployments | bash skills only | ✓ `pages deployments create` (build trigger, `--apply`); bash for projects / domains / purge | Deploy-trigger ported to Python; rest pending |
 | API tokens | — | — | Operator-driven by design (out of scope) |
 | Zero Trust org onboarding | — | — | Dashboard only for now |
 
-## Commands (v0.2.2)
+## Commands (v0.12.0)
 
 | Command | Description |
 |---|---|
 | `cultureflare whoami` | Verify the configured API token is alive |
 | `cultureflare zones list` | List zones in the token's account |
 | `cultureflare dns create ZONE TYPE NAME CONTENT` | Create a DNS record (dry-run; `--apply` to commit) |
+| `cultureflare pages deployments create PROJECT [--branch B]` | Trigger a Pages deployment / build (dry-run; `--apply` to commit) |
 | `cultureflare remote-login setup --hostname H --service URL --allow EMAIL` | Provision the full Tunnel + DNS + Access stack for `H` (dry-run; `--apply` to commit) |
 | `cultureflare remote-login setup --hostname H --service URL --no-access` | Tunnel + DNS only — no Access app; the backend at `URL` provides its own auth |
 | `cultureflare remote-login show --hostname H` | Inspect what's currently provisioned for `H` |

--- a/cultureflare/__init__.py
+++ b/cultureflare/__init__.py
@@ -8,7 +8,7 @@ from importlib.metadata import PackageNotFoundError, version as _pkg_version
 # version is rewritten to "0.3.0.devN" by the publish workflow) report
 # their actual version here. The legacy `cfafi` wheel (frozen at 0.2.2)
 # is the second-tier fallback for anyone still on the old install.
-__version__ = "0.11.0"
+__version__ = "0.12.0"
 
 try:
     __version__ = _pkg_version("cultureflare")

--- a/cultureflare/_api.py
+++ b/cultureflare/_api.py
@@ -10,6 +10,7 @@ import json
 import urllib.error
 import urllib.parse
 import urllib.request
+import uuid
 from typing import Any, Iterator, NoReturn
 
 from cultureflare import __version__
@@ -71,7 +72,11 @@ def http_request(
         "User-Agent": f"cultureflare/{__version__} (github.com/agentculture/cultureflare)",
     }
     if form is not None:
-        boundary = "----cultureflareFormBoundaryZ9x7Z9x7Z9x7"
+        # Per-request random boundary: RFC 2046 forbids the delimiter
+        # appearing in any field value, and our values (branch names) share
+        # a charset with a fixed boundary. uuid4 (stdlib) makes a collision
+        # vanishingly improbable — and matches what curl does on the bash side.
+        boundary = "----cultureflareFormBoundary" + uuid.uuid4().hex
         body = _encode_multipart(form, boundary)
         headers["Content-Type"] = f"multipart/form-data; boundary={boundary}"
     elif payload is not None:

--- a/cultureflare/_api.py
+++ b/cultureflare/_api.py
@@ -20,19 +20,45 @@ CF_API_BASE = "https://api.cloudflare.com/client/v4"
 _DEFAULT_PER_PAGE = 50
 
 
+def _encode_multipart(fields: dict[str, Any], boundary: str) -> bytes:
+    """Encode ``fields`` as a ``multipart/form-data`` body.
+
+    Hand-rolled (stdlib has no request-side multipart encoder) and kept
+    minimal: simple text fields only, which is all CloudFlare's
+    create-deployment endpoint needs (an optional ``branch``). Values are
+    stringified; keys are assumed safe (caller-validated branch names).
+    """
+    lines: list[str] = []
+    for key, value in fields.items():
+        lines.append(f"--{boundary}")
+        lines.append(f'Content-Disposition: form-data; name="{key}"')
+        lines.append("")
+        lines.append(str(value))
+    lines.append(f"--{boundary}--")
+    lines.append("")
+    return "\r\n".join(lines).encode("utf-8")
+
+
 def http_request(
     method: str,
     path: str,
     *,
     payload: dict[str, Any] | None = None,
     query: dict[str, Any] | None = None,
+    form: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Perform one CloudFlare API request, returning the parsed JSON envelope.
 
     Raises CfafiError on HTTP 4xx/5xx. 401/403 → EXIT_AUTH, everything
     else → EXIT_API. The CloudFlare error envelope (``.errors[0]``) is
     preserved in ``CfafiError.message`` when present.
+
+    ``payload`` sends a JSON body; ``form`` sends a ``multipart/form-data``
+    body (CF Pages' create-deployment endpoint requires multipart, not
+    JSON). They are mutually exclusive.
     """
+    if payload is not None and form is not None:
+        raise ValueError("http_request: pass payload or form, not both")
     token = require_env("CLOUDFLARE_API_TOKEN")
     url = CF_API_BASE + path
     if query:
@@ -44,7 +70,11 @@ def http_request(
         "Accept": "application/json",
         "User-Agent": f"cultureflare/{__version__} (github.com/agentculture/cultureflare)",
     }
-    if payload is not None:
+    if form is not None:
+        boundary = "----cultureflareFormBoundaryZ9x7Z9x7Z9x7"
+        body = _encode_multipart(form, boundary)
+        headers["Content-Type"] = f"multipart/form-data; boundary={boundary}"
+    elif payload is not None:
         body = json.dumps(payload).encode("utf-8")
         headers["Content-Type"] = "application/json"
 

--- a/cultureflare/cli/__init__.py
+++ b/cultureflare/cli/__init__.py
@@ -70,6 +70,7 @@ def _build_parser() -> argparse.ArgumentParser:
     from cultureflare.cli._commands import dns as _dns
     from cultureflare.cli._commands import explain as _explain
     from cultureflare.cli._commands import learn as _learn
+    from cultureflare.cli._commands import pages as _pages
     from cultureflare.cli._commands import remote_login as _remote_login
     from cultureflare.cli._commands import whoami as _whoami
     from cultureflare.cli._commands import zones as _zones
@@ -92,6 +93,7 @@ def _build_parser() -> argparse.ArgumentParser:
     # Noun groups
     _zones.register(sub)
     _dns.register(sub)
+    _pages.register(sub)
     _remote_login.register(sub)
 
     return parser

--- a/cultureflare/cli/_commands/dns.py
+++ b/cultureflare/cli/_commands/dns.py
@@ -13,7 +13,7 @@ import json as _json
 
 import cultureflare._api as _api
 from cultureflare.cli._errors import EXIT_USER_ERROR, CfafiError
-from cultureflare.cli._output import emit_json, emit_kv, emit_result
+from cultureflare.cli._output import dry_run_envelope, emit_json, emit_kv, emit_result
 
 _SUPPORTED_TYPES = {"A", "AAAA", "CNAME", "TXT", "MX", "NS", "SRV", "CAA"}
 
@@ -98,10 +98,7 @@ def cmd_dns_create(args: argparse.Namespace) -> None:
 
     if not args.apply:
         if json_mode:
-            emit_json({
-                "success": True, "errors": [], "messages": ["dry-run: no changes applied"],
-                "result": {"dry_run": True, "zone_id": zone_id, "would_post": body},
-            })
+            emit_json(dry_run_envelope({"zone_id": zone_id, "would_post": body}))
         else:
             emit_result("**Dry-run — no changes applied**\n", json_mode=False)
             emit_kv([

--- a/cultureflare/cli/_commands/explain.py
+++ b/cultureflare/cli/_commands/explain.py
@@ -20,6 +20,7 @@ Available paths (v0.1.0):
 - `cultureflare whoami` — verify the configured CloudFlare API token
 - `cultureflare zones list` — list zones in the token's account
 - `cultureflare dns create` — create a DNS record (dry-run by default)
+- `cultureflare pages deployments create` — trigger a Pages build (dry-run by default)
 - `cultureflare learn` — self-teaching prompt
 - `cultureflare explain <path>...` — this lookup
 
@@ -117,6 +118,65 @@ without creating a duplicate.
 - `2` — CLOUDFLARE_API_TOKEN not set
 - `3` — authentication error
 - `4` — upstream CloudFlare API error
+""",
+    ("pages",): """\
+# cultureflare pages
+
+CloudFlare Pages projects and deployments. Current verbs:
+
+- `cultureflare pages deployments create` — trigger a deployment / build (dry-run by default)
+
+More verbs (`projects list/create/delete`, `deployments list/delete/purge`)
+land in future minor releases.
+""",
+    ("pages", "deployments"): """\
+# cultureflare pages deployments
+
+Pages deployment management. Current verbs:
+
+- `cultureflare pages deployments create` — trigger a new deployment (dry-run by default)
+""",
+    ("pages", "deployments", "create"): """\
+# cultureflare pages deployments create
+
+Trigger a new deployment for a git-connected Pages project. **Dry-run by default.**
+
+```
+cultureflare pages deployments create PROJECT [--branch BRANCH] [--apply] [--json]
+```
+
+## Behaviour
+
+Resolves the project (confirming it exists and has a git source), then
+determines the branch to build: `--branch` if given, otherwise the
+project's `production_branch`. A build on the production branch is a
+**production** deployment; any other branch is a **preview**.
+
+Dry-run (no `--apply`): prints the deployments endpoint it would POST to
+and the branch, and exits 0 without mutating anything.
+
+`--apply`: POSTs `multipart/form-data` to
+`/accounts/<id>/pages/projects/<project>/deployments` with the `branch`
+field. CloudFlare clones the repo at that branch's HEAD server-side and
+builds — so this works even when an API-created project never got its
+GitHub webhook (pushes don't auto-deploy in that case).
+
+Direct Upload projects have no git source and are refused.
+
+## Flags
+
+- `--branch BRANCH` — branch to build (default: project production_branch).
+- `--apply` — actually POST. Without it, this is a dry-run.
+- `--json` — emit raw CloudFlare response envelope (or a synthetic
+  `{result: {dry_run: true, ...}}` envelope in dry-run mode).
+
+## Exit codes
+
+- `0` — success (dry-run printed, or deployment triggered with --apply)
+- `1` — invalid project/branch name, or Direct Upload project
+- `2` — CLOUDFLARE_API_TOKEN / CLOUDFLARE_ACCOUNT_ID not set
+- `3` — authentication error
+- `4` — upstream CloudFlare API error (incl. project not found)
 """,
     ("learn",): """\
 # cultureflare learn

--- a/cultureflare/cli/_commands/pages.py
+++ b/cultureflare/cli/_commands/pages.py
@@ -1,0 +1,122 @@
+"""``cultureflare pages <subnoun> <verb>`` — CloudFlare Pages.
+
+v0 exposes ``pages deployments create`` only — trigger a new deployment
+(production build) for a git-connected project. The bash counterpart at
+``.claude/skills/cultureflare-write/scripts/cf-pages-deployment-create.sh``
+is the behavioural reference: same dry-run default, same direct-upload
+guard, same production-vs-preview branch classification.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import urllib.parse
+
+import cultureflare._api as _api
+from cultureflare._env import require_env
+from cultureflare.cli._errors import EXIT_USER_ERROR, CfafiError
+from cultureflare.cli._output import dry_run_envelope, emit_json, emit_kv, emit_result
+
+# Project names are CF-restricted (lowercase, digits, dashes); branch
+# names allow the usual git set. Both feed a URL path — validate at the
+# boundary for clean errors (urllib.quote handles escaping regardless).
+_PROJECT_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9._-]*$")
+_BRANCH_RE = re.compile(r"^[A-Za-z0-9._/-]{1,255}$")
+
+
+def cmd_pages_deployments_create(args: argparse.Namespace) -> None:
+    """Trigger a Pages deployment. See cmd_dns_create for the no-explicit-0 rationale."""
+    project = args.project
+    if not _PROJECT_RE.match(project):
+        raise CfafiError(
+            code=EXIT_USER_ERROR,
+            message=f"invalid project name: {project}",
+            remediation="project names are lowercase letters, digits, dots, dashes",
+        )
+    if args.branch is not None and not _BRANCH_RE.match(args.branch):
+        raise CfafiError(
+            code=EXIT_USER_ERROR,
+            message=f"invalid --branch: {args.branch}",
+            remediation="branch names use letters, digits, and . _ / -",
+        )
+
+    account_id = require_env("CLOUDFLARE_ACCOUNT_ID")
+    project_enc = urllib.parse.quote(project, safe="")
+
+    # Project detail: existence check + production_branch default + git-source guard.
+    detail = _api.http_request("GET", f"/accounts/{account_id}/pages/projects/{project_enc}")
+    result = detail.get("result") or {}
+    source_type = (result.get("source") or {}).get("type") or ""
+    production_branch = result.get("production_branch") or "main"
+
+    if not source_type:
+        raise CfafiError(
+            code=EXIT_USER_ERROR,
+            message=f"project {project} has no git source (Direct Upload)",
+            remediation="Direct Upload projects build via wrangler / the direct-upload API, not a branch",
+        )
+
+    branch = args.branch if args.branch is not None else production_branch
+    environment = "production" if branch == production_branch else "preview"
+    deploy_path = f"/accounts/{account_id}/pages/projects/{project_enc}/deployments"
+    json_mode = bool(getattr(args, "json", False))
+
+    if not args.apply:
+        if json_mode:
+            emit_json(dry_run_envelope({
+                "project": project, "branch": branch,
+                "environment": environment, "would_post": deploy_path,
+            }))
+        else:
+            emit_result("**Dry-run — no changes applied**\n", json_mode=False)
+            emit_kv([
+                ("project", project),
+                ("source", source_type),
+                ("branch", branch),
+                ("environment", environment),
+            ])
+            emit_result(
+                f"\n**would POST** `{deploy_path}` (branch={branch})",
+                json_mode=False,
+            )
+        return
+
+    response = _api.http_request("POST", deploy_path, form={"branch": branch})
+    if json_mode:
+        emit_json(response)
+        return
+    dep = response.get("result") or {}
+    stage = dep.get("latest_stage") or {}
+    emit_result("**Deployment triggered**\n", json_mode=False)
+    emit_kv([
+        ("project", project),
+        ("source", source_type),
+        ("branch", branch),
+        ("environment", environment),
+        ("deployment", f"{dep.get('short_id', '—')} (id={dep.get('id', '—')})"),
+        ("stage", f"{stage.get('name', '—')}/{stage.get('status', '—')}"),
+        ("url", dep.get("url", "—")),
+    ])
+
+
+def register(sub: argparse._SubParsersAction) -> None:
+    p = sub.add_parser("pages", help="CloudFlare Pages projects and deployments.")
+    pages_sub = p.add_subparsers(dest="subnoun", required=True)
+
+    deployments = pages_sub.add_parser("deployments", help="Pages deployments.")
+    dep_verbs = deployments.add_subparsers(dest="verb", required=True)
+
+    c = dep_verbs.add_parser(
+        "create",
+        help="Trigger a deployment / production build (dry-run by default; --apply commits).",
+    )
+    c.add_argument("project", help="Pages project name, e.g. tools-culture-dev")
+    c.add_argument(
+        "--branch",
+        default=None,
+        help="Branch to build (default: the project's production_branch)",
+    )
+    c.add_argument("--apply", action="store_true", help="Actually POST (without it, dry-run).")
+    c.add_argument("--json", action="store_true", help="Emit raw/synthetic JSON envelope.")
+    c.set_defaults(func=cmd_pages_deployments_create)

--- a/cultureflare/cli/_commands/pages.py
+++ b/cultureflare/cli/_commands/pages.py
@@ -25,37 +25,52 @@ _PROJECT_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9._-]*$")
 _BRANCH_RE = re.compile(r"^[A-Za-z0-9._/-]{1,255}$")
 
 
-def cmd_pages_deployments_create(args: argparse.Namespace) -> None:
-    """Trigger a Pages deployment. See cmd_dns_create for the no-explicit-0 rationale."""
-    project = args.project
+def _validate_args(project: str, branch: str | None) -> None:
+    """Raise CfafiError for an invalid project name or branch name."""
     if not _PROJECT_RE.match(project):
         raise CfafiError(
             code=EXIT_USER_ERROR,
             message=f"invalid project name: {project}",
             remediation="project names are lowercase letters, digits, dots, dashes",
         )
-    if args.branch is not None and not _BRANCH_RE.match(args.branch):
+    if branch is not None and not _BRANCH_RE.match(branch):
         raise CfafiError(
             code=EXIT_USER_ERROR,
-            message=f"invalid --branch: {args.branch}",
+            message=f"invalid --branch: {branch}",
             remediation="branch names use letters, digits, and . _ / -",
         )
 
-    account_id = require_env("CLOUDFLARE_ACCOUNT_ID")
-    project_enc = urllib.parse.quote(project, safe="")
 
-    # Project detail: existence check + production_branch default + git-source guard.
+def _resolve_project(account_id: str, project: str, project_enc: str) -> tuple[str, str]:
+    """Fetch project detail; return (source_type, production_branch).
+
+    Raises CfafiError when the project has no git source (Direct Upload).
+    """
     detail = _api.http_request("GET", f"/accounts/{account_id}/pages/projects/{project_enc}")
     result = detail.get("result") or {}
     source_type = (result.get("source") or {}).get("type") or ""
     production_branch = result.get("production_branch") or "main"
-
     if not source_type:
         raise CfafiError(
             code=EXIT_USER_ERROR,
             message=f"project {project} has no git source (Direct Upload)",
-            remediation="Direct Upload projects build via wrangler / the direct-upload API, not a branch",
+            remediation=(
+                "Direct Upload projects build via wrangler / the direct-upload API,"
+                " not a branch"
+            ),
         )
+    return source_type, production_branch
+
+
+def cmd_pages_deployments_create(args: argparse.Namespace) -> None:
+    """Trigger a Pages deployment. See cmd_dns_create for the no-explicit-0 rationale."""
+    _validate_args(args.project, args.branch)
+
+    account_id = require_env("CLOUDFLARE_ACCOUNT_ID")
+    project_enc = urllib.parse.quote(args.project, safe="")
+
+    # Project detail: existence check + production_branch default + git-source guard.
+    source_type, production_branch = _resolve_project(account_id, args.project, project_enc)
 
     branch = args.branch if args.branch is not None else production_branch
     environment = "production" if branch == production_branch else "preview"
@@ -65,13 +80,13 @@ def cmd_pages_deployments_create(args: argparse.Namespace) -> None:
     if not args.apply:
         if json_mode:
             emit_json(dry_run_envelope({
-                "project": project, "branch": branch,
+                "project": args.project, "branch": branch,
                 "environment": environment, "would_post": deploy_path,
             }))
         else:
             emit_result("**Dry-run — no changes applied**\n", json_mode=False)
             emit_kv([
-                ("project", project),
+                ("project", args.project),
                 ("source", source_type),
                 ("branch", branch),
                 ("environment", environment),
@@ -90,7 +105,7 @@ def cmd_pages_deployments_create(args: argparse.Namespace) -> None:
     stage = dep.get("latest_stage") or {}
     emit_result("**Deployment triggered**\n", json_mode=False)
     emit_kv([
-        ("project", project),
+        ("project", args.project),
         ("source", source_type),
         ("branch", branch),
         ("environment", environment),

--- a/cultureflare/cli/_output.py
+++ b/cultureflare/cli/_output.py
@@ -61,11 +61,13 @@ def dry_run_envelope(result: dict[str, Any]) -> dict[str, Any]:
     caller would have POSTed. Keeps the dry-run JSON identical across
     ``dns create``, ``pages deployments create``, etc.
     """
+    # `**result` first so the dry_run marker always wins, even if a caller
+    # passes a `dry_run` key of its own — the marker is the helper's contract.
     return {
         "success": True,
         "errors": [],
         "messages": ["dry-run: no changes applied"],
-        "result": {"dry_run": True, **result},
+        "result": {**result, "dry_run": True},
     }
 
 

--- a/cultureflare/cli/_output.py
+++ b/cultureflare/cli/_output.py
@@ -52,6 +52,23 @@ def emit_json(payload: Any, *, stream: TextIO | None = None) -> None:
     s.write("\n")
 
 
+def dry_run_envelope(result: dict[str, Any]) -> dict[str, Any]:
+    """Synthetic CloudFlare-style envelope for a dry-run (``--apply`` absent).
+
+    Mutation verbs share this shape so their ``--json`` dry-run output
+    mirrors a real CF envelope without a network call: ``success: true``
+    plus a ``result`` carrying a ``dry_run: true`` marker and whatever the
+    caller would have POSTed. Keeps the dry-run JSON identical across
+    ``dns create``, ``pages deployments create``, etc.
+    """
+    return {
+        "success": True,
+        "errors": [],
+        "messages": ["dry-run: no changes applied"],
+        "result": {"dry_run": True, **result},
+    }
+
+
 def _escape_cell(value: Any) -> str:
     # Pipes break markdown tables; newlines/CRs/tabs collapse to spaces.
     return (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cultureflare"
-version = "0.11.0"
+version = "0.12.0"
 description = "CloudFlare Agent First Interface — agent-first CLI for CloudFlare management in the AgentCulture org."
 readme = "README.md"
 license = "MIT"

--- a/tests/bats/cf-pages-deployment-create.bats
+++ b/tests/bats/cf-pages-deployment-create.bats
@@ -1,0 +1,126 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+setup() {
+  cf_bats_setup
+  WRITE_SCRIPTS="$SKILL_DIR/../cfafi-write/scripts"
+  # Project-detail GET and deployments POST share the
+  # /accounts/.../pages/projects/culture-dev/... prefix; the stub's
+  # longest-substring-wins policy disambiguates by URL suffix
+  # (".../deployments" beats ".../culture-dev").
+}
+
+_assert_no_post() {
+  if grep -qF -- '-X	POST' "$BATS_TEST_TMPDIR/curl.log" 2>/dev/null; then
+    echo "expected no POST, but curl.log contains one:" >&2
+    cat "$BATS_TEST_TMPDIR/curl.log" >&2
+    return 1
+  fi
+  return 0
+}
+
+# --- usage errors ---
+
+@test "cf-pages-deployment-create exits 2 when PROJECT missing" {
+  run bash "$WRITE_SCRIPTS/cf-pages-deployment-create.sh"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"expected exactly one PROJECT"* ]]
+}
+
+@test "cf-pages-deployment-create exits 2 on unknown flag" {
+  run bash "$WRITE_SCRIPTS/cf-pages-deployment-create.sh" culture-dev --bogus
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"unknown flag"* ]]
+}
+
+@test "cf-pages-deployment-create exits 2 on invalid project name" {
+  run bash "$WRITE_SCRIPTS/cf-pages-deployment-create.sh" 'bad name!'
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"invalid project name"* ]]
+}
+
+@test "cf-pages-deployment-create exits 2 on invalid --branch" {
+  run bash "$WRITE_SCRIPTS/cf-pages-deployment-create.sh" culture-dev --branch='bad branch!'
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"invalid --branch"* ]]
+}
+
+# --- dry-run ---
+
+@test "cf-pages-deployment-create dry-run defaults to production_branch, no POST" {
+  cf_mock "/pages/projects/culture-dev" "pages_project_culture_dev_detail.json"
+  run bash "$WRITE_SCRIPTS/cf-pages-deployment-create.sh" culture-dev
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"**Dry-run — no changes applied**"* ]]
+  [[ "$output" == *"**branch:** main"* ]]
+  [[ "$output" == *"**environment:** production"* ]]
+  [[ "$output" == *"would POST"* ]]
+  [[ "$output" == *"/pages/projects/culture-dev/deployments"* ]]
+  [[ "$output" == *"(branch=main)"* ]]
+  _assert_no_post
+}
+
+@test "cf-pages-deployment-create dry-run with --branch on non-prod branch → preview" {
+  cf_mock "/pages/projects/culture-dev" "pages_project_culture_dev_detail.json"
+  run bash "$WRITE_SCRIPTS/cf-pages-deployment-create.sh" culture-dev --branch=feat/x
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"**branch:** feat/x"* ]]
+  [[ "$output" == *"**environment:** preview"* ]]
+  [[ "$output" == *"(branch=feat/x)"* ]]
+  _assert_no_post
+}
+
+@test "cf-pages-deployment-create --json dry-run emits synthetic envelope" {
+  cf_mock "/pages/projects/culture-dev" "pages_project_culture_dev_detail.json"
+  run bash "$WRITE_SCRIPTS/cf-pages-deployment-create.sh" culture-dev --json
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.success == true'
+  echo "$output" | jq -e '.result.dry_run == true'
+  echo "$output" | jq -e '.result.branch == "main"'
+  echo "$output" | jq -e '.result.environment == "production"'
+  _assert_no_post
+}
+
+# --- direct-upload guard ---
+
+@test "cf-pages-deployment-create refuses a Direct Upload project" {
+  # agentirc-dev detail has source: null (Direct Upload).
+  cf_mock "/pages/projects/agentirc-dev" "pages_project_agentirc_detail.json"
+  run bash "$WRITE_SCRIPTS/cf-pages-deployment-create.sh" agentirc-dev --apply
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"no git source"* ]]
+  _assert_no_post
+}
+
+# --- project not found ---
+
+@test "cf-pages-deployment-create exits 1 when project not found" {
+  cf_mock "/pages/projects/nope" "pages_project_not_found.json"
+  run bash "$WRITE_SCRIPTS/cf-pages-deployment-create.sh" nope
+  [ "$status" -eq 1 ]
+  _assert_no_post
+}
+
+# --- apply path ---
+
+@test "cf-pages-deployment-create --apply POSTs branch form field and reports deployment" {
+  cf_mock "/pages/projects/culture-dev/deployments" "pages_deployment_create_ok.json"
+  cf_mock "/pages/projects/culture-dev" "pages_project_culture_dev_detail.json"
+  run bash "$WRITE_SCRIPTS/cf-pages-deployment-create.sh" culture-dev --apply
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"**Deployment triggered**"* ]]
+  [[ "$output" == *"8313565b"* ]]
+  [[ "$output" == *"**stage:** queued/idle"* ]]
+  cf_assert_called '-X	POST'
+  cf_assert_called 'branch=main'
+}
+
+@test "cf-pages-deployment-create --apply --json passes response through" {
+  cf_mock "/pages/projects/culture-dev/deployments" "pages_deployment_create_ok.json"
+  cf_mock "/pages/projects/culture-dev" "pages_project_culture_dev_detail.json"
+  run bash "$WRITE_SCRIPTS/cf-pages-deployment-create.sh" culture-dev --apply --json
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.success == true'
+  echo "$output" | jq -e '.result.id == "8313565b-e95b-4804-b457-4c1a11b5fd19"'
+}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,12 +25,12 @@ class Stub:
     - ``queue(*items)`` stacks responses returned FIFO across calls
       (used for pagination tests where the same path is hit with
       different ``page=`` values).
-    - ``stub.calls`` is the list of ``(method, path, payload, query)``
+    - ``stub.calls`` is the list of ``(method, path, payload, query, form)``
       tuples recorded in order.
     """
 
     def __init__(self) -> None:
-        self.calls: list[tuple[str, str, dict | None, dict]] = []
+        self.calls: list[tuple[str, str, dict | None, dict, dict | None]] = []
         self._responses: dict[tuple[str, str], object] = {}
         self._queue: list[object] = []
 
@@ -43,9 +43,9 @@ class Stub:
     def queue(self, *items: object) -> None:
         self._queue.extend(items)
 
-    def __call__(self, method: str, path: str, *, payload=None, query=None) -> dict:
+    def __call__(self, method: str, path: str, *, payload=None, query=None, form=None) -> dict:
         q = dict(query or {})
-        self.calls.append((method, path, payload, q))
+        self.calls.append((method, path, payload, q, form))
         if self._queue:
             item = self._queue.pop(0)
         else:

--- a/tests/fixtures/pages_deployment_create_ok.json
+++ b/tests/fixtures/pages_deployment_create_ok.json
@@ -1,0 +1,24 @@
+{
+  "success": true,
+  "errors": [],
+  "messages": [],
+  "result": {
+    "id": "8313565b-e95b-4804-b457-4c1a11b5fd19",
+    "short_id": "8313565b",
+    "project_name": "culture-dev",
+    "environment": "production",
+    "url": "https://8313565b.culture-dev.pages.dev",
+    "created_on": "2026-06-22T17:45:00.000000Z",
+    "latest_stage": {
+      "name": "queued",
+      "status": "idle"
+    },
+    "deployment_trigger": {
+      "type": "ad_hoc",
+      "metadata": {
+        "branch": "main",
+        "commit_hash": "cb3b9e84fa389157e1787602fd364590d1ea26c8"
+      }
+    }
+  }
+}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -68,6 +68,17 @@ def test_http_request_rejects_payload_and_form_together():
         http_request("POST", "/x", payload={"a": 1}, form={"b": 2})
 
 
+def test_http_request_multipart_boundary_is_per_request():
+    """Each form POST gets a fresh boundary so a field value can't collide
+    with the delimiter (RFC 2046)."""
+    boundaries = []
+    with patch("cultureflare._api.urllib.request.urlopen", return_value=_ok_resp({"success": True})) as mock:  # noqa: E501
+        for _ in range(2):
+            http_request("POST", "/accounts/a/pages/projects/p/deployments", form={"branch": "main"})
+            boundaries.append(mock.call_args[0][0].get_header("Content-type"))
+    assert boundaries[0] != boundaries[1]
+
+
 def test_http_request_raises_cfafi_auth_error_on_401():
     err_body = json.dumps({"success": False, "errors": [{"code": 10000, "message": "bad token"}]})
     http_err = urllib.error.HTTPError(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -51,6 +51,23 @@ def test_http_request_sends_json_payload_on_post():
     assert json.loads(req.data.decode("utf-8")) == {"type": "A", "name": "x"}
 
 
+def test_http_request_sends_multipart_form_on_post():
+    with patch("cultureflare._api.urllib.request.urlopen", return_value=_ok_resp({"success": True})) as mock:  # noqa: E501
+        http_request("POST", "/accounts/a/pages/projects/p/deployments", form={"branch": "main"})
+    req = mock.call_args[0][0]
+    assert req.get_method() == "POST"
+    content_type = req.get_header("Content-type")
+    assert content_type.startswith("multipart/form-data; boundary=")
+    body = req.data.decode("utf-8")
+    assert 'Content-Disposition: form-data; name="branch"' in body
+    assert "main" in body
+
+
+def test_http_request_rejects_payload_and_form_together():
+    with pytest.raises(ValueError):
+        http_request("POST", "/x", payload={"a": 1}, form={"b": 2})
+
+
 def test_http_request_raises_cfafi_auth_error_on_401():
     err_body = json.dumps({"success": False, "errors": [{"code": 10000, "message": "bad token"}]})
     http_err = urllib.error.HTTPError(

--- a/tests/test_cli_pages_deployments_create.py
+++ b/tests/test_cli_pages_deployments_create.py
@@ -1,0 +1,127 @@
+"""Tests for `cultureflare pages deployments create`."""
+
+import json
+
+from cultureflare.cli import main
+from cultureflare.cli._errors import EXIT_API, EXIT_USER_ERROR, CfafiError
+
+_GET_PATH = "/accounts/test-account/pages/projects/tools-culture-dev"
+_POST_PATH = "/accounts/test-account/pages/projects/tools-culture-dev/deployments"
+
+
+def _project_detail(*, source_type="github", production_branch="main"):
+    source = {"type": source_type} if source_type else None
+    return {
+        "success": True, "errors": [], "messages": [],
+        "result": {
+            "name": "tools-culture-dev",
+            "production_branch": production_branch,
+            "source": source,
+        },
+    }
+
+
+def _deployment_ok():
+    return {
+        "success": True, "errors": [], "messages": [],
+        "result": {
+            "id": "dep-123", "short_id": "dep-123"[:8],
+            "environment": "production",
+            "url": "https://dep-123.tools-culture-dev.pages.dev",
+            "latest_stage": {"name": "queued", "status": "idle"},
+        },
+    }
+
+
+def test_dry_run_defaults_to_production_branch_no_post(http_stub, capsys):
+    http_stub.queue(_project_detail())
+    rc = main(["pages", "deployments", "create", "tools-culture-dev"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "Dry-run" in out
+    assert "would POST" in out and _POST_PATH in out
+    assert "branch=main" in out
+    assert "**environment:** production" in out
+    methods = [c[0] for c in http_stub.calls]
+    assert "POST" not in methods
+
+
+def test_dry_run_branch_override_is_preview(http_stub, capsys):
+    http_stub.queue(_project_detail())
+    rc = main(["pages", "deployments", "create", "tools-culture-dev", "--branch", "feat/x"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "branch=feat/x" in out
+    assert "**environment:** preview" in out
+    assert "POST" not in [c[0] for c in http_stub.calls]
+
+
+def test_json_dry_run_synthetic_envelope(http_stub, capsys):
+    http_stub.queue(_project_detail())
+    rc = main(["pages", "deployments", "create", "tools-culture-dev", "--json"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    payload = json.loads(out)
+    assert payload["success"] is True
+    assert payload["result"]["dry_run"] is True
+    assert payload["result"]["branch"] == "main"
+    assert payload["result"]["environment"] == "production"
+    assert payload["result"]["would_post"] == _POST_PATH
+
+
+def test_apply_posts_branch_form_field(http_stub, capsys):
+    http_stub.queue(_project_detail())
+    http_stub.set("POST", _POST_PATH, _deployment_ok())
+    rc = main(["pages", "deployments", "create", "tools-culture-dev", "--apply"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "Deployment triggered" in out
+    assert "dep-123" in out
+    assert "queued/idle" in out
+    posts = [c for c in http_stub.calls if c[0] == "POST"]
+    assert len(posts) == 1
+    assert posts[0][1] == _POST_PATH
+    assert posts[0][2] is None          # no JSON payload
+    assert posts[0][4] == {"branch": "main"}  # multipart form field
+
+
+def test_apply_json_passthrough(http_stub, capsys):
+    http_stub.queue(_project_detail())
+    http_stub.set("POST", _POST_PATH, _deployment_ok())
+    rc = main(["pages", "deployments", "create", "tools-culture-dev", "--apply", "--json"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    payload = json.loads(out)
+    assert payload["result"]["id"] == "dep-123"
+
+
+def test_direct_upload_project_refused(http_stub, capsys):
+    http_stub.queue(_project_detail(source_type=None))
+    rc = main(["pages", "deployments", "create", "tools-culture-dev", "--apply"])
+    err = capsys.readouterr().err
+    assert rc == EXIT_USER_ERROR
+    assert "no git source" in err
+    assert "POST" not in [c[0] for c in http_stub.calls]
+
+
+def test_invalid_project_name_rejected(capsys):
+    rc = main(["pages", "deployments", "create", "bad name!"])
+    err = capsys.readouterr().err
+    assert rc == EXIT_USER_ERROR
+    assert "invalid project name" in err
+
+
+def test_invalid_branch_rejected(capsys):
+    rc = main(["pages", "deployments", "create", "tools-culture-dev", "--branch", "bad branch!"])
+    err = capsys.readouterr().err
+    assert rc == EXIT_USER_ERROR
+    assert "invalid --branch" in err
+
+
+def test_project_not_found_propagates_api_error(http_stub, capsys):
+    http_stub.queue(CfafiError(code=EXIT_API, message="CloudFlare API 8000007: not found"))
+    rc = main(["pages", "deployments", "create", "tools-culture-dev"])
+    err = capsys.readouterr().err
+    assert rc == EXIT_API
+    assert "not found" in err
+    assert "POST" not in [c[0] for c in http_stub.calls]

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -7,6 +7,7 @@ import pytest
 
 from cultureflare.cli._errors import EXIT_API, EXIT_USER_ERROR, CfafiError
 from cultureflare.cli._output import (
+    dry_run_envelope,
     emit_error,
     emit_json,
     emit_kv,
@@ -118,3 +119,13 @@ def test_emit_json_writes_envelope():
     buf = io.StringIO()
     emit_json({"success": True, "result": [1, 2, 3]}, stream=buf)
     assert json.loads(buf.getvalue()) == {"success": True, "result": [1, 2, 3]}
+
+
+def test_dry_run_envelope_wraps_result_with_marker():
+    env = dry_run_envelope({"zone_id": "z1", "would_post": {"type": "A"}})
+    assert env["success"] is True
+    assert env["errors"] == []
+    assert env["messages"] == ["dry-run: no changes applied"]
+    assert env["result"]["dry_run"] is True
+    assert env["result"]["zone_id"] == "z1"
+    assert env["result"]["would_post"] == {"type": "A"}

--- a/tests/test_remote_login_access_app.py
+++ b/tests/test_remote_login_access_app.py
@@ -63,4 +63,4 @@ def test_delete_app_calls_delete_with_id(http_stub):
         {"success": True, "errors": [], "messages": [], "result": {"id": "app-b"}},
     )
     delete_app(account_id="acc-1", app_id="app-b")
-    assert http_stub.calls == [("DELETE", "/accounts/acc-1/access/apps/app-b", None, {})]
+    assert http_stub.calls == [("DELETE", "/accounts/acc-1/access/apps/app-b", None, {}, None)]

--- a/tests/test_remote_login_access_policy.py
+++ b/tests/test_remote_login_access_policy.py
@@ -188,5 +188,5 @@ def test_delete_policy_calls_delete(http_stub):
     )
     delete_policy(account_id="acc-1", app_id="app-1", policy_id="pol-1")
     assert http_stub.calls == [
-        ("DELETE", "/accounts/acc-1/access/apps/app-1/policies/pol-1", None, {}),
+        ("DELETE", "/accounts/acc-1/access/apps/app-1/policies/pol-1", None, {}, None),
     ]

--- a/tests/test_remote_login_dns.py
+++ b/tests/test_remote_login_dns.py
@@ -100,4 +100,4 @@ def test_delete_cname_calls_delete_with_record_id(http_stub):
         {"success": True, "errors": [], "messages": [], "result": {"id": "rec-1"}},
     )
     delete_cname(zone_id="zid-1", record_id="rec-1")
-    assert http_stub.calls == [("DELETE", "/zones/zid-1/dns_records/rec-1", None, {})]
+    assert http_stub.calls == [("DELETE", "/zones/zid-1/dns_records/rec-1", None, {}, None)]

--- a/tests/test_remote_login_service_token.py
+++ b/tests/test_remote_login_service_token.py
@@ -85,5 +85,5 @@ def test_delete_service_token_calls_delete(http_stub):
     )
     delete_service_token(account_id="acc-1", token_id="st-b")
     assert http_stub.calls == [
-        ("DELETE", "/accounts/acc-1/access/service_tokens/st-b", None, {}),
+        ("DELETE", "/accounts/acc-1/access/service_tokens/st-b", None, {}, None),
     ]

--- a/tests/test_remote_login_tunnel.py
+++ b/tests/test_remote_login_tunnel.py
@@ -33,7 +33,7 @@ def test_find_tunnel_returns_none_when_no_match(http_stub):
 def test_find_tunnel_lists_with_is_deleted_false(http_stub):
     http_stub.queue(_list_envelope())
     find_tunnel(account_id="acc-1", name="x")
-    method, path, _, query = http_stub.calls[0]
+    method, path, _, query, _ = http_stub.calls[0]
     assert method == "GET"
     assert path == "/accounts/acc-1/cfd_tunnel"
     assert query.get("is_deleted") == "false"
@@ -76,7 +76,7 @@ def test_delete_tunnel_passes_force_true(http_stub):
         {"success": True, "errors": [], "messages": [], "result": {"id": "tun-b"}},
     )
     delete_tunnel(account_id="acc-1", tunnel_id="tun-b")
-    method, path, _, query = http_stub.calls[0]
+    method, path, _, query, _ = http_stub.calls[0]
     assert method == "DELETE"
     assert path == "/accounts/acc-1/cfd_tunnel/tun-b"
     assert query.get("force") == "true"


### PR DESCRIPTION
## What

Adds a **deploy-trigger primitive** for CloudFlare Pages, on both
surfaces, parameterized by project + optional `--branch`, dry-run by
default:

- **Python CLI:** new `pages` noun →
  `cultureflare pages deployments create <project> [--branch B] [--apply]`
  (the spec-locked shape from `docs/.../python-cli-design.md`).
- **Bash twin:** `cf-pages-deployment-create.sh` under
  `cultureflare-write/scripts/`, plus a shared `cf_api_form` multipart
  helper in `_lib.sh`.

## Why

A Pages project created via the REST API doesn't always get its GitHub
webhook installed (the dashboard connect flow does extra OAuth + webhook
setup the API create skips), so pushes to the production branch may not
auto-deploy. This endpoint clones the repo at the branch HEAD
server-side and builds **regardless of webhook state** — the manual
"redeploy" primitive.

Context: this is exactly the call that brought **tools.culture.dev**
live for #47 (the project's first build never auto-fired; a manual
trigger fixed it). That was done with raw `curl` because the skill had
no such primitive — this PR adds one so it's a one-liner next time, and
so the culture-tools catalog-refresh lane can call it.

## How it works

- Resolves project metadata: existence check + `production_branch`
  default + **git-source guard** (Direct Upload projects are refused —
  nothing to build from a branch).
- Classifies production vs preview by `branch == production_branch`.
- `--apply` POSTs `multipart/form-data` (`branch=…`) to the deployments
  endpoint. `cf_api` hardcodes `application/json`, which corrupts the
  multipart `Content-Type` (verified: curl emits
  `application/json; boundary=…`) — hence the separate `cf_api_form`
  helper / `_api.http_request(form=…)` path rather than a flag on the
  JSON helpers.

## Tests

- **bats (11):** usage errors, dry-run (prod default + preview
  override + `--json`), direct-upload guard, project-not-found, apply
  (asserts `-X POST` + `branch=` form field).
- **pytest:** the `pages deployments create` command, multipart
  encoding in `_api`, and the new `_output.dry_run_envelope()` helper
  (now shared by `dns create` — removes the duplicated synthetic
  envelope, killing a pylint R0801 and pre-empting Sonar new-code
  duplication).
- conftest stub records a 5th `form` element; the four full-tuple call
  assertions were updated to match.

Version bumped 0.11.0 → 0.12.0 (new command = minor).

Refs: agentculture/cultureflare#47

- cultureflare (Claude)
