### PR TITLE
feat(pages): surface preview branch-alias URL on deployments create

### DIFF
--- a/.claude/skills/cultureflare-write/scripts/cf-pages-deployment-create.sh
+++ b/.claude/skills/cultureflare-write/scripts/cf-pages-deployment-create.sh
@@ -27,6 +27,12 @@
 #   --json            raw CloudFlare response envelope (or simulated body
 #                     in dry-run)
 #
+# A PREVIEW deployment gets a predictable branch-alias URL
+# (<branch-slug>.<project>.pages.dev) reviewers can click and `cicd status`
+# can key on. The dry-run PREDICTS it from the branch slug; --apply reports
+# CF's authoritative `aliases`. Production serves the canonical + custom
+# domains, so it has no branch alias.
+#
 # Only works on git-connected (github / gitlab source) projects. A
 # Direct Upload project has no git source to build from and is refused.
 #
@@ -104,6 +110,12 @@ fi
 
 source_type=$(printf '%s' "$project_json" | jq -r '.result.source.type // ""')
 production_branch=$(printf '%s' "$project_json" | jq -r '.result.production_branch // "main"')
+# Canonical *.pages.dev host — base for the preview branch-alias URL. CF may
+# omit it on some payloads; fall back to <project>.pages.dev to match.
+subdomain=$(printf '%s' "$project_json" | jq -r '.result.subdomain // ""')
+if [[ -z "$subdomain" ]]; then
+  subdomain="$project.pages.dev"
+fi
 
 # Direct Upload projects (source null/absent) have no git to build from.
 if [[ -z "$source_type" ]]; then
@@ -126,6 +138,20 @@ else
   environment=preview
 fi
 
+# Predict the preview branch-alias host. CF builds the subdomain label from
+# the branch: lowercase, non-alphanumeric runs collapse to a single dash,
+# leading/trailing dashes stripped, truncated to 28 chars. Best-effort — the
+# apply path reports CF's authoritative `aliases`. Only previews get one.
+predicted_alias=""
+if [[ "$environment" == "preview" ]]; then
+  alias_label=$(printf '%s' "$effective_branch" \
+    | tr '[:upper:]' '[:lower:]' \
+    | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//')
+  alias_label="${alias_label:0:28}"
+  alias_label="${alias_label%-}"
+  predicted_alias="https://$alias_label.$subdomain"
+fi
+
 deploy_path="/accounts/$CLOUDFLARE_ACCOUNT_ID/pages/projects/$project_encoded/deployments"
 
 render_summary_kv() {
@@ -144,13 +170,18 @@ if (( apply == 0 )); then
       --arg branch "$effective_branch" \
       --arg environment "$environment" \
       --arg deploy_path "$deploy_path" \
+      --arg predicted_alias "$predicted_alias" \
       '{success: true, errors: [], messages: ["dry-run: no changes applied"],
-        result: {dry_run: true, project: $project, branch: $branch,
-                 environment: $environment, would_post: $deploy_path}}'
+        result: ({dry_run: true, project: $project, branch: $branch,
+                  environment: $environment, would_post: $deploy_path}
+                 + (if $predicted_alias != "" then {predicted_alias: $predicted_alias} else {} end))}'
     exit 0
   fi
   printf '**Dry-run — no changes applied**\n\n'
   render_summary_kv
+  if [[ -n "$predicted_alias" ]]; then
+    printf -- '- **predicted alias:** %s\n' "$predicted_alias"
+  fi
   # shellcheck disable=SC2016  # literal backticks wrap markdown inline code
   printf '\n**would POST** `%s` (branch=%s)\n' "$deploy_path" "$effective_branch"
   exit 0
@@ -170,9 +201,15 @@ short_id=$(printf '%s' "$response" | jq -r '.result.short_id // "—"')
 deploy_url=$(printf '%s' "$response" | jq -r '.result.url // "—"')
 stage_name=$(printf '%s' "$response" | jq -r '.result.latest_stage.name // "—"')
 stage_status=$(printf '%s' "$response" | jq -r '.result.latest_stage.status // "—"')
+# CF's authoritative branch-alias URL(s) — present for previews, usually empty
+# for production. This is the predictable URL to post on a PR.
+aliases=$(printf '%s' "$response" | jq -r '(.result.aliases // []) | join(", ")')
 
 printf '**Deployment triggered**\n\n'
 render_summary_kv
 printf -- '- **deployment:** %s (id=%s)\n' "$short_id" "$deployment_id"
 printf -- '- **stage:** %s/%s\n' "$stage_name" "$stage_status"
 printf -- '- **url:** %s\n' "$deploy_url"
+if [[ -n "$aliases" ]]; then
+  printf -- '- **aliases:** %s\n' "$aliases"
+fi

--- a/.claude/skills/cultureflare-write/scripts/cf-pages-deployment-create.sh
+++ b/.claude/skills/cultureflare-write/scripts/cf-pages-deployment-create.sh
@@ -149,7 +149,12 @@ if [[ "$environment" == "preview" ]]; then
     | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//')
   alias_label="${alias_label:0:28}"
   alias_label="${alias_label%-}"
-  predicted_alias="https://$alias_label.$subdomain"
+  # A punctuation-only branch (e.g. '---', '///') normalizes to an empty
+  # label and has no valid alias host; leave predicted_alias empty so we
+  # never emit "https://.<subdomain>".
+  if [[ -n "$alias_label" ]]; then
+    predicted_alias="https://$alias_label.$subdomain"
+  fi
 fi
 
 deploy_path="/accounts/$CLOUDFLARE_ACCOUNT_ID/pages/projects/$project_encoded/deployments"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `pages deployments create` now reports the preview branch-alias URL when `--branch` names a non-production branch: a predicted `<branch>.<project>.pages.dev` host on dry-run, and CloudFlare's authoritative `aliases` on `--apply`. On both surfaces (Python CLI + the `cf-pages-deployment-create.sh` bash twin), so a preview deployment's URL can be posted straight onto a PR for reviewers / picked up by `cicd status`. Production deployments serve the canonical + custom domains, so they show no branch alias.
 
+### Fixed
+
+- Preview branch-alias prediction no longer emits a malformed `https://.<subdomain>` URL when the branch normalizes to an empty label (a punctuation-only branch like `---` or `///`): both the Python CLI and the bash twin now omit the predicted alias entirely in that case. Surfaced by qodo on PR #49.
+
 ## [0.12.0] - 2026-06-22
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented here. The format
 is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.13.0] - 2026-06-23
+
+### Added
+
+- `pages deployments create` now reports the preview branch-alias URL when `--branch` names a non-production branch: a predicted `<branch>.<project>.pages.dev` host on dry-run, and CloudFlare's authoritative `aliases` on `--apply`. On both surfaces (Python CLI + the `cf-pages-deployment-create.sh` bash twin), so a preview deployment's URL can be posted straight onto a PR for reviewers / picked up by `cicd status`. Production deployments serve the canonical + custom domains, so they show no branch alias.
+
 ## [0.12.0] - 2026-06-22
 
 ### Added

--- a/cultureflare/__init__.py
+++ b/cultureflare/__init__.py
@@ -8,7 +8,7 @@ from importlib.metadata import PackageNotFoundError, version as _pkg_version
 # version is rewritten to "0.3.0.devN" by the publish workflow) report
 # their actual version here. The legacy `cfafi` wheel (frozen at 0.2.2)
 # is the second-tier fallback for anyone still on the old install.
-__version__ = "0.12.0"
+__version__ = "0.13.0"
 
 try:
     __version__ = _pkg_version("cultureflare")

--- a/cultureflare/cli/_commands/pages.py
+++ b/cultureflare/cli/_commands/pages.py
@@ -1,10 +1,12 @@
 """``cultureflare pages <subnoun> <verb>`` — CloudFlare Pages.
 
 v0 exposes ``pages deployments create`` only — trigger a new deployment
-(production build) for a git-connected project. The bash counterpart at
+for a git-connected project (production build, or a preview build when
+``--branch`` names a non-production branch). The bash counterpart at
 ``.claude/skills/cultureflare-write/scripts/cf-pages-deployment-create.sh``
 is the behavioural reference: same dry-run default, same direct-upload
-guard, same production-vs-preview branch classification.
+guard, same production-vs-preview branch classification, and the same
+preview branch-alias URL (predicted on dry-run, authoritative on apply).
 """
 
 from __future__ import annotations
@@ -24,6 +26,27 @@ from cultureflare.cli._output import dry_run_envelope, emit_json, emit_kv, emit_
 _PROJECT_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9._-]*$")
 _BRANCH_RE = re.compile(r"^[A-Za-z0-9._/-]{1,255}$")
 
+# CF derives a preview's subdomain label from the branch name and truncates
+# it; 28 chars is CF's documented branch-alias label limit.
+_ALIAS_LABEL_MAXLEN = 28
+
+
+def _branch_alias_host(branch: str, subdomain: str) -> str:
+    """Predict the CF Pages preview branch-alias host for ``branch``.
+
+    CF builds a preview subdomain label from the branch: lowercase, every
+    run of non-alphanumerics collapses to a single dash, leading/trailing
+    dashes stripped, and the label truncated to 28 chars. The alias host is
+    ``<label>.<project-subdomain>`` (e.g. ``feat-x.tools-culture-dev.pages.dev``).
+
+    Best-effort — CF is the authority. The apply path reports CF's real
+    ``aliases``; this prediction is only for the dry-run preview, and a long
+    branch name may truncate differently.
+    """
+    label = re.sub(r"[^a-z0-9]+", "-", branch.lower()).strip("-")
+    label = label[:_ALIAS_LABEL_MAXLEN].rstrip("-")
+    return f"{label}.{subdomain}"
+
 
 def _validate_args(project: str, branch: str | None) -> None:
     """Raise CfafiError for an invalid project name or branch name."""
@@ -41,15 +64,19 @@ def _validate_args(project: str, branch: str | None) -> None:
         )
 
 
-def _resolve_project(account_id: str, project: str, project_enc: str) -> tuple[str, str]:
-    """Fetch project detail; return (source_type, production_branch).
+def _resolve_project(account_id: str, project: str, project_enc: str) -> tuple[str, str, str]:
+    """Fetch project detail; return (source_type, production_branch, subdomain).
 
-    Raises CfafiError when the project has no git source (Direct Upload).
+    ``subdomain`` is the project's canonical ``*.pages.dev`` host, used to
+    build the preview branch-alias URL (falls back to ``<project>.pages.dev``
+    if CF omits it). Raises CfafiError when the project has no git source
+    (Direct Upload).
     """
     detail = _api.http_request("GET", f"/accounts/{account_id}/pages/projects/{project_enc}")
     result = detail.get("result") or {}
     source_type = (result.get("source") or {}).get("type") or ""
     production_branch = result.get("production_branch") or "main"
+    subdomain = result.get("subdomain") or f"{project}.pages.dev"
     if not source_type:
         raise CfafiError(
             code=EXIT_USER_ERROR,
@@ -59,7 +86,7 @@ def _resolve_project(account_id: str, project: str, project_enc: str) -> tuple[s
                 " not a branch"
             ),
         )
-    return source_type, production_branch
+    return source_type, production_branch, subdomain
 
 
 def cmd_pages_deployments_create(args: argparse.Namespace) -> None:
@@ -70,27 +97,41 @@ def cmd_pages_deployments_create(args: argparse.Namespace) -> None:
     project_enc = urllib.parse.quote(args.project, safe="")
 
     # Project detail: existence check + production_branch default + git-source guard.
-    source_type, production_branch = _resolve_project(account_id, args.project, project_enc)
+    source_type, production_branch, subdomain = _resolve_project(
+        account_id, args.project, project_enc
+    )
 
     branch = args.branch if args.branch is not None else production_branch
     environment = "production" if branch == production_branch else "preview"
     deploy_path = f"/accounts/{account_id}/pages/projects/{project_enc}/deployments"
     json_mode = bool(getattr(args, "json", False))
 
+    # A preview deployment (non-production branch) gets a predictable branch
+    # alias; production serves the canonical + custom domains, no branch alias.
+    predicted_alias = (
+        f"https://{_branch_alias_host(branch, subdomain)}" if environment == "preview" else None
+    )
+
     if not args.apply:
         if json_mode:
-            emit_json(dry_run_envelope({
+            result: dict[str, object] = {
                 "project": args.project, "branch": branch,
                 "environment": environment, "would_post": deploy_path,
-            }))
+            }
+            if predicted_alias is not None:
+                result["predicted_alias"] = predicted_alias
+            emit_json(dry_run_envelope(result))
         else:
             emit_result("**Dry-run — no changes applied**\n", json_mode=False)
-            emit_kv([
+            pairs = [
                 ("project", args.project),
                 ("source", source_type),
                 ("branch", branch),
                 ("environment", environment),
-            ])
+            ]
+            if predicted_alias is not None:
+                pairs.append(("predicted alias", predicted_alias))
+            emit_kv(pairs)
             emit_result(
                 f"\n**would POST** `{deploy_path}` (branch={branch})",
                 json_mode=False,
@@ -101,10 +142,21 @@ def cmd_pages_deployments_create(args: argparse.Namespace) -> None:
     if json_mode:
         emit_json(response)
         return
+    _render_deployment(args, source_type, branch, environment, response)
+
+
+def _render_deployment(
+    args: argparse.Namespace,
+    source_type: str,
+    branch: str,
+    environment: str,
+    response: dict[str, object],
+) -> None:
+    """Render a triggered deployment, surfacing CF's authoritative branch aliases."""
     dep = response.get("result") or {}
     stage = dep.get("latest_stage") or {}
     emit_result("**Deployment triggered**\n", json_mode=False)
-    emit_kv([
+    pairs = [
         ("project", args.project),
         ("source", source_type),
         ("branch", branch),
@@ -112,7 +164,13 @@ def cmd_pages_deployments_create(args: argparse.Namespace) -> None:
         ("deployment", f"{dep.get('short_id', '—')} (id={dep.get('id', '—')})"),
         ("stage", f"{stage.get('name', '—')}/{stage.get('status', '—')}"),
         ("url", dep.get("url", "—")),
-    ])
+    ]
+    # CF's own branch-alias URLs (authoritative). Present for previews; usually
+    # empty for production. The predictable URL reviewers / `cicd status` key on.
+    aliases = dep.get("aliases") or []
+    if aliases:
+        pairs.append(("aliases", ", ".join(aliases)))
+    emit_kv(pairs)
 
 
 def register(sub: argparse._SubParsersAction) -> None:
@@ -130,7 +188,11 @@ def register(sub: argparse._SubParsersAction) -> None:
     c.add_argument(
         "--branch",
         default=None,
-        help="Branch to build (default: the project's production_branch)",
+        help=(
+            "Branch to build (default: the project's production_branch). A "
+            "non-production branch makes a preview deployment, whose "
+            "branch-alias URL is reported for posting on a PR."
+        ),
     )
     c.add_argument("--apply", action="store_true", help="Actually POST (without it, dry-run).")
     c.add_argument("--json", action="store_true", help="Emit raw/synthetic JSON envelope.")

--- a/cultureflare/cli/_commands/pages.py
+++ b/cultureflare/cli/_commands/pages.py
@@ -123,29 +123,9 @@ def cmd_pages_deployments_create(args: argparse.Namespace) -> None:
             predicted_alias = f"https://{alias_host}"
 
     if not args.apply:
-        if json_mode:
-            result: dict[str, object] = {
-                "project": args.project, "branch": branch,
-                "environment": environment, "would_post": deploy_path,
-            }
-            if predicted_alias is not None:
-                result["predicted_alias"] = predicted_alias
-            emit_json(dry_run_envelope(result))
-        else:
-            emit_result("**Dry-run — no changes applied**\n", json_mode=False)
-            pairs = [
-                ("project", args.project),
-                ("source", source_type),
-                ("branch", branch),
-                ("environment", environment),
-            ]
-            if predicted_alias is not None:
-                pairs.append(("predicted alias", predicted_alias))
-            emit_kv(pairs)
-            emit_result(
-                f"\n**would POST** `{deploy_path}` (branch={branch})",
-                json_mode=False,
-            )
+        _render_dry_run(
+            args, source_type, branch, environment, deploy_path, predicted_alias, json_mode
+        )
         return
 
     response = _api.http_request("POST", deploy_path, form={"branch": branch})
@@ -153,6 +133,41 @@ def cmd_pages_deployments_create(args: argparse.Namespace) -> None:
         emit_json(response)
         return
     _render_deployment(args, source_type, branch, environment, response)
+
+
+def _render_dry_run(  # pylint: disable=too-many-arguments,too-many-positional-arguments
+    args: argparse.Namespace,
+    source_type: str,
+    branch: str,
+    environment: str,
+    deploy_path: str,
+    predicted_alias: str | None,
+    json_mode: bool,
+) -> None:
+    """Render the dry-run preview (no mutation). JSON or markdown."""
+    if json_mode:
+        result: dict[str, object] = {
+            "project": args.project, "branch": branch,
+            "environment": environment, "would_post": deploy_path,
+        }
+        if predicted_alias is not None:
+            result["predicted_alias"] = predicted_alias
+        emit_json(dry_run_envelope(result))
+    else:
+        emit_result("**Dry-run — no changes applied**\n", json_mode=False)
+        pairs = [
+            ("project", args.project),
+            ("source", source_type),
+            ("branch", branch),
+            ("environment", environment),
+        ]
+        if predicted_alias is not None:
+            pairs.append(("predicted alias", predicted_alias))
+        emit_kv(pairs)
+        emit_result(
+            f"\n**would POST** `{deploy_path}` (branch={branch})",
+            json_mode=False,
+        )
 
 
 def _render_deployment(

--- a/cultureflare/cli/_commands/pages.py
+++ b/cultureflare/cli/_commands/pages.py
@@ -31,7 +31,7 @@ _BRANCH_RE = re.compile(r"^[A-Za-z0-9._/-]{1,255}$")
 _ALIAS_LABEL_MAXLEN = 28
 
 
-def _branch_alias_host(branch: str, subdomain: str) -> str:
+def _branch_alias_host(branch: str, subdomain: str) -> str | None:
     """Predict the CF Pages preview branch-alias host for ``branch``.
 
     CF builds a preview subdomain label from the branch: lowercase, every
@@ -39,12 +39,19 @@ def _branch_alias_host(branch: str, subdomain: str) -> str:
     dashes stripped, and the label truncated to 28 chars. The alias host is
     ``<label>.<project-subdomain>`` (e.g. ``feat-x.tools-culture-dev.pages.dev``).
 
+    Returns ``None`` when the branch normalizes to an empty label (a
+    punctuation-only branch like ``---`` or ``///``) — there is no valid
+    alias host to predict, and emitting ``.<subdomain>`` would be a malformed
+    URL.
+
     Best-effort — CF is the authority. The apply path reports CF's real
     ``aliases``; this prediction is only for the dry-run preview, and a long
     branch name may truncate differently.
     """
     label = re.sub(r"[^a-z0-9]+", "-", branch.lower()).strip("-")
     label = label[:_ALIAS_LABEL_MAXLEN].rstrip("-")
+    if not label:
+        return None
     return f"{label}.{subdomain}"
 
 
@@ -108,9 +115,12 @@ def cmd_pages_deployments_create(args: argparse.Namespace) -> None:
 
     # A preview deployment (non-production branch) gets a predictable branch
     # alias; production serves the canonical + custom domains, no branch alias.
-    predicted_alias = (
-        f"https://{_branch_alias_host(branch, subdomain)}" if environment == "preview" else None
-    )
+    # A branch that normalizes to an empty label yields no host (None) — skip.
+    predicted_alias: str | None = None
+    if environment == "preview":
+        alias_host = _branch_alias_host(branch, subdomain)
+        if alias_host is not None:
+            predicted_alias = f"https://{alias_host}"
 
     if not args.apply:
         if json_mode:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cultureflare"
-version = "0.12.0"
+version = "0.13.0"
 description = "CloudFlare Agent First Interface — agent-first CLI for CloudFlare management in the AgentCulture org."
 readme = "README.md"
 license = "MIT"

--- a/tests/bats/cf-pages-deployment-create.bats
+++ b/tests/bats/cf-pages-deployment-create.bats
@@ -85,8 +85,29 @@ _assert_no_post() {
   cf_mock "/pages/projects/culture-dev" "pages_project_culture_dev_detail.json"
   run bash "$WRITE_SCRIPTS/cf-pages-deployment-create.sh" culture-dev --branch=feat/x --json
   [ "$status" -eq 0 ]
-  echo "$output" | jq -e '.result.environment == "preview"'
-  echo "$output" | jq -e '.result.predicted_alias == "https://feat-x.culture-dev.pages.dev"'
+  printf '%s\n' "$output" | jq -e '.result.environment == "preview"'
+  printf '%s\n' "$output" | jq -e '.result.predicted_alias == "https://feat-x.culture-dev.pages.dev"'
+  _assert_no_post
+}
+
+@test "cf-pages-deployment-create preview with a punctuation-only branch emits no alias" {
+  # A branch like '---' normalizes to an empty label; we must not emit
+  # "https://.<subdomain>". Still a preview (branch != production_branch).
+  cf_mock "/pages/projects/culture-dev" "pages_project_culture_dev_detail.json"
+  run bash "$WRITE_SCRIPTS/cf-pages-deployment-create.sh" culture-dev --branch=---
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"**environment:** preview"* ]]
+  [[ "$output" != *"predicted alias"* ]]
+  [[ "$output" != *"https://."* ]]
+  _assert_no_post
+}
+
+@test "cf-pages-deployment-create --json preview punctuation-only branch omits predicted_alias" {
+  cf_mock "/pages/projects/culture-dev" "pages_project_culture_dev_detail.json"
+  run bash "$WRITE_SCRIPTS/cf-pages-deployment-create.sh" culture-dev --branch=--- --json
+  [ "$status" -eq 0 ]
+  printf '%s\n' "$output" | jq -e '.result.environment == "preview"'
+  printf '%s\n' "$output" | jq -e 'has("result") and (.result | has("predicted_alias") | not)'
   _assert_no_post
 }
 
@@ -94,10 +115,10 @@ _assert_no_post() {
   cf_mock "/pages/projects/culture-dev" "pages_project_culture_dev_detail.json"
   run bash "$WRITE_SCRIPTS/cf-pages-deployment-create.sh" culture-dev --json
   [ "$status" -eq 0 ]
-  echo "$output" | jq -e '.success == true'
-  echo "$output" | jq -e '.result.dry_run == true'
-  echo "$output" | jq -e '.result.branch == "main"'
-  echo "$output" | jq -e '.result.environment == "production"'
+  printf '%s\n' "$output" | jq -e '.success == true'
+  printf '%s\n' "$output" | jq -e '.result.dry_run == true'
+  printf '%s\n' "$output" | jq -e '.result.branch == "main"'
+  printf '%s\n' "$output" | jq -e '.result.environment == "production"'
   _assert_no_post
 }
 
@@ -159,6 +180,6 @@ _assert_no_post() {
   cf_mock "/pages/projects/culture-dev" "pages_project_culture_dev_detail.json"
   run bash "$WRITE_SCRIPTS/cf-pages-deployment-create.sh" culture-dev --apply --json
   [ "$status" -eq 0 ]
-  echo "$output" | jq -e '.success == true'
-  echo "$output" | jq -e '.result.id == "8313565b-e95b-4804-b457-4c1a11b5fd19"'
+  printf '%s\n' "$output" | jq -e '.success == true'
+  printf '%s\n' "$output" | jq -e '.result.id == "8313565b-e95b-4804-b457-4c1a11b5fd19"'
 }

--- a/tests/bats/cf-pages-deployment-create.bats
+++ b/tests/bats/cf-pages-deployment-create.bats
@@ -67,7 +67,26 @@ _assert_no_post() {
   [ "$status" -eq 0 ]
   [[ "$output" == *"**branch:** feat/x"* ]]
   [[ "$output" == *"**environment:** preview"* ]]
+  # Preview predicts the branch-alias URL (feat/x → feat-x).
+  [[ "$output" == *"**predicted alias:** https://feat-x.culture-dev.pages.dev"* ]]
   [[ "$output" == *"(branch=feat/x)"* ]]
+  _assert_no_post
+}
+
+@test "cf-pages-deployment-create production dry-run has no predicted alias" {
+  cf_mock "/pages/projects/culture-dev" "pages_project_culture_dev_detail.json"
+  run bash "$WRITE_SCRIPTS/cf-pages-deployment-create.sh" culture-dev
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"predicted alias"* ]]
+  _assert_no_post
+}
+
+@test "cf-pages-deployment-create --json dry-run preview carries predicted_alias" {
+  cf_mock "/pages/projects/culture-dev" "pages_project_culture_dev_detail.json"
+  run bash "$WRITE_SCRIPTS/cf-pages-deployment-create.sh" culture-dev --branch=feat/x --json
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.result.environment == "preview"'
+  echo "$output" | jq -e '.result.predicted_alias == "https://feat-x.culture-dev.pages.dev"'
   _assert_no_post
 }
 
@@ -114,6 +133,25 @@ _assert_no_post() {
   [[ "$output" == *"**stage:** queued/idle"* ]]
   cf_assert_called '-X	POST'
   cf_assert_called 'branch=main'
+}
+
+@test "cf-pages-deployment-create --apply preview surfaces authoritative aliases" {
+  cf_mock "/pages/projects/culture-dev/deployments" "pages_deployment_create_preview_ok.json"
+  cf_mock "/pages/projects/culture-dev" "pages_project_culture_dev_detail.json"
+  run bash "$WRITE_SCRIPTS/cf-pages-deployment-create.sh" culture-dev --branch=feat/x --apply
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"**environment:** preview"* ]]
+  # CF's authoritative alias from the response, not a prediction.
+  [[ "$output" == *"**aliases:** https://feat-x.culture-dev.pages.dev"* ]]
+  cf_assert_called 'branch=feat/x'
+}
+
+@test "cf-pages-deployment-create --apply production has no alias line" {
+  cf_mock "/pages/projects/culture-dev/deployments" "pages_deployment_create_ok.json"
+  cf_mock "/pages/projects/culture-dev" "pages_project_culture_dev_detail.json"
+  run bash "$WRITE_SCRIPTS/cf-pages-deployment-create.sh" culture-dev --apply
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"**aliases:**"* ]]
 }
 
 @test "cf-pages-deployment-create --apply --json passes response through" {

--- a/tests/fixtures/pages_deployment_create_preview_ok.json
+++ b/tests/fixtures/pages_deployment_create_preview_ok.json
@@ -1,0 +1,25 @@
+{
+  "success": true,
+  "errors": [],
+  "messages": [],
+  "result": {
+    "id": "9f1a2b3c-1111-2222-3333-444455556666",
+    "short_id": "9f1a2b3c",
+    "project_name": "culture-dev",
+    "environment": "preview",
+    "url": "https://9f1a2b3c.culture-dev.pages.dev",
+    "aliases": ["https://feat-x.culture-dev.pages.dev"],
+    "created_on": "2026-06-23T09:00:00.000000Z",
+    "latest_stage": {
+      "name": "queued",
+      "status": "idle"
+    },
+    "deployment_trigger": {
+      "type": "ad_hoc",
+      "metadata": {
+        "branch": "feat/x",
+        "commit_hash": "0000000000000000000000000000000000000000"
+      }
+    }
+  }
+}

--- a/tests/test_cli_pages_deployments_create.py
+++ b/tests/test_cli_pages_deployments_create.py
@@ -95,6 +95,30 @@ def test_json_dry_run_preview_includes_predicted_alias(http_stub, capsys):
     )
 
 
+def test_dry_run_punctuation_only_branch_emits_no_predicted_alias(http_stub, capsys):
+    # A branch like '---' normalizes to an empty alias label; we must not
+    # emit "https://.<subdomain>". It is still a preview (branch != main).
+    http_stub.queue(_project_detail())
+    rc = main(["pages", "deployments", "create", "tools-culture-dev", "--branch=---"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "**environment:** preview" in out
+    assert "predicted alias" not in out
+    assert "https://." not in out
+
+
+def test_json_punctuation_only_branch_omits_predicted_alias(http_stub, capsys):
+    http_stub.queue(_project_detail())
+    rc = main(
+        ["pages", "deployments", "create", "tools-culture-dev", "--branch=---", "--json"]
+    )
+    out = capsys.readouterr().out
+    assert rc == 0
+    payload = json.loads(out)
+    assert payload["result"]["environment"] == "preview"
+    assert "predicted_alias" not in payload["result"]
+
+
 def test_json_dry_run_synthetic_envelope(http_stub, capsys):
     http_stub.queue(_project_detail())
     rc = main(["pages", "deployments", "create", "tools-culture-dev", "--json"])

--- a/tests/test_cli_pages_deployments_create.py
+++ b/tests/test_cli_pages_deployments_create.py
@@ -15,6 +15,7 @@ def _project_detail(*, source_type="github", production_branch="main"):
         "success": True, "errors": [], "messages": [],
         "result": {
             "name": "tools-culture-dev",
+            "subdomain": "tools-culture-dev.pages.dev",
             "production_branch": production_branch,
             "source": source,
         },
@@ -28,6 +29,19 @@ def _deployment_ok():
             "id": "dep-123", "short_id": "dep-123"[:8],
             "environment": "production",
             "url": "https://dep-123.tools-culture-dev.pages.dev",
+            "latest_stage": {"name": "queued", "status": "idle"},
+        },
+    }
+
+
+def _deployment_preview_ok():
+    return {
+        "success": True, "errors": [], "messages": [],
+        "result": {
+            "id": "dep-456", "short_id": "dep-456"[:8],
+            "environment": "preview",
+            "url": "https://dep-456.tools-culture-dev.pages.dev",
+            "aliases": ["https://feat-m4-polish.tools-culture-dev.pages.dev"],
             "latest_stage": {"name": "queued", "status": "idle"},
         },
     }
@@ -53,7 +67,32 @@ def test_dry_run_branch_override_is_preview(http_stub, capsys):
     assert rc == 0
     assert "branch=feat/x" in out
     assert "**environment:** preview" in out
+    # Preview deployments predict the branch-alias URL (feat/x -> feat-x).
+    assert "**predicted alias:** https://feat-x.tools-culture-dev.pages.dev" in out
     assert "POST" not in [c[0] for c in http_stub.calls]
+
+
+def test_dry_run_production_has_no_predicted_alias(http_stub, capsys):
+    http_stub.queue(_project_detail())
+    rc = main(["pages", "deployments", "create", "tools-culture-dev"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "predicted alias" not in out
+
+
+def test_json_dry_run_preview_includes_predicted_alias(http_stub, capsys):
+    http_stub.queue(_project_detail())
+    rc = main(
+        ["pages", "deployments", "create", "tools-culture-dev", "--branch", "feat/x", "--json"]
+    )
+    out = capsys.readouterr().out
+    assert rc == 0
+    payload = json.loads(out)
+    assert payload["result"]["environment"] == "preview"
+    assert (
+        payload["result"]["predicted_alias"]
+        == "https://feat-x.tools-culture-dev.pages.dev"
+    )
 
 
 def test_json_dry_run_synthetic_envelope(http_stub, capsys):
@@ -83,6 +122,32 @@ def test_apply_posts_branch_form_field(http_stub, capsys):
     assert posts[0][1] == _POST_PATH
     assert posts[0][2] is None          # no JSON payload
     assert posts[0][4] == {"branch": "main"}  # multipart form field
+
+
+def test_apply_production_has_no_alias_line(http_stub, capsys):
+    http_stub.queue(_project_detail())
+    http_stub.set("POST", _POST_PATH, _deployment_ok())
+    rc = main(["pages", "deployments", "create", "tools-culture-dev", "--apply"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    # Production deployment response carries no `aliases` -> no alias line.
+    assert "**aliases:**" not in out
+
+
+def test_apply_preview_surfaces_authoritative_aliases(http_stub, capsys):
+    http_stub.queue(_project_detail())
+    http_stub.set("POST", _POST_PATH, _deployment_preview_ok())
+    rc = main(
+        ["pages", "deployments", "create", "tools-culture-dev", "--branch", "feat/m4-polish",
+         "--apply"]
+    )
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "Deployment triggered" in out
+    assert "**environment:** preview" in out
+    # CF's authoritative alias from the response, not a prediction.
+    assert "**aliases:** https://feat-m4-polish.tools-culture-dev.pages.dev" in out
+    assert http_stub.calls[-1][4] == {"branch": "feat/m4-polish"}
 
 
 def test_apply_json_passthrough(http_stub, capsys):

--- a/uv.lock
+++ b/uv.lock
@@ -183,7 +183,7 @@ wheels = [
 
 [[package]]
 name = "cultureflare"
-version = "0.8.0"
+version = "0.13.0"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## What

`pages deployments create` now surfaces the **preview branch-alias URL**
when `--branch` names a non-production branch — on both surfaces:

- **Python CLI** (`cultureflare pages deployments create`)
- **Bash twin** (`cf-pages-deployment-create.sh`)

| phase | what's reported | source |
|---|---|---|
| dry-run (preview) | `predicted alias` / `predicted_alias` = `https://<branch-slug>.<project>.pages.dev` | predicted from the branch slug + project subdomain |
| `--apply` (preview) | `aliases` line | CloudFlare's authoritative `.result.aliases` |

Production deployments serve the canonical + custom domains, so they show
**no** branch alias (unchanged output).

## Why

Follows up #47. tools.culture.dev's catalog-refresh / PR-preview lane wants
the *predictable* preview URL so it can be posted on a PR for reviewers and
picked up by `cicd status` (which keys off a `pages.dev` URL in the
comments). PR #48 added the deploy trigger but only echoed CF's opaque
per-deployment `url` (`https://<hash>.<project>.pages.dev`) — not the
stable `<branch>.<project>.pages.dev` alias reviewers actually click.

This is the **manual / CI-driven** half of #47's preview ask (a one-liner
the catalog lane can call). The **native** half — the CF Pages ↔ GitHub
App posting the preview check/comment on every PR automatically (katvan
parity) — is a Pages git-integration reconnect, tracked separately on #47.

## How

- `_branch_alias_host(branch, subdomain)` predicts CF's slug: lowercase,
  non-alphanumeric runs → single `-`, strip leading/trailing `-`, truncate
  to 28 chars. Best-effort — apply reports CF's real `aliases`, so the
  prediction is only the dry-run preview.
- `_resolve_project` now also returns the project `subdomain` (falls back
  to `<project>.pages.dev`) for the alias base.
- Apply rendering extracted to `_render_deployment` (keeps the command
  function under the locals threshold).

## Tests

- **pytest:** predicted alias on dry-run (text + `--json`), authoritative
  `aliases` on apply, and production has neither.
- **bats:** same matrix + a new `pages_deployment_create_preview_ok.json`
  fixture carrying `aliases`.
- Full suite green: pytest, bats, shellcheck, markdownlint.

Version `0.12.0` → `0.13.0`. Refs: #47.

- cultureflare (Claude)
